### PR TITLE
bugfix: Make squash work properly with trees and graphs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
       os: linux
       language: python
       script:
-        - black --check .
+        - black --diff --check .
         - flake8
     - stage: "unit tests"
       python: '2.7'

--- a/hatchet/frame.py
+++ b/hatchet/frame.py
@@ -59,9 +59,7 @@ class Frame:
 
     def __str__(self):
         """str() wtih sorted attributes, so output is deterministic."""
-        return "{%s}" % ", ".join(
-            "'%s': '%s'" % (k, v) for k, v in sorted(self.attrs.items())
-        )
+        return "{%s}" % ", ".join("'%s': '%s'" % (k, v) for k, v in self.tuple_repr)
 
     def __repr__(self):
         return "Frame(%s)" % self
@@ -70,7 +68,7 @@ class Frame:
     def tuple_repr(self):
         """Make a tuple of attributes and values based on reader."""
         if not self._tuple_repr:
-            self._tuple_repr = tuple((k, self.attrs[k]) for k in sorted(self.attrs))
+            self._tuple_repr = tuple(sorted((k, v) for k, v in self.attrs.items()))
         return self._tuple_repr
 
     def copy(self):

--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -8,7 +8,7 @@ import sys
 
 from .external.printtree import trees_as_text
 from .util.dot import trees_to_dot
-from .node import Node
+from .node import Node, traversal_order
 
 
 def index_by(attr, objects):
@@ -47,7 +47,7 @@ class Graph:
         visited = set()
 
         # iterate over roots in order
-        for root in self.roots:
+        for root in sorted(self.roots, key=traversal_order):
             for value in root.traverse(attrs=attrs, visited=visited, **kwargs):
                 yield value
 

--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -30,13 +30,16 @@ class Graph:
         assert roots is not None
         self.roots = roots
 
-    def traverse(self, attrs=None):
+    def traverse(self, attrs=None, **kwargs):
         """Preorder traversal of all roots of this Graph.
 
         Arguments:
             attrs (list or str, optional): If provided, extract these
                 fields from nodes while traversing and yield them. See
                 node.traverse() for details.
+
+        Keyword Args:
+            see Node.traverse()
 
         Only preorder traversal is currently supported.
         """
@@ -45,7 +48,7 @@ class Graph:
 
         # iterate over roots in order
         for root in self.roots:
-            for value in root.traverse(attrs=attrs, visited=visited):
+            for value in root.traverse(attrs=attrs, visited=visited, **kwargs):
                 yield value
 
     def find_merges(self):

--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -247,12 +247,7 @@ class Graph:
 
     def __len__(self):
         """Size of the graph in terms of number of nodes."""
-        num_nodes = 0
-
-        for root in self.roots:
-            num_nodes = sum(1 for n in root.traverse())
-
-        return num_nodes
+        return sum(1 for _ in self.traverse())
 
     def __eq__(self, other):
         """Check if two graphs have the same structure by comparing frame at each

--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -30,7 +30,7 @@ class Graph:
         assert roots is not None
         self.roots = roots
 
-    def traverse(self, attrs=None, **kwargs):
+    def traverse(self, order="pre", attrs=None, visited=None):
         """Preorder traversal of all roots of this Graph.
 
         Arguments:
@@ -43,13 +43,23 @@ class Graph:
 
         Only preorder traversal is currently supported.
         """
-        # share visited set so that we visit each node at most once.
-        visited = set()
+        # share visited dict so that we visit each node at most once.
+        if visited is None:
+            visited = {}
 
         # iterate over roots in order
         for root in sorted(self.roots, key=traversal_order):
-            for value in root.traverse(attrs=attrs, visited=visited, **kwargs):
+            for value in root.traverse(order=order, attrs=attrs, visited=visited):
                 yield value
+
+    def is_tree(self):
+        """True if this graph is a tree, false otherwise."""
+        if len(self.roots) > 1:
+            return False
+
+        visited = {}
+        list(self.traverse(visited=visited))
+        return all(v == 1 for v in visited.values())
 
     def find_merges(self):
         """Find nodes that have the same parent and frame.

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -205,7 +205,7 @@ class GraphFrame:
         """
         graph = Graph.from_lists(*lists)
 
-        df = pd.DataFrame({"node": graph.traverse()})
+        df = pd.DataFrame({"node": list(graph.traverse())})
         df.set_index(["node"], inplace=True, drop=False)
         df["time"] = [1.0] * len(graph)
 

--- a/hatchet/node.py
+++ b/hatchet/node.py
@@ -121,17 +121,21 @@ class Node:
             order (str):  "pre" or "post" for preorder or postorder (default pre)
             attrs (list or str, optional): If provided, extract these fields
                 from nodes while traversing and yield them.
+            visited (dict, optional): dictionary in which each visited
+                node's in-degree will be stored.
         """
         if order not in ("pre", "post"):
             raise ValueError("order must be one of 'pre' or 'post'")
 
         if visited is None:
