### PR TITLE
bugfix: graph union

### DIFF
--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -179,7 +179,7 @@ class Graph:
                 """Make a new node to represent the union of other nodes."""
                 new_node = nodes[0].copy()
                 for node in nodes:
-                    old_to_new[node] = new_node
+                    old_to_new[id(node)] = new_node
                 return new_node
 
             new_children = []
@@ -198,7 +198,7 @@ class Graph:
             while self_child and other_child:
                 if self_child.frame < other_child.frame:
                     # self_child is unique
-                    new_node = old_to_new.get(self_child)
+                    new_node = old_to_new.get(id(self_child))
                     if not new_node:
                         new_node = make_node(self_child)
                         _merge(frame_ordered(self_child.children), (), new_node)
@@ -207,7 +207,7 @@ class Graph:
 
                 elif self_child.frame > other_child.frame:
                     # other_child is unique
-                    new_node = old_to_new.get(other_child)
+                    new_node = old_to_new.get(id(other_child))
                     if not new_node:
                         new_node = make_node(other_child)
                         _merge((), frame_ordered(other_child.children), new_node)
@@ -216,8 +216,8 @@ class Graph:
 
                 else:
                     # self_child and other_child are equal
-                    self_mapped = old_to_new.get(self_child)
-                    other_mapped = old_to_new.get(other_child)
+                    self_mapped = old_to_new.get(id(self_child))
+                    other_mapped = old_to_new.get(id(other_child))
                     if not self_mapped and not other_mapped:
                         new_node = make_node(self_child, other_child)
                     else:
@@ -225,13 +225,13 @@ class Graph:
 
                     # map whichever node was not mapped yet
                     if not self_mapped:
-                        old_to_new[self_child] = new_node
+                        old_to_new[id(self_child)] = new_node
                         self_side = frame_ordered(self_child.children)
                     else:
                         self_side = []
 
                     if not other_mapped:
-                        old_to_new[other_child] = new_node
+                        old_to_new[id(other_child)] = new_node
                         other_side = frame_ordered(other_child.children)
                     else:
                         other_side = []
@@ -244,7 +244,7 @@ class Graph:
 
             # finish off whichever list of children is longer
             while self_child:
-                new_node = old_to_new.get(self_child)
+                new_node = old_to_new.get(id(self_child))
                 if not new_node:
                     new_node = make_node(self_child)
                     _merge(frame_ordered(self_child.children), (), new_node)
@@ -252,7 +252,7 @@ class Graph:
                 self_child = next(self_children, None)
 
             while other_child:
-                new_node = old_to_new.get(self_child)
+                new_node = old_to_new.get(id(other_child))
                 if not new_node:
                     new_node = make_node(other_child)
                     _merge((), frame_ordered(other_child.children), new_node)

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -491,7 +491,6 @@ class GraphFrame:
 
         node_map = {}
         union_graph = self.graph.union(other.graph, node_map)
-        union_graph.enumerate_traverse()
 
         self_index_names = self.dataframe.index.names
         other_index_names = other.dataframe.index.names
@@ -499,21 +498,16 @@ class GraphFrame:
         self.dataframe.reset_index(inplace=True)
         other.dataframe.reset_index(inplace=True)
 
-        self.dataframe["node"] = self.dataframe["node"].apply(lambda x: node_map[x])
-        other.dataframe["node"] = other.dataframe["node"].apply(lambda x: node_map[x])
+        self.dataframe["node"] = self.dataframe["node"].apply(lambda x: node_map[id(x)])
+        other.dataframe["node"] = other.dataframe["node"].apply(
+            lambda x: node_map[id(x)]
+        )
 
         self.dataframe.set_index(self_index_names, inplace=True, drop=True)
         other.dataframe.set_index(other_index_names, inplace=True, drop=True)
 
-        for i, node in enumerate(union_graph.traverse()):
-            self.dataframe.loc[node]._hatchet_nid = i
-            other.dataframe.loc[node]._hatchet_nid = i
-
         self.graph = union_graph
         other.graph = union_graph
-
-        self.dataframe.sort_index(inplace=True)
-        other.dataframe.sort_index(inplace=True)
 
     def tree(
         self,


### PR DESCRIPTION
Update dict indexing in graph union now that we are indexing the dataframe by
_hatchet_nid, which is not unique across multiple graphs, not id(node), which
is unique across multiple graphs.