### PR TITLE
add GraphFrame.copy() and GraphFrame.deepcopy() methods

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -214,6 +214,19 @@ class GraphFrame:
         return gf
 
     def copy(self):
+        """Return a shallow copy of the graphframe.
+
+        This copies the DataFrame, but the Graph is shared between `self` and
+        the new GraphFrame.
+        """
+        return GraphFrame(
+            self.graph,
+            self.dataframe.copy(),
+            list(self.exc_metrics),
+            list(self.inc_metrics),
+        )
+
+    def deepcopy(self):
         """Return a copy of the graphframe."""
         node_clone = {}
         graph_copy = self.graph.copy(node_clone)

--- a/hatchet/tests/dataframe_ops.py
+++ b/hatchet/tests/dataframe_ops.py
@@ -33,7 +33,7 @@ def test_add(mock_graph_literal):
     assert gf3.dataframe["time (inc)"].sum() == 1280
 
     gf4 = gf3.copy()
-    assert gf4.graph == gf3.graph
+    assert gf4.graph is gf3.graph
 
     gf5 = gf3.add(gf4)
     assert gf5.graph == gf3.graph == gf4.graph
@@ -53,7 +53,7 @@ def test_sub(mock_graph_literal):
         assert gf3.dataframe[metric].sum() == 0
 
     gf4 = gf3.copy()
-    assert gf4.graph == gf3.graph
+    assert gf4.graph is gf3.graph
 
     gf5 = gf3.sub(gf4)
     assert gf5.graph == gf3.graph == gf4.graph
@@ -73,7 +73,7 @@ def test_add_operator(mock_graph_literal):
     assert gf3.dataframe["time (inc)"].sum() == 1280
 
     gf4 = gf3.copy()
-    assert gf4.graph == gf3.graph
+    assert gf4.graph is gf3.graph
 
     gf5 = gf3 + gf4
     assert gf5.graph == gf3.graph == gf4.graph
@@ -93,7 +93,7 @@ def test_sub_operator(mock_graph_literal):
         assert gf3.dataframe[metric].sum() == 0
 
     gf4 = gf3.copy()
-    assert gf4.graph == gf3.graph
+    assert gf4.graph is gf3.graph
 
     gf5 = gf3.sub(gf4)
 
@@ -114,7 +114,7 @@ def test_iadd_operator(mock_graph_literal):
     assert gf1.dataframe["time (inc)"].sum() == 1280
 
     gf3 = gf1.copy()
-    assert gf3.graph == gf1.graph
+    assert gf3.graph is gf1.graph
 
     gf3 += gf1
 
@@ -135,7 +135,7 @@ def test_isub_operator(mock_graph_literal):
         assert gf1.dataframe[metric].sum() == 0
 
     gf3 = gf1.copy()
-    assert gf3.graph == gf1.graph
+    assert gf3.graph is gf1.graph
 
     gf3 -= gf1
 

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -18,7 +18,19 @@ def test_copy(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     other = gf.copy()
 
+    assert gf.graph is other.graph
+    assert gf.dataframe is not other.dataframe
+    assert gf.dataframe.equals(other.dataframe)
+    assert gf.inc_metrics == other.inc_metrics
+    assert gf.exc_metrics == other.exc_metrics
+
+
+def test_deepcopy(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    other = gf.deepcopy()
+
     assert gf.graph == other.graph
+    assert gf.dataframe is not other.dataframe
     assert gf.inc_metrics == other.inc_metrics
     assert gf.exc_metrics == other.exc_metrics
 


### PR DESCRIPTION
Returns a new graphframe containing the following:
- copy() returns a copy of the dataframe and the same graph object
- deepcopy() returns a copy of the dataframe and graph

- add graphframe deepcopy and copy tests
- modify add/sub tests to check for graph object equivalence (original
  input graphframes are left unmodified)