### PR TITLE
Ignore egg-info files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ experiment.xml
 docs/_build
 
 *.metric-db
+*.egg-info


### PR DESCRIPTION
If you use `python ./setup.py develop` to set up the project for
development, it will create a `.egg-info` directory for the hatchet
"egg".  This ignores these files.