### PR TITLE
add markups to identify missing nodes (in unify)

### DIFF
--- a/hatchet/external/printtree.py
+++ b/hatchet/external/printtree.py
@@ -126,9 +126,26 @@ def as_text(
                 c=colors_enabled if color else colors_disabled,
             )
         else:
-            result = "{indent}{time_str} {function}\n".format(
-                indent=indent, time_str=time_str, function=func_name
-            )
+            if "_missing_node" in dataframe.columns:
+                # if value of _missing_node column is not nan, then this is a missing
+                # node, so add decorators to differentiate it
+                is_missing_node = dataframe.loc[df_index, "_missing_node"]
+                if is_missing_node == "R":
+                    result = "{indent}{time_str} \033[1m[[{function}]] (R)\033[0m\n".format(
+                        indent=indent, time_str=time_str, function=func_name
+                    )
+                elif is_missing_node == "L":
+                    result = "{indent}{time_str} \033[1m[[{function}]] (L)\033[0m\n".format(
+                        indent=indent, time_str=time_str, function=func_name
+                    )
+                elif is_missing_node == "":
+                    result = "{indent}{time_str} {function}\n".format(
+                        indent=indent, time_str=time_str, function=func_name
+                    )
+            else:
+                result = "{indent}{time_str} {function}\n".format(
+                    indent=indent, time_str=time_str, function=func_name
+                )
 
         # only display those edges where child's metric is greater than
         # threshold

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -621,16 +621,39 @@ class GraphFrame:
             )
         )
 
-        # get rows that exist in other, but not in self, set metric column to 0
-        # for these rows
+        # get nodes that exist in other, but not in self, set metric columns to 0 for
+        # these rows
         other_not_in_self = other.dataframe[
             ~other.dataframe.index.isin(self.dataframe.index)
         ]
+        # get nodes that exist in self, but not in other
+        self_not_in_other = self.dataframe[
+            ~self.dataframe.index.isin(other.dataframe.index)
+        ]
+        # if there are missing nodes in either self or other, add a new column
+        # called _missing_node
+        if not self_not_in_other.empty:
+            self.dataframe["_missing_node"] = ""
+        if not other_not_in_self.empty:
+            other_not_in_self["_missing_node"] = ""
+
+        # for nodes that only exist in self, set value to be "L" indicating
+        # it exists in left graphframe
+        for i in self_not_in_other.index:
+            # a value of L indicates that the node exists in self, but not other
+            self.dataframe.at[i, "_missing_node"] = "L"
+
+        # for nodes that only exist in other, set the metric to be 0 (since
+        # it's a missing node in sel), and set value of _missing_node to be "R"
+        # indicating it exists in right graphframe
         for i in other_not_in_self.index:
             for j in all_metrics:
                 other_not_in_self.at[i, j] = 0
+            # a value of R indicates that the node exists in other, but not self
+            other_not_in_self.at[i, "_missing_node"] = "R"
 
-        # append missing rows to self's dataframe
+        # append missing rows (nodes that exist in other, but not self) to self's
+        # dataframe
         self.dataframe = self.dataframe.append(other_not_in_self)
 
         # sort self's dataframe by index

--- a/hatchet/tests/conftest.py
+++ b/hatchet/tests/conftest.py
@@ -347,3 +347,84 @@ def mock_dag_literal2():
     ]
 
     return dag_ldict
+
+
+@pytest.fixture
+def small_mock1():
+    ldict = [
+        {
+            "name": "A",
+            "metrics": {"time (inc)": 130.0, "time": 0.0},
+            "children": [
+                {
+                    "name": "B",
+                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                    "children": [
+                        {"name": "C", "metrics": {"time (inc)": 5.0, "time": 5.0}}
+                    ],
+                },
+                {
+                    "name": "E",
+                    "metrics": {"time (inc)": 55.0, "time": 10.0},
+                    "children": [
+                        {"name": "F", "metrics": {"time (inc)": 1.0, "time": 9.0}}
+                    ],
+                },
+                {"name": "H", "metrics": {"time (inc)": 55.0, "time": 10.0}},
+            ],
+        }
+    ]
+
+    return ldict
+
+
+@pytest.fixture
+def small_mock2():
+    ldict = [
+        {
+            "name": "A",
+            "metrics": {"time (inc)": 130.0, "time": 0.0},
+            "children": [
+                {
+                    "name": "B",
+                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                    "children": [
+                        {"name": "C", "metrics": {"time (inc)": 5.0, "time": 5.0}},
+                        {"name": "D", "metrics": {"time (inc)": 5.0, "time": 5.0}},
+                    ],
+                },
+                {
+                    "name": "E",
+                    "metrics": {"time (inc)": 55.0, "time": 10.0},
+                    "children": [
+                        {"name": "F", "metrics": {"time (inc)": 1.0, "time": 9.0}},
+                        {"name": "G", "metrics": {"time (inc)": 1.0, "time": 9.0}},
+                    ],
+                },
+            ],
+        }
+    ]
+
+    return ldict
+
+
+@pytest.fixture
+def small_mock3():
+    ldict = [
+        {
+            "name": "A",
+            "metrics": {"time (inc)": 130.0, "time": 0.0},
+            "children": [
+                {"name": "B", "metrics": {"time (inc)": 20.0, "time": 5.0}},
+                {
+                    "name": "E",
+                    "metrics": {"time (inc)": 55.0, "time": 10.0},
+                    "children": [
+                        {"name": "F", "metrics": {"time (inc)": 1.0, "time": 9.0}}
+                    ],
+                },
+            ],
+        }
+    ]
+
+    return ldict

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -416,3 +416,29 @@ def test_unify_diff_graphs():
     assert gf1.graph is gf2.graph
 
     assert len(gf1.graph) == gf1.dataframe.shape[0]
+
+
+def test_sub_decorator(small_mock1, small_mock2, small_mock3):
+    gf1 = GraphFrame.from_literal(small_mock1)
+    gf2 = GraphFrame.from_literal(small_mock2)
+    gf3 = GraphFrame.from_literal(small_mock3)
+
+    assert len(gf1.graph) == 6
+    assert len(gf2.graph) == 7
+
+    gf4 = gf1 - gf2
+
+    assert len(gf4.graph) == 8
+    assert gf4.dataframe.loc[gf4.dataframe["_missing_node"] == "R"].shape[0] == 2
+    assert gf4.dataframe.loc[gf4.dataframe["_missing_node"] == "L"].shape[0] == 1
+    assert gf4.dataframe.loc[gf4.dataframe["_missing_node"] == ""].shape[0] == 5
+
+    gf5 = gf1 - gf3
+
+    assert len(gf1.graph) == 6
+    assert len(gf3.graph) == 4
+
+    assert len(gf5.graph) == 6
+    assert gf5.dataframe.loc[gf5.dataframe["_missing_node"] == "R"].shape[0] == 0
+    assert gf5.dataframe.loc[gf5.dataframe["_missing_node"] == "L"].shape[0] == 2
+    assert gf5.dataframe.loc[gf5.dataframe["_missing_node"] == ""].shape[0] == 4


### PR DESCRIPTION
If two trees have different number of nodes, then unify may add nodes to the
resulting tree and dataframe. When looking at the trees, it is not easy to
identify the added nodes, so we differentiate the tree printout with brackets (`[[ func_name ]]`).