### PR TITLE
literal reader: fix for multi-rooted trees

### DIFF
--- a/examples/dag_literal.py
+++ b/examples/dag_literal.py
@@ -120,10 +120,30 @@ if __name__ == "__main__":
                                     }
                                 ]
                             }
+                        ],
+                    },
+                    {
+                        'name': 'waldo',
+                        'metrics': {'time (inc)': 80.0, 'time': 9.0},
+                        'children': [
+                            {
+                                'name': 'bar',
+                                'metrics': {'time (inc)': 20.0, 'time': 5.0},
+                                'children': [
+                                    {
+                                        'name': 'baz',
+                                        'metrics': {'time (inc)': 5.0, 'time': 5.0}
+                                    },
+                                    {
+                                        'name': 'grault',
+                                        'metrics': {'time (inc)': 10.0, 'time': 10.0}
+                                    }
+                                ]
+                            },
                         ]
-                    }])
+                    }
+                    ])
 
     print(gf.dataframe)
-    print("\n")
 
     print(gf.graph.to_string(gf.graph.roots, gf.dataframe, threshold=0.0))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def mock_graph_literal():
     """ Creates a mock tree
         Metasyntactic variables: https://www.ietf.org/rfc/rfc3092.txt
     """
-    graph_dict = {
+    graph_dict = [{
                     'name': 'foo',
                     'metrics': {'time (inc)': 130.0, 'time': 0.0},
                     'children': [
@@ -206,8 +206,28 @@ def mock_graph_literal():
                                 }
                             ]
                         }
+                    ],
+                },
+                {
+                    'name': 'waldo',
+                    'metrics': {'time (inc)': 80.0, 'time': 9.0},
+                    'children': [
+                        {
+                            'name': 'bar',
+                            'metrics': {'time (inc)': 20.0, 'time': 5.0},
+                            'children': [
+                                {
+                                    'name': 'baz',
+                                    'metrics': {'time (inc)': 5.0, 'time': 5.0}
+                                },
+                                {
+                                    'name': 'grault',
+                                    'metrics': {'time (inc)': 10.0, 'time': 10.0}
+                                }
+                            ]
+                        },
                     ]
-               }
+                }]
 
     return graph_dict
 

--- a/tests/dataframe_ops.py
+++ b/tests/dataframe_ops.py
@@ -19,5 +19,5 @@ def test_filter(mock_graph_literal):
     gf.from_literal(mock_graph_literal)
 
     filtered_gf = gf.filter(lambda x: x['time'] > 5.0)
-    assert len(filtered_gf.dataframe) == 7
+    assert len(filtered_gf.dataframe) == 9
 

--- a/tests/graph_literal.py
+++ b/tests/graph_literal.py
@@ -18,5 +18,5 @@ def test_graphframe(mock_graph_literal):
     gf = GraphFrame()
     gf.from_literal(mock_graph_literal)
 
-    assert len(gf.dataframe) == 20
+    assert len(gf.dataframe) == 24
 


### PR DESCRIPTION
Update `from_literal` to handle multi-rooted trees. Fixes #21.

- Modify `from_literal` to take a list of dicts instead of a single dict. Each item in the list represents a unique hierarchy with a different root.
- Add new example ingesting a multi-node tree literal
- Update existing tests and examples using literal reader to use a list of dicts