### PR TITLE
[WIP] Standardize functions in graph construction time for readers

### DIFF
--- a/hatchet/readers/caliper_reader.py
+++ b/hatchet/readers/caliper_reader.py
@@ -150,6 +150,7 @@ class CaliperReader:
 
         with self.timer.phase("graph construction"):
             list_roots = self.create_graph()
+            graph = Graph(list_roots)
 
         # create a dataframe of metrics from the data section
         self.df_json_data = pd.DataFrame(self.json_data, columns=self.json_cols)
@@ -314,6 +315,4 @@ class CaliperReader:
             else:
                 exc_metrics.append(column)
 
-        return hatchet.graphframe.GraphFrame(
-            Graph(list_roots), dataframe, exc_metrics, inc_metrics
-        )
+        return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics)

--- a/hatchet/readers/hpctoolkit_reader.py
+++ b/hatchet/readers/hpctoolkit_reader.py
@@ -216,6 +216,9 @@ class HPCToolkitReader:
             with self.timer.phase("graph construction"):
                 self.parse_xml_children(root, graph_root, list(node_callpath))
 
+        with self.timer.phase("graph construction"):
+            graph = Graph(list_roots)
+
         # create a dataframe for all the nodes in the graph
         self.df_nodes = pd.DataFrame.from_dict(data=self.node_dicts)
 
@@ -235,9 +238,7 @@ class HPCToolkitReader:
             else:
                 exc_metrics.append(column)
 
-        return hatchet.graphframe.GraphFrame(
-            Graph(list_roots), dataframe, exc_metrics, inc_metrics
-        )
+        return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics)
 
     def parse_xml_children(self, xml_node, hnode, callpath):
         """Parses all children of an XML node."""


### PR DESCRIPTION
In each reader, the graph construction time includes getting the list of roots
and initializing the graph object, not just the former.