### PR TITLE
Fix required pandas version to omit v0.23.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
-pandas==0.23.0
+pandas<1.0.0
 pydot
 pytest
 codecov

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         "hatchet.external",
         "hatchet.tests",
     ],
-    install_requires=["pydot", "PyYAML", "matplotlib", "numpy", "pandas==0.23.0"],
+    install_requires=["pydot", "PyYAML", "matplotlib", "numpy", "pandas<1.0.0"],
 )


### PR DESCRIPTION
Current hatchet package requires pandas v0.23.0, but there's a bug with this
version that gives an error with python 3.6 and later. We want to omit this
pandas version.