### PR TITLE
change Node identifier from callpath to Frame

### DIFF
--- a/hatchet/frame.py
+++ b/hatchet/frame.py
@@ -1,0 +1,55 @@
+##############################################################################
+# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Hatchet.
+# Created by Abhinav Bhatele <bhatele@llnl.gov>.
+# LLNL-CODE-741008. All rights reserved.
+#
+# For details, see: https://github.com/LLNL/hatchet
+# Please also read the LICENSE file for the MIT License notice.
+##############################################################################
+import sys
+
+from functools import total_ordering
+from .util.lang import memoized
+
+
+@total_ordering
+class Frame:
+    """ The frame index for a node. The node only stores its frame.
+
+        Args:
+            attrs (dict): Dictionary of attributes and values.
+            index_attrs (list): List of index attributes.
+    """
+
+    def __init__(self, attrs_dict, index_list):
+        # Check that all index attributes are in attribute dictionary
+        if not all(k in attrs_dict for k in index_list):
+            raise KeyError("Invalid index attribute(s)")
+
+        self.attrs = attrs_dict
+        self.index_attrs = index_list
+
+    def __eq__(self, other):
+        return (self._cmp_key() == other._cmp_key())
+
+    def __lt__(self, other):
+        return (self._cmp_key() < other._cmp_key())
+
+    def __gt__(self, other):
+        return (self._cmp_key() > other._cmp_key())
+
+    def __str__(self):
+        ret = {}
+        for i in self.index_attrs:
+            if i in self.attrs:
+                ret[i] = self.attrs[i]
+        return str(ret)
+
+    @memoized
+    def _cmp_key(self):
+        """ Make a tuple of attributes and values based on reader
+        """
+        return tuple((k, self.attrs[k]) for k in sorted(self.index_attrs))

--- a/hatchet/node.py
+++ b/hatchet/node.py
@@ -14,12 +14,11 @@ from functools import total_ordering
 
 @total_ordering
 class Node:
-    """ A node in the graph. The node only stores its callpath.
+    """ A node in the graph. The node only stores its frame.
     """
 
-    def __init__(self, nid, callpath_tuple, parent):
-        self.nid = nid
-        self.callpath = callpath_tuple
+    def __init__(self, frame_obj, parent):
+        self.frame = frame_obj
 
         self.parents = []
         if parent is not None:
@@ -64,9 +63,6 @@ class Node:
             if last == node:
                 return
 
-    def set_callpath(self, callpath):
-        self.callpath = callpath
-
     def __hash__(self):
         return hash(id(self))
 
@@ -74,9 +70,9 @@ class Node:
         return (id(self) == id(other))
 
     def __lt__(self, other):
-        return (self.callpath < other.callpath)
+        return (id(self) < id(other))
 
     def __str__(self):
         """ Returns a string representation of the node.
         """
-        return self.callpath[-1]
+        return str(self.frame)

--- a/hatchet/util/lang.py
+++ b/hatchet/util/lang.py
@@ -1,0 +1,31 @@
+##############################################################################
+# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Hatchet.
+# Created by Abhinav Bhatele <bhatele@llnl.gov>.
+# LLNL-CODE-741008. All rights reserved.
+#
+# For details, see: https://github.com/LLNL/hatchet
+# Please also read the LICENSE file for the MIT License notice.
+##############################################################################
+import functools
+
+def memoized(func):
+    """Decorator that caches the results of a function, storing them in
+    an attribute of that function.
+    """
+    func.cache = {}
+
+    @functools.wraps(func)
+    def _memoized_function(*args):
+        if not isinstance(args, collections.Hashable):
+            # Not hashable, so just call the function.
+            return func(*args)
+
+        if args not in func.cache:
+            func.cache[args] = func(*args)
+
+        return func.cache[args]
+
+    return _memoized_function


### PR DESCRIPTION
- Readers specify dict of attributes and values, and a list specifying which attributes are index attributes
- Handle invalid attribute specified as an index, but is not in the dict of attributes
- Implement eq, lt, and gt functions for total_ordering