### PR TITLE
Remove Python 2.7 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ jobs:
         - black --diff --check .
         - flake8
     - stage: "unit tests"
-      python: '2.7'
-      os: linux
-      language: python
-    - python: '3.5'
+      python: '3.5'
       os: linux
       language: python
     - python: '3.6'


### PR DESCRIPTION
Python 2.7 is no longer maintained as of January 1, 2020.