### PR TITLE
README status, Timer class, python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - python setup.py install
 
 script:
-  - pytest
+  - PYTHONPATH=. pytest
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Hatchet
 =======
 
+[![Build Status](https://travis-ci.com/LLNL/hatchet.svg?branch=master)](https://travis-ci.org/LLNL/hatchet)
+
 Hatchet analyzes performance data that is organized in a tree hierarchy (such
 as calling context trees, call graphs, nested regions' timers etc.)
 
@@ -19,4 +21,3 @@ Produced at the Lawrence Livermore National Laboratory.
 Created by Abhinav Bhatele <bhatele@llnl.gov>.
 LLNL-CODE-741008. All rights reserved.
 ```
-

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Hatchet
 =======
 
 [![Build Status](https://travis-ci.com/LLNL/hatchet.svg?branch=master)](https://travis-ci.org/LLNL/hatchet)
+[![Read the Docs](http://readthedocs.org/projects/hatchet/badge/?version=latest)](http://hatchet.readthedocs.io)
 
 Hatchet analyzes performance data that is organized in a tree hierarchy (such
 as calling context trees, call graphs, nested regions' timers etc.)

--- a/examples/time-read.py
+++ b/examples/time-read.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+##############################################################################
+# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Hatchet.
+# Created by Abhinav Bhatele <bhatele@llnl.gov>.
+# LLNL-CODE-741008. All rights reserved.
+#
+# For details, see: https://github.com/LLNL/hatchet
+# Please also read the LICENSE file for the MIT License notice.
+##############################################################################
+from __future__ import print_function
+import argparse
+
+from hatchet.hpctoolkit_reader import HPCToolkitReader
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='print timings for reading an HPCToolkit database')
+    parser.add_argument('directory', metavar='DIRECTORY', action='store',
+                        help='directory to read')
+    args = parser.parse_args()
+
+    reader = HPCToolkitReader(args.directory)
+    reader.create_graph()
+    print(str(reader.timer))

--- a/hatchet/__init__.py
+++ b/hatchet/__init__.py
@@ -10,4 +10,4 @@
 # Please also read the LICENSE file for the MIT License notice.
 ##############################################################################
 
-from graphframe import *
+from .graphframe import *

--- a/hatchet/caliper_reader.py
+++ b/hatchet/caliper_reader.py
@@ -12,8 +12,9 @@
 
 import json
 import pandas as pd
-from node import Node
-from graph import Graph
+
+from .node import Node
+from .graph import Graph
 
 
 class CaliperReader:

--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -10,7 +10,7 @@
 # Please also read the LICENSE file for the MIT License notice.
 ##############################################################################
 
-from hatchet.external.printtree import trees_as_text
+from .external.printtree import trees_as_text
 
 
 class Graph:

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -9,10 +9,11 @@
 # For details, see: https://github.com/LLNL/hatchet
 # Please also read the LICENSE file for the MIT License notice.
 ##############################################################################
-
-from hpctoolkit_reader import HPCToolkitReader
-from caliper_reader import CaliperReader
 import pandas as pd
+
+from .hpctoolkit_reader import HPCToolkitReader
+from .caliper_reader import CaliperReader
+
 
 
 class GraphFrame:

--- a/hatchet/node.py
+++ b/hatchet/node.py
@@ -9,7 +9,6 @@
 # For details, see: https://github.com/LLNL/hatchet
 # Please also read the LICENSE file for the MIT License notice.
 ##############################################################################
-
 from functools import total_ordering
 
 

--- a/hatchet/util/__init__.py
+++ b/hatchet/util/__init__.py
@@ -1,0 +1,11 @@
+##############################################################################
+# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Hatchet.
+# Created by Abhinav Bhatele <bhatele@llnl.gov>.
+# LLNL-CODE-741008. All rights reserved.
+#
+# For details, see: https://github.com/LLNL/hatchet
+# Please also read the LICENSE file for the MIT License notice.
+##############################################################################

--- a/hatchet/util/timer.py
+++ b/hatchet/util/timer.py
@@ -1,0 +1,59 @@
+##############################################################################
+# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Hatchet.
+# Created by Abhinav Bhatele <bhatele@llnl.gov>.
+# LLNL-CODE-741008. All rights reserved.
+#
+# For details, see: https://github.com/LLNL/hatchet
+# Please also read the LICENSE file for the MIT License notice.
+##############################################################################
+from collections import OrderedDict
+from contextlib import contextmanager
+from datetime import datetime
+from io import StringIO
+
+
+class Timer(object):
+    """Simple phase timer with a context manager."""
+
+    def __init__(self):
+        self._phase = None
+        self._start_time = None
+        self._times = OrderedDict()
+
+    def start_phase(self, phase):
+        now = datetime.now()
+        delta = None
+
+        if self._phase:
+            delta = now - self._start_time
+            self._times[self._phase] = delta
+
+        self._phase = phase
+        self._start_time = now
+        return delta
+
+    def end_phase(self):
+        assert self._phase and self._start_time
+
+        now = datetime.now()
+        delta = now - self._start_time
+        self._times[self._phase] = delta
+
+        self._phase = None
+        self._start_time = None
+
+    def __str__(self):
+        out = StringIO()
+        out.write(u"Times:\n")
+        for phase, delta in self._times.items():
+            out.write(u'    %-20s %.2fs\n' % (phase + ':', delta.total_seconds()))
+        return out.getvalue()
+
+    @contextmanager
+    def phase(self, name):
+        self.start_phase(name)
+        yield
+        self.end_phase()


### PR DESCRIPTION
This PR adds 3 things and should probably be rebased (not squashed) to preserve the commits:

- [x] add a travis build status badge to the readme
- [x] add a `Timer` class to do simple phase timing and keep `HPCToolkitReader` clean
- [x] make things work in Python 3 (imports, byte strings, `dict.values()`)