### PR TITLE
ignore test.dot file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 experiment.xml
 docs/_build
+examples/test.dot
 
 *.metric-db
 *.egg-info


### PR DESCRIPTION
Ignore `test.dot` file generated when running the `caliper.py` test.