-            visited = set()
+            visited = {}
 
         key = id(self)
         if key in visited:
+            # count the number of times we reached
+            visited[key] += 1
             return
-        visited.add(key)
+        visited[key] = 1
 
         def value(node):
             return node if attrs is None else node.frame.values(attrs)
@@ -140,7 +144,7 @@ class Node:
             yield value(self)
 
         for child in sorted(self.children, key=traversal_order):
-            for item in child.traverse(order, attrs, visited):
+            for item in child.traverse(order=order, attrs=attrs, visited=visited):
                 yield item
 
         if order == "post":

--- a/hatchet/node.py
+++ b/hatchet/node.py
@@ -8,6 +8,11 @@ from functools import total_ordering
 from .frame import Frame
 
 
+def traversal_order(node):
+    """Deterministic key function for sorting nodes in traversals."""
+    return (node.frame, id(node))
+
+
 @total_ordering
 class Node:
     """A node in the graph. The node only stores its frame."""
@@ -134,7 +139,7 @@ class Node:
         if order == "pre":
             yield value(self)
 
-        for child in self.children:
+        for child in sorted(self.children, key=traversal_order):
             for item in child.traverse(order, attrs, visited):
                 yield item
 

--- a/hatchet/tests/graph.py
+++ b/hatchet/tests/graph.py
@@ -60,3 +60,32 @@ def test_union_dag():
     g4 = g1.union(g2)
 
     assert g4 == g3
+
+
+def test_dag_is_not_tree():
+    g = Graph.from_lists(("b", "c"), ("d", "e"))
+    assert not g.is_tree()
+
+    d = Node(Frame(name="d"))
+    diamond_subdag = Node.from_lists(("a", ("b", d), ("c", d)))
+    g = Graph([diamond_subdag])
+    assert not g.is_tree()
+
+    g = Graph.from_lists(("e", "f", diamond_subdag), ("g", diamond_subdag, "h"))
+    assert not g.is_tree()
+
+
+def test_trees_are_trees():
+    g = Graph.from_lists(("a",))
+    assert g.is_tree()
+
+    g = Graph.from_lists(("a", ("b", ("c"))))
+    assert g.is_tree()
+
+    g = Graph.from_lists(("a", "b", "c"))
+    assert g.is_tree()
+
+    g = Graph.from_lists(
+        ("a", ("b", "e", "f", "g"), ("c", "e", "f", "g"), ("d", "e", "f", "g"))
+    )
+    assert g.is_tree()

--- a/hatchet/tests/graph.py
+++ b/hatchet/tests/graph.py
@@ -19,6 +19,22 @@ def test_from_lists():
     assert list(g.traverse(attrs="name")) == ["e", "f", "a", "b", "d", "c", "g", "h"]
 
 
+def test_len_chain():
+    graph = Graph.from_lists(("a", "b", "c", "d", "e"))
+    assert len(graph) == 5
+
+
+def test_len_diamond():
+    d = Node(Frame(name="d"))
+    graph = Graph.from_lists(("a", ("b", d), ("c", d)))
+    assert len(graph) == 4
+
+
+def test_len_tree():
+    graph = Graph.from_lists(("a", ("b", "d"), ("c", "d")))
+    assert len(graph) == 5
+
+
 def test_copy():
     d = Node(Frame(name="d"))
     diamond_subdag = Node.from_lists(("a", ("b", d), ("c", d)))

--- a/hatchet/tests/graph.py
+++ b/hatchet/tests/graph.py
@@ -16,7 +16,7 @@ def test_from_lists():
     diamond_subdag = Node.from_lists(("a", ("b", d), ("c", d)))
 
     g = Graph.from_lists(("e", "f", diamond_subdag), ("g", diamond_subdag, "h"))
