### PR TITLE
caliper reader now uses node as index

### DIFF
--- a/hatchet/caliper_reader.py
+++ b/hatchet/caliper_reader.py
@@ -115,17 +115,6 @@ class CaliperReader:
         indices = [self.node_column_name, 'mpi.rank']
         self.dataframe.set_index(indices, drop=False, inplace=True)
 
-        # add rows without metrics
-        rows_not_in_dataframe = []
-        for node in self.graph_root.traverse():
-            if node not in self.dataframe.index:
-                data = [None] * len(self.json_columns) + [node]
-                index = self.json_columns + [self.node_column_name]
-                row = pd.Series(data=data, index=index, name=(node, None))
-                row.loc[name_column_name] = node.callpath[-1]
-                rows_not_in_dataframe.append(row)
-        self.dataframe = self.dataframe.append(rows_not_in_dataframe)
-
         graph = Graph([self.graph_root])
         return (graph, self.dataframe)
 

--- a/tests/caliper.py
+++ b/tests/caliper.py
@@ -50,4 +50,4 @@ def test_dataframe(calc_pi_cali_db):
     assert isinstance(dataframe, pd.DataFrame)
     assert len(dataframe.groupby('source.line#cali.sampler.pc')) == 7
     assert len(dataframe.groupby('source.file#cali.sampler.pc')) == 7
-    assert len(dataframe.groupby('source.function#callpath.address')) == 31
+    assert len(dataframe.groupby('source.function#callpath.address')) == 8

--- a/tests/caliper.py
+++ b/tests/caliper.py
@@ -50,4 +50,4 @@ def test_dataframe(calc_pi_cali_db):
     assert isinstance(dataframe, pd.DataFrame)
     assert len(dataframe.groupby('source.line#cali.sampler.pc')) == 7
     assert len(dataframe.groupby('source.file#cali.sampler.pc')) == 7
-    assert len(dataframe.groupby('source.function#callpath.address')) == 8
+    assert len(dataframe.groupby('source.function#callpath.address')) == 31


### PR DESCRIPTION
• added in empty rows to dataframe for when a node in the call graph doesn't have any metrics associated with it
• switched dataframe from using multiindex with callpath and mpi rank to use multiindex with node object and mpi rank