### PR TITLE
coverage: Add codecov support to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,14 @@ install:
   - pip install --upgrade numpy
   - pip install --upgrade pandas
   - pip install --upgrade pytest
+  - pip install --upgrade codecov
   - python setup.py install
 
 script:
-  - PYTHONPATH=. pytest
+  - PYTHONPATH=. coverage run $(which pytest)
+
+after_success:
+  - codecov --env PYTHON_VERSION --required --flags "${TEST_SUITE}${TRAVIS_OS_NAME}"
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Hatchet
 =======
 
 [![Build Status](https://travis-ci.com/LLNL/hatchet.svg?branch=master)](https://travis-ci.com/LLNL/hatchet)
+[![codecov](https://codecov.io/gh/LLNL/hatchet/branch/master/graph/badge.svg)](https://codecov.io/gh/LLNL/hatchet)
 [![Read the Docs](http://readthedocs.org/projects/hatchet/badge/?version=latest)](http://hatchet.readthedocs.io)
 
 Hatchet analyzes performance data that is organized in a tree hierarchy (such


### PR DESCRIPTION
Add codecov support (copied mostly from Spack) to `.travis.yml`.

If this works we should see coverage at http://codecov.io/gh/llnl/hatchet.