### PR TITLE
Link to travis-ci.com instead of travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hatchet
 =======
 
-[![Build Status](https://travis-ci.com/LLNL/hatchet.svg?branch=master)](https://travis-ci.org/LLNL/hatchet)
+[![Build Status](https://travis-ci.com/LLNL/hatchet.svg?branch=master)](https://travis-ci.com/LLNL/hatchet)
 [![Read the Docs](http://readthedocs.org/projects/hatchet/badge/?version=latest)](http://hatchet.readthedocs.io)
 
 Hatchet analyzes performance data that is organized in a tree hierarchy (such


### PR DESCRIPTION
- [x] Fix copy/paste error from Spack repo (which is still on travis-ci.org)