### PR TITLE
bugfix: make str() and repr() tests deterministic

### DIFF
--- a/hatchet/frame.py
+++ b/hatchet/frame.py
@@ -58,10 +58,13 @@ class Frame:
         return hash(self.tuple_repr)
 
     def __str__(self):
-        return str(self.attrs)
+        """str() wtih sorted attributes, so output is deterministic."""
+        return "{%s}" % ", ".join(
+            "'%s': '%s'" % (k, v) for k, v in sorted(self.attrs.items())
+        )
 
     def __repr__(self):
-        return "Frame(%s)" % str(self.attrs)
+        return "Frame(%s)" % self
 
     @property
     def tuple_repr(self):

--- a/hatchet/tests/frame.py
+++ b/hatchet/tests/frame.py
@@ -86,8 +86,8 @@ def test_values():
 
 
 def test_repr():
-    assert repr(Frame(foo="baz", bar="quux")) == "Frame({'foo': 'baz', 'bar': 'quux'})"
+    assert repr(Frame(foo="baz", bar="quux")) == "Frame({'bar': 'quux', 'foo': 'baz'})"
 
 
 def test_str():
-    assert str(Frame(foo="baz", bar="quux")) == "{'foo': 'baz', 'bar': 'quux'}"
+    assert str(Frame(foo="baz", bar="quux")) == "{'bar': 'quux', 'foo': 'baz'}"


### PR DESCRIPTION
This fixes the intermittent bugs in Travis with tests for `Frame.__str__` and `Frame.__repr__`.

Previous implementation was nondeterministic for Python 3.5, which uses randomly-orderd dictionaries.