-    assert list(g.traverse(attrs="name")) == ["e", "f", "a", "b", "d", "c", "g", "h"]
+    assert list(g.traverse(attrs="name")) == ["e", "a", "b", "d", "c", "f", "g", "h"]
 
 
 def test_len_chain():

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -248,3 +248,31 @@ def test_filter_squash_bunny_to_goat():
         lambda row: row["node"].frame["name"] not in ("a", "c"),
         Graph.from_lists(("e", "f", new_d, new_b), ("g", new_b, new_d, "h")),
     )
+
+
+@pytest.mark.xfail
+def test_filter_squash_bunny_to_goat_with_merge():
+    r"""Test squash on a "bunny" shaped graph:
+
+    This one is more complex because there are more transitive edges to
+    maintain between the roots (e, g) and b and c.
+
+          e   g
+         / \ / \
+        f   a   h    remove ac      e   g
+           / \      ---------->    / \ / \
+          b   c                   f   b   h
+           \ /
+            b
+
+    """
+    b = Node(Frame(name="b"))
+    diamond = Node.from_lists(("a", ("b", b), ("c", b)))
+
+    new_b = Node(Frame(name="b"))
+
+    check_filter_squash(
+        GraphFrame.from_lists(("e", "f", diamond), ("g", diamond, "h")),
+        lambda row: row["node"].frame["name"] not in ("a", "c"),
+        Graph.from_lists(("e", "f", new_b), ("g", new_b, "h")),
+    )

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -348,3 +348,18 @@ def test_filter_squash_bunny_to_goat_with_merge():
         Graph.from_lists(("e", new_b, "f"), ("g", new_b, "h")),
         [4, 2, 1, 4, 1],  # e, b, f, g, h
     )
+
+
+def test_filter_squash_mock_literal(mock_graph_literal):
+    """Test the squash operation with a foo-bar tree."""
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    print(gf.dataframe)
+    nodes = list(gf.graph.traverse())
+    assert not all(gf.dataframe.loc[nodes, "time"] > 5.0)
+    filtered_gf = gf.filter(lambda x: x["time"] > 5.0)
+
+    squashed_gf = filtered_gf.squash()
+    print(squashed_gf.dataframe)
+    squashed_nodes = list(squashed_gf.graph.traverse())
+    assert all(squashed_gf.dataframe.loc[squashed_nodes, "time"] > 5.0)
+    assert len(squashed_gf.graph) == 7

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -161,7 +161,7 @@ def check_filter_squash(gf, filter_func, expected_graph, expected_inc_time):
     ]
 
 
-def test_filter_squash1():
+def test_filter_squash():
     r"""Test squash on a simple tree with one root.
 
           a
@@ -292,7 +292,6 @@ def test_filter_squash_bunny():
     )
 
 
-@pytest.mark.xfail(reason="Subgraph sums are not yet properly supported")
 def test_filter_squash_bunny_to_goat():
     r"""Test squash on a "bunny" shaped graph:
 

--- a/hatchet/tests/node.py
+++ b/hatchet/tests/node.py
@@ -26,6 +26,9 @@ def test_from_lists():
 
 
 def test_traverse_pre():
+    node = Node(Frame(name="a"))
+    assert list(node.traverse(attrs="name")) == ["a"]
+
     node = Node.from_lists(["a", ["b", "d", "e"], ["c", "f", "g"]])
     assert list(node.traverse(attrs="name")) == ["a", "b", "d", "e", "c", "f", "g"]
 
@@ -86,4 +89,4 @@ def test_traverse_paths():
     diamond_subdag = Node.from_lists(("a", ("b", d), ("c", d)))
 
     g = Graph.from_lists(("e", "f", diamond_subdag), ("g", diamond_subdag, "h"))
-    assert list(g.traverse(attrs="name")) == ["e", "f", "a", "b", "d", "c", "g", "h"]
+    assert list(g.traverse(attrs="name")) == ["e", "a", "b", "d", "c", "f", "g", "h"]


### PR DESCRIPTION
`GraphFrame.squash()` was not correctly handling our new `Frame`-handled `Graph` `Nodes`.  This completely rewrites it and adds a number of tests.

Supersedes #55.

TODO:
- [x] make squash handle DAGs
- [x] make squash non-destructive
- [x] add tests for tree and graph squashes
- [x] handle merging nodes and DataFrame rows when squash results in children that share a frame
- [x] update inclusive metrics after squash
- [x] make update handle graphs correctly