### PR TITLE
Sort index of dataframe as part of unify

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -448,9 +448,11 @@ class GraphFrame:
 
         self.dataframe["node"] = self.dataframe["node"].apply(lambda x: node_map[x])
         self.dataframe.set_index(self.dataframe.index.names, inplace=True, drop=False)
+        self.dataframe.sort_index(inplace=True)
 
         other.dataframe["node"] = other.dataframe["node"].apply(lambda x: node_map[x])
         other.dataframe.set_index(other.dataframe.index.names, inplace=True, drop=False)
+        other.dataframe.sort_index(inplace=True)
 
         self.graph = union_graph
         other.graph = union_graph

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -102,3 +102,31 @@ def test_sample_json(sample_caliper_json):
     gf = GraphFrame.from_caliper_json(str(sample_caliper_json))
 
     assert len(gf.dataframe.groupby("name")) == 18
+
+
+def test_filter_squash_calc_unify_pi_database(lulesh_caliper_json):
+    gf = GraphFrame.from_caliper_json(str(lulesh_caliper_json))
+
+    orig_graph = gf.graph.copy()
+
+    filtered = gf.filter(lambda x: x["name"].startswith("Calc"))
+    assert filtered.graph is gf.graph
+    assert filtered.graph == orig_graph
+
+    gf2 = GraphFrame.from_caliper_json(str(lulesh_caliper_json))
+
+    assert gf.graph is not gf2.graph
+
+    filtered2 = gf2.filter(lambda x: x["name"].startswith("Calc"))
+    assert filtered2.graph is gf2.graph
+
+    squashed_gf = filtered.squash()
+    squashed_gf2 = filtered2.squash()
+
+    squashed_gf.unify(squashed_gf2)
+    assert squashed_gf.graph is squashed_gf2.graph
+    assert all(
+        squashed_gf.dataframe["node"].apply(id)
+        == squashed_gf2.dataframe["node"].apply(id)
+    )
+    assert all(squashed_gf.dataframe.index == squashed_gf2.dataframe.index)


### PR DESCRIPTION
Depending on the operations that occur prior to a unify, the order of the rows may differ, particularly if the dataframe is indexed by `node`. In the case where a `filter`/`squash` occur, the squash performs a `groupby` on the dataframe, which by default sorts the specified column (in our case, this was `node`, which sorts by `id()`). This can result in two different index orderings, though both lists contain the same indexes. Unifying two dataframes with indexes in different order should involve a sort of the indexes.

Add test for workflow that includes a filter, then squash, then unify.