### PR TITLE
license: add required NOTICE, fix license headers

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,21 @@
+This work was produced under the auspices of the U.S. Department of
+Energy by Lawrence Livermore National Laboratory under Contract
+DE-AC52-07NA27344.
+
+This work was prepared as an account of work sponsored by an agency of
+the United States Government. Neither the United States Government nor
+Lawrence Livermore National Security, LLC, nor any of their employees
+makes any warranty, expressed or implied, or assumes any legal liability
+or responsibility for the accuracy, completeness, or usefulness of any
+information, apparatus, product, or process disclosed, or represents that
+its use would not infringe privately owned rights.
+
+Reference herein to any specific commercial product, process, or service
+by trade name, trademark, manufacturer, or otherwise does not necessarily
+constitute or imply its endorsement, recommendation, or favoring by the
+United States Government or Lawrence Livermore National Security, LLC.
+
+The views and opinions of authors expressed herein do not necessarily
+state or reflect those of the United States Government or Lawrence
+Livermore National Security, LLC, and shall not be used for advertising
+or product endorsement purposes.

--- a/README.md
+++ b/README.md
@@ -6,23 +6,54 @@ Hatchet
 [![Read the Docs](http://readthedocs.org/projects/hatchet/badge/?version=latest)](http://hatchet.readthedocs.io)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-Hatchet analyzes performance data that is organized in a tree hierarchy (such
-as calling context trees, call graphs, nested regions' timers etc.)
+Hatchet allows [Pandas](https://pandas.pydata.org/) dataframes to be
+indexed by structured tree and graph data.  It is intended for analyzing
+sequential and parallel profile data.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/LLNL/hatchet/master/screenshot.png" width=600>
 </p>
 
-### Running hatchet
+### Installing hatchet
 
-To use hatchet, add the cloned directory to your PYTHONPATH.
-
-### Copyright
+To use hatchet, install it with pip:
 
 ```
-Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory.
+$ pip install hatchet
+``
 
-Created by Abhinav Bhatele <bhatele@cs.umd.edu>.
-LLNL-CODE-741008. All rights reserved.
-```
+Or, if you want to develop with this repo directly, add the cloned
+directory to your `PYTHONPATH`.
+
+Authors
+----------------
+
+Many thanks go to Hatchet's
+[contributors](https://github.com/llnl/hatchet/graphs/contributors).
+
+Hatchet was originally written by Abhinav Bhatele, bhatele@cs.umd.edu.
+
+### Citing Hatchet
+
+If you are referencing Hatchet in a publication, please cite the
+following paper:
+
+ * Abhinav Bhatele, Stephanie Brink, and Todd Gamblin. Hatchet: Pruning
+   the Overgrowth in Parallel Profiles.  In *Supercomputing 2019
+   (SC'19)*, Denver, Colorado, November 17-22 2019. LLNL-CONF-772402.
+
+License
+----------------
+
+Hatchet is distributed under the terms of the MIT license.
+
+All contributions must be made under the MIT license.  Copyrights in the
+Hatchet project are retained by contributors.  No copyright assignment is
+required to contribute to Hatchet.
+
+See [LICENSE](https://github.com/llnl/hatchet/blob/master/LICENSE) and
+[NOTICE](https://github.com/llnl/hatchet/blob/master/NOTICE) for details.
+
+SPDX-License-Identifier: MIT
+
+LLNL-CODE-741008

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 # Minimal makefile for Sphinx documentation
 #
@@ -30,4 +23,3 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,16 +1,9 @@
-# -*- coding: utf-8 -*-
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
 
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
-#
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# -*- coding: utf-8 -*-
 
 # Configuration file for the Sphinx documentation builder.
 #

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,14 +1,7 @@
-..
-.. Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-.. Produced at the Lawrence Livermore National Laboratory.
-..
-.. This file is part of Hatchet.
-.. Created by Abhinav Bhatele <bhatele@llnl.gov>.
-.. LLNL-CODE-741008. All rights reserved.
-..
-.. For details, see: https://github.com/LLNL/hatchet
-.. Please also read the LICENSE file for the MIT License notice.
-..
+.. Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+   Hatchet Project Developers. See the top-level LICENSE file for details.
+
+   SPDX-License-Identifier: MIT
 
 .. hatchet documentation master file, created by
    sphinx-quickstart on Tue Jun 26 08:43:21 2018.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,14 +1,7 @@
-..
-.. Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-.. Produced at the Lawrence Livermore National Laboratory.
-..
-.. This file is part of Hatchet.
-.. Created by Abhinav Bhatele <bhatele@llnl.gov>.
-.. LLNL-CODE-741008. All rights reserved.
-..
-.. For details, see: https://github.com/LLNL/hatchet
-.. Please also read the LICENSE file for the MIT License notice.
-..
+.. Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+   Hatchet Project Developers. See the top-level LICENSE file for details.
+
+   SPDX-License-Identifier: MIT
 
 Download and Install
 ====================

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -1,14 +1,7 @@
-..
-.. Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-.. Produced at the Lawrence Livermore National Laboratory.
-..
-.. This file is part of Hatchet.
-.. Created by Abhinav Bhatele <bhatele@llnl.gov>.
-.. LLNL-CODE-741008. All rights reserved.
-..
-.. For details, see: https://github.com/LLNL/hatchet
-.. Please also read the LICENSE file for the MIT License notice.
-..
+.. Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+   Hatchet Project Developers. See the top-level LICENSE file for details.
+
+   SPDX-License-Identifier: MIT
 
 User Guide
 ==========
@@ -84,4 +77,3 @@ dataframe to only return rows that are True. The returned graphframe preserves
 the graph provided as input.
 
 **Fill**:
-

--- a/examples/caliper.py
+++ b/examples/caliper.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python
-##############################################################################
-# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from __future__ import print_function
 

--- a/examples/dag_literal.py
+++ b/examples/dag_literal.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python
-##############################################################################
-# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from __future__ import print_function
 

--- a/examples/gprof_dot.py
+++ b/examples/gprof_dot.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python
-##############################################################################
-# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from __future__ import print_function
 

--- a/examples/hpctoolkit.py
+++ b/examples/hpctoolkit.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from __future__ import print_function
 

--- a/examples/time-read.py
+++ b/examples/time-read.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from __future__ import print_function
 import argparse

--- a/examples/tree_literal.py
+++ b/examples/tree_literal.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python
-##############################################################################
-# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from __future__ import print_function
 

--- a/hatchet/__init__.py
+++ b/hatchet/__init__.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 # make flake8 unused names in this file.
 # flake8: noqa: F401

--- a/hatchet/caliper_reader.py
+++ b/hatchet/caliper_reader.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 import json
 import sys

--- a/hatchet/external/__init__.py
+++ b/hatchet/external/__init__.py
@@ -1,11 +1,4 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT

--- a/hatchet/frame.py
+++ b/hatchet/frame.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from functools import total_ordering
 

--- a/hatchet/gprof_dot_reader.py
+++ b/hatchet/gprof_dot_reader.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 import re
 

--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 import sys
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 import pandas as pd
 import numpy

--- a/hatchet/hpctoolkit_reader.py
+++ b/hatchet/hpctoolkit_reader.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 import glob
 import struct

--- a/hatchet/node.py
+++ b/hatchet/node.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from functools import total_ordering
 

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from hatchet import GraphFrame, CaliperReader
 

--- a/hatchet/tests/callgrind.py
+++ b/hatchet/tests/callgrind.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from hatchet import GraphFrame, GprofDotReader
 

--- a/hatchet/tests/conftest.py
+++ b/hatchet/tests/conftest.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 import os
 import shutil

--- a/hatchet/tests/dataframe_ops.py
+++ b/hatchet/tests/dataframe_ops.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from hatchet import GraphFrame
 

--- a/hatchet/tests/frame.py
+++ b/hatchet/tests/frame.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 import pytest
 

--- a/hatchet/tests/graph.py
+++ b/hatchet/tests/graph.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from hatchet.node import Node
 from hatchet.frame import Frame

--- a/hatchet/tests/graph_literal.py
+++ b/hatchet/tests/graph_literal.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from hatchet import GraphFrame
 

--- a/hatchet/tests/graph_ops.py
+++ b/hatchet/tests/graph_ops.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from hatchet import GraphFrame
 

--- a/hatchet/tests/graphframe_ops.py
+++ b/hatchet/tests/graphframe_ops.py
@@ -1,13 +1,7 @@
-##############################################################################
-# Copyright (c) 2019, University of Maryland.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@cs.umd.edu>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from hatchet import GraphFrame
 

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from hatchet import GraphFrame, HPCToolkitReader
 

--- a/hatchet/tests/node.py
+++ b/hatchet/tests/node.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from hatchet.node import Node
 from hatchet.frame import Frame

--- a/hatchet/util/__init__.py
+++ b/hatchet/util/__init__.py
@@ -1,11 +1,4 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT

--- a/hatchet/util/config.py
+++ b/hatchet/util/config.py
@@ -1,1 +1,6 @@
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
 dot_keywords = ["graph", "subgraph", "digraph", "node", "edge", "strict"]

--- a/hatchet/util/dot.py
+++ b/hatchet/util/dot.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 import matplotlib.cm
 import matplotlib.colors

--- a/hatchet/util/timer.py
+++ b/hatchet/util/timer.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from collections import OrderedDict
 from contextlib import contextmanager

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 [pytest]
 addopts = --durations=20 -ra

--- a/scripts/metricdb_reader.py
+++ b/scripts/metricdb_reader.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from __future__ import print_function
 import glob

--- a/scripts/xml_reader.py
+++ b/scripts/xml_reader.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from __future__ import print_function
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,7 @@
-##############################################################################
-# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC.
-# Produced at the Lawrence Livermore National Laboratory.
+# Copyright 2017-2019 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
 #
-# This file is part of Hatchet.
-# Created by Abhinav Bhatele <bhatele@llnl.gov>.
-# LLNL-CODE-741008. All rights reserved.
-#
-# For details, see: https://github.com/LLNL/hatchet
-# Please also read the LICENSE file for the MIT License notice.
-##############################################################################
+# SPDX-License-Identifier: MIT
 
 from setuptools import setup
 from codecs import open


### PR DESCRIPTION
This adds a section on contributing to `README.md`, adds information about authorship, adds LLNL's required `NOTICE` file to the repo, and simplifies headers across the project to use a simple 4-line copyright statement with an SPDX identifier.

- [x] Fix license language in `README.md`
- [x] Add sections on authorship and citing hatchet to `README.md`
- [x] Add LLNL required `NOTICE` file to Hatchet
- [x] Fix/simplify license headers across the project
