### PR TITLE
Fix phase timer to aggregate times for duplicate phases

### DIFF
--- a/examples/time-read.py
+++ b/examples/time-read.py
@@ -8,7 +8,7 @@
 from __future__ import print_function
 import argparse
 
-from hatchet.readers.hpctoolkit_reader import HPCToolkitReader
+from hatchet import GraphFrame
 
 
 if __name__ == "__main__":
@@ -20,6 +20,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    reader = HPCToolkitReader(args.directory)
-    reader.create_graph()
-    print(str(reader.timer))
+    reader = GraphFrame.from_hpctoolkit(args.directory)

--- a/hatchet/util/timer.py
+++ b/hatchet/util/timer.py
@@ -34,7 +34,10 @@ class Timer(object):
 
         now = datetime.now()
         delta = now - self._start_time
-        self._times[self._phase] = delta
+        if self._times.get(self._phase):
+            self._times[self._phase] = self._times.get(self._phase) + delta
+        else:
+            self._times[self._phase] = delta
 
         self._phase = None
         self._start_time = None


### PR DESCRIPTION
- [x] Bugfix in timer example. This now compiles with updated Hatchet APIs.
- [x] For phases called more than once, aggregate the execution time. Current
implementation recorded the time of the last instance of the phase called.

For example, if the timed phases are as follows:
```
Calling phase fill tables
Calling phase read metric db
Calling phase graph construction
Calling phase graph construction
Calling phase data frame
```

We want the execution time for each graph construction phase to be aggregated to get the total time for this phase.