### PR TITLE
Add parameter to invert color scheme for tree printout

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -525,6 +525,7 @@ class GraphFrame:
         depth=60,
         expand_names=False,
         unicode=True,
+        invert_colors=False,
         color=None,
     ):
         """Format this graphframe as a tree and return the resulting string."""
@@ -544,6 +545,7 @@ class GraphFrame:
             precision,
             depth,
             expand_names,
+            invert_colors,
             unicode=unicode,
             color=color,
         )

--- a/hatchet/tests/external/printtree.py
+++ b/hatchet/tests/external/printtree.py
@@ -6,10 +6,19 @@
 from hatchet.external import printtree as pt
 
 
-def test_ansi_color_for_time():
-    c = pt.colors_enabled
-    pt.ansi_color_for_time(0.95, 1) == c.light_red + c.faint
-    pt.ansi_color_for_time(0.8, 1) == c.red
-    pt.ansi_color_for_time(0.5, 1) == c.yellow
-    pt.ansi_color_for_time(0.15, 1) == c.green
-    pt.ansi_color_for_time(0.05, 1) == c.green + c.faint
+def test_ansi_color_for_time_default():
+    c = pt.colors_enabled_default
+    pt.ansi_color_for_time(0.95, 1, c) == c.highest + c.faint
+    pt.ansi_color_for_time(0.8, 1, c) == c.high
+    pt.ansi_color_for_time(0.5, 1, c) == c.med
+    pt.ansi_color_for_time(0.15, 1, c) == c.low
+    pt.ansi_color_for_time(0.05, 1, c) == c.lowest + c.faint
+
+
+def test_ansi_color_for_time_invert():
+    c = pt.colors_enabled_invert
+    pt.ansi_color_for_time(0.95, 1, c) == c.highest + c.faint
+    pt.ansi_color_for_time(0.8, 1, c) == c.high
+    pt.ansi_color_for_time(0.5, 1, c) == c.med
+    pt.ansi_color_for_time(0.15, 1, c) == c.low
+    pt.ansi_color_for_time(0.05, 1, c) == c.lowest + c.faint


### PR DESCRIPTION
Invert the coloring scheme for tree printout by specifying the `inverse_colors=True` in the `tree()` API. This will color nodes with a value green, and nodes with a small value red. Inverting the colors may be useful for printing the resulting tree of a division operator (i.e., speedup) where small values indicate minimal change. The default is `inverse_colors=False`. Resolves #153.

Default: `print(gf.tree(color=True, metric="time"))`
![Screen Shot 2020-05-11 at 3 08 28 PM](https://user-images.githubusercontent.com/5253432/81617358-25fff700-939a-11ea-9c64-432e38ffe57c.png)


New Parameter: `print(gf.tree(color=True, metric="time", invert_colors=True))`
![Screen Shot 2020-05-11 at 3 08 34 PM](https://user-images.githubusercontent.com/5253432/81617349-226c7000-939a-11ea-9a3d-b165418d3b2d.png)

