### PR TITLE
Remove unnecessary setting of _hatchet_nid in dataframe

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -200,8 +200,6 @@ class GraphFrame:
 
         dataframe = pd.DataFrame(data=node_dicts)
         dataframe.set_index(["node"], inplace=True)
-        for i, node in enumerate(graph.traverse()):
-            dataframe.loc[node]._hatchet_nid = i
         dataframe.sort_index(inplace=True)
 
         return GraphFrame(graph, dataframe, exc_metrics, inc_metrics)
@@ -221,9 +219,6 @@ class GraphFrame:
         df = pd.DataFrame({"node": list(graph.traverse())})
         df["time"] = [1.0] * len(graph)
         df.set_index(["node"], inplace=True)
-
-        for i, node in enumerate(graph.traverse()):
-            df.loc[node]._hatchet_nid = i
         df.sort_index(inplace=True)
 
         gf = GraphFrame(graph, df, ["time"], [])
@@ -376,10 +371,7 @@ class GraphFrame:
 
         # perform a groupby to merge nodes with the same callpath
         agg_df = df.groupby(index_names).agg(agg_dict)
-
-        for i, node in enumerate(graph.traverse()):
-            df.loc[node]._hatchet_nid = i
-        df.sort_index(inplace=True)
+        agg_df.sort_index(inplace=True)
 
         # put it all together
         new_gf = GraphFrame(graph, agg_df, self.exc_metrics, self.inc_metrics)

--- a/hatchet/readers/caliper_reader.py
+++ b/hatchet/readers/caliper_reader.py
@@ -319,8 +319,6 @@ class CaliperReader:
             if "rank" in self.json_cols:
                 indices.append("rank")
             dataframe.set_index(indices, inplace=True)
-            for i, node in enumerate(graph.traverse()):
-                dataframe.loc[node]._hatchet_nid = i
             dataframe.sort_index(inplace=True)
 
         # create list of exclusive and inclusive metric columns

--- a/hatchet/readers/gprof_dot_reader.py
+++ b/hatchet/readers/gprof_dot_reader.py
@@ -108,8 +108,6 @@ class GprofDotReader:
             dataframe = pd.DataFrame.from_dict(data=list(self.name_to_dict.values()))
             index = ["node"]
             dataframe.set_index(index, inplace=True)
-            for i, node in enumerate(graph.traverse()):
-                dataframe.loc[node]._hatchet_nid = i
             dataframe.sort_index(inplace=True)
 
         return hatchet.graphframe.GraphFrame(graph, dataframe, ["time"], ["time (inc)"])

--- a/hatchet/readers/hpctoolkit_reader.py
+++ b/hatchet/readers/hpctoolkit_reader.py
@@ -259,9 +259,6 @@ class HPCToolkitReader:
             elif self.num_threads_per_rank == 1:
                 indices = ["node", "rank"]
             dataframe.set_index(indices, inplace=True)
-
-            for i, node in enumerate(graph.traverse()):
-                dataframe.loc[node]._hatchet_nid = i
             dataframe.sort_index(inplace=True)
 
         # create list of exclusive and inclusive metric columns


### PR DESCRIPTION
Any reader or operation that modifies the graph was traversing the graph, then
traversing the node column of the dataframe to set the _hatchet_nid. Traversing
the dataframe is unnecessary, since updated node objects will be reflected in
both the graph and dataframe. This does not change the functionality, it
just removes an extra (duplicated) step that has been covered by traversing the
graph.