### PR TITLE
Initial Implementation of a Graph-based Query Language

### DIFF
--- a/hatchet/__init__.py
+++ b/hatchet/__init__.py
@@ -7,6 +7,7 @@
 # flake8: noqa: F401
 
 from .graphframe import GraphFrame
+from .query_matcher import QueryMatcher
 
 __version_info__ = ("1", "1", "0")
 __version__ = ".".join(__version_info__)

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -275,8 +275,13 @@ class GraphFrame:
 
         self.dataframe = agg_df
 
-    def filter(self, filter_obj):
-        """Filter the dataframe using a user-supplied function."""
+    def filter(self, filter_obj, squash=False):
+        """Filter the dataframe using a user-supplied function.
+
+        Arguments:
+            filter_obj (callable, list, or QueryMatcher): the filter to apply to the GraphFrame.
+            squash (boolean, optional): if True, automatically call squash for the user.
+        """
         dataframe_copy = self.dataframe.copy()
 
         index_names = self.dataframe.index.names
@@ -296,7 +301,12 @@ class GraphFrame:
             filtered_df = dataframe_copy.loc[dataframe_copy["node"].isin(match_set)]
         else:
             raise InvalidFilter(
-                "The arugment passed to filter must be a callable, a query path list, or a QueryMatcher object."
+                "The argument passed to filter must be a callable, a query path list, or a QueryMatcher object."
+            )
+
+        if filtered_df.shape[0] == 0:
+            raise EmptyFilter(
+                "The provided filter would have produced an empty GraphFrame."
             )
 
         filtered_df.set_index(index_names, inplace=True)
@@ -305,6 +315,8 @@ class GraphFrame:
         filtered_gf.exc_metrics = self.exc_metrics
         filtered_gf.inc_metrics = self.inc_metrics
 
+        if squash:
+            return filtered_gf.squash()
         return filtered_gf
 
     def squash(self):
@@ -951,4 +963,8 @@ class GraphFrame:
 
 
 class InvalidFilter(Exception):
-    """Raised when an invalid arugment is passed to the filter function."""
+    """Raised when an invalid argument is passed to the filter function."""
+
+
+class EmptyFilter(Exception):
+    """Raised when a filter would otherwise return an empty GraphFrame."""

--- a/hatchet/query_matcher.py
+++ b/hatchet/query_matcher.py
@@ -1,0 +1,366 @@
+# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+from numbers import Real
+import re
+
+from .node import Node, traversal_order
+
+
+class QueryMatcher:
+    """Process and apply queries to GraphFrames."""
+
+    def __init__(self, query=None):
+        """Create a new QueryMatcher object.
+
+        Arguments:
+            query (list, optional): if provided, convert the contents of the high-level API query into an internal representation.
+        """
+        # Initialize containers for query and memoization cache.
+        self.query_pattern = []
+        self.search_cache = {}
+        # If a high-level API list is provided, process it.
+        if query is not None:
+            assert isinstance(query, list)
+
+            def _convert_dict_to_filter(attr_filter):
+                """Converts high-level API attribute filter to a lambda"""
+                compops = ("<", ">", "==", ">=", "<=", "<>", "!=")  # ,
+                # Currently not supported
+                #           "is", "is not", "in", "not in")
+
+                def filter_func(df_row):
+                    """Lambda filter function for high-level API"""
+                    matches = True
+                    for k, v in attr_filter.items():
+                        if k not in df_row.keys():
+                            return False
+                        if isinstance(df_row[k], str):
+                            if not isinstance(v, str):
+                                raise InvalidQueryFilter(
+                                    "Value for attribute {} must be a string.", k
+                                )
+                            if re.match(v + r"\Z", df_row[k]) is not None:
+                                matches = matches and True
+                            else:
+                                matches = matches and False
+                        elif isinstance(df_row[k], Real):
+                            if isinstance(v, str) and v.lower().startswith(compops):
+                                matches = matches and eval("{} {}".format(df_row[k], v))
+                            elif isinstance(v, Real):
+                                matches = matches and (df_row[k] == v)
+                            else:
+                                raise InvalidQueryFilter(
+                                    "Attribute {} has a numeric type. Valid filters for this attribute are a string starting with a comparison operator or a real number.".format(
+                                        k
+                                    )
+                                )
+                        else:
+                            raise InvalidQueryFilter(
+                                "Filter must be one of the following:\n  * A regex string for a String attribute\n  * A string starting with a comparison operator for a Numeric attribute\n  * A number for a Numeric attribute\n"
+                            )
+                    return matches
+
+                return filter_func if attr_filter != {} else lambda row: True
+
+            for elem in query:
+                if isinstance(elem, dict):
+                    self._add_node(".", _convert_dict_to_filter(elem))
+                elif isinstance(elem, str) or isinstance(elem, int):
+                    self._add_node(elem)
+                elif isinstance(elem, tuple):
+                    assert isinstance(elem[1], dict)
+                    if isinstance(elem[0], str) or isinstance(elem[0], int):
+                        self._add_node(elem[0], _convert_dict_to_filter(elem[1]))
+                    else:
+                        raise InvalidQueryPath(
+                            "The first value of a tuple entry in a path must be either a string or integer."
+                        )
+                else:
+                    raise InvalidQueryPath(
+                        "A query path must be a list containing String, Integer, Dict, or Tuple elements"
+                    )
+
+    def match(self, wildcard_spec=".", filter_func=lambda row: True):
+        """Start a query with a root node described by the arguments.
+
+        Arugments:
+            wildcard_spec (str, optional, ".", "*", or "+"): the wildcard status of the node (follows standard Regex styntax)
+            filter_func (callable, optional): a callable accepting only a row from a Pandas DataFrame that is used to filter this node in the query
+
+        Returns:
+            (QueryMatcher): The instance of the class that called this function (enables fluent design).
+        """
+        if len(self.query_pattern) != 0:
+            self.query_pattern = []
+        self._add_node(wildcard_spec, filter_func)
+        return self
+
+    def rel(self, wildcard_spec=".", filter_func=lambda row: True):
+        """Add another edge and node to the query.
+        Arugments:
+            wildcard_spec (str, optional, ".", "*", or "+"): the wildcard status of the node (follows standard Regex styntax)
+            filter_func (callable, optional): a callable accepting only a row from a Pandas DataFrame that is used to filter this node in the query
+
+        Returns:
+            (QueryMatcher): The instance of the class that called this function (enables fluent design).
+        """
+        self._add_node(wildcard_spec, filter_func)
+        return self
+
+    def apply(self, gf):
+        """Apply the query to a GraphFrame.
+
+        Arguments:
+            gf (GraphFrame): the GraphFrame on which to apply the query.
+
+        Returns:
+            (list): A list of lists representing the set of paths that match this query.
+        """
+        self.search_cache = {}
+        matches = []
+        visited = set()
+        for root in sorted(gf.graph.roots, key=traversal_order):
+            self._apply_impl(gf, root, visited, matches)
+        assert len(visited) == len(gf.graph)
+        return matches
+
+    def _add_node(self, wildcard_spec=".", filter_func=lambda row: True):
+        """Add a node to the query.
+        Arugments:
+            wildcard_spec (str, optional, ".", "*", or "+"): the wildcard status of the node (follows standard Regex styntax)
+            filter_func (callable, optional): a callable accepting only a row from a Pandas DataFrame that is used to filter this node in the query
+        """
+        assert isinstance(wildcard_spec, int) or isinstance(wildcard_spec, str)
+        assert callable(filter_func)
+        if isinstance(wildcard_spec, int):
+            for i in range(wildcard_spec):
+                self.query_pattern.append((".", filter_func))
+        else:
+            assert wildcard_spec == "." or wildcard_spec == "*" or wildcard_spec == "+"
+            self.query_pattern.append((wildcard_spec, filter_func))
+
+    def _cache_node(self, gf, node):
+        """Cache (Memoize) the parts of the query that the node matches.
+
+        Arguments:
+            gf (GraphFrame): the GraphFrame containing the node to be cached.
+            node (Node): the Node to be cached.
+        """
+        assert isinstance(node, Node)
+        matches = []
+        # Applies each filtering function to the node to cache which
+        # query nodes the current node matches.
+        for i, node_query in enumerate(self.query_pattern):
+            _, filter_func = node_query
+            if filter_func(gf.dataframe.loc[node]):
+                matches.append(i)
+        self.search_cache[node._hatchet_nid] = matches
+
+    def _match_0_or_more(self, gf, node, wcard_idx):
+        """Process a "*" wildcard in the query on a subgraph.
+
+        Arguments:
+            gf (GraphFrame): the GraphFrame being queried.
+            node (Node): the node being queried against the "*" wildcard.
+            wcard_idx (int): the index associated with the "*" wildcard query.
+
+        Returns:
+            (list): a list of lists representing the paths rooted at "node" that match the "*" wildcard and/or the next query node. Will return None if there is no match for the "*" wildcard or the next query node.
+        """
+        # Cache the node if it's not already cached
+        if node._hatchet_nid not in self.search_cache:
+            self._cache_node(gf, node)
+        # If the node matches with the next non-wildcard query node,
+        # end the recursion and return the node.
+        if wcard_idx + 1 in self.search_cache[node._hatchet_nid]:
+            return [[]]
+        # If the node matches the "*" wildcard query, recursively
+        # apply this function to the current node's children. Then,
+        # collect their returned matches, and prepend the current node.
+        elif wcard_idx in self.search_cache[node._hatchet_nid]:
+            matches = []
+            if len(node.children) == 0:
+                if wcard_idx == len(self.query_pattern) - 1:
+                    return [[node]]
+                return None
+            for child in sorted(node.children, key=traversal_order):
+                sub_match = self._match_0_or_more(gf, child, wcard_idx)
+                if sub_match is not None:
+                    matches.extend(sub_match)
+            if len(matches) == 0:
+                return None
+            tmp = set(tuple(m) for m in matches)
+            matches = [list(t) for t in tmp]
+            return [[node] + m for m in matches]
+        # If the current node doesn't match the current "*" wildcard or
+        # the next non-wildcard query node, return None.
+        else:
+            if wcard_idx == len(self.query_pattern) - 1:
+                return [[]]
+            return None
+
+    def _match_1_or_more(self, gf, node, wcard_idx):
+        """Process a "+" wildcard in the query on a subgraph.
+
+        Arguments:
+            gf (GraphFrame): the GraphFrame being queried.
+            node (Node): the node being queried against the "+" wildcard.
+            wcard_idx (int): the index associated with the "+" wildcard query.
+
+        Returns:
+            (list): a list of lists representing the paths rooted at "node" that match the "+" wildcard and/or the next query node. Will return None if there is no match for the "+" wildcard or the next query node.
+        """
+        # Cache the node if it's not already cached
+        if node._hatchet_nid not in self.search_cache:
+            self._cache_node(gf, node)
+        # If the current node doesn't match the "+" wildcard, return None.
+        if wcard_idx not in self.search_cache[node._hatchet_nid]:
+            return None
+        # Since a query can't end on a wildcard, return None if the
+        # current node has no children.
+        if len(node.children) == 0:
+            return None
+        # Use _match_0_or_more to collect all additional wildcard matches.
+        matches = []
+        for child in sorted(node.children, key=traversal_order):
+            sub_match = self._match_0_or_more(gf, child, wcard_idx)
+            if sub_match is not None:
+                matches.extend(sub_match)
+        # Since _match_0_or_more will capture the query node that follows
+        # the wildcard, if no paths were retrieved from that function,
+        # the pattern does not continue after the "+" wildcard. Thus,
+        # since a pattern cannot end on a wildcard, the function
+        # returns None.
+        if len(matches) == 0:
+            return None
+        return [[node] + m for m in matches]
+
+    def _match_1(self, gf, node, idx):
+        """Process a "." wildcard in the query on a subgraph.
+
+        Arguments:
+            gf (GraphFrame): the GraphFrame being queried.
+            node (Node): the node being queried against the "." wildcard.
+            wcard_idx (int): the index associated with the "." wildcard query.
+
+        Returns:
+            (list): A list of lists representing the children of "node" that match the "." wildcard being considered. Will return None if there are no matches for the "." wildcard.
+        """
+        if node._hatchet_nid not in self.search_cache:
+            self._cache_node(gf, node)
+        matches = []
+        for child in sorted(node.children, key=traversal_order):
+            # Cache the node if it's not already cached
+            if child._hatchet_nid not in self.search_cache:
+                self._cache_node(gf, child)
+            if idx in self.search_cache[child._hatchet_nid]:
+                matches.append([child])
+        # To be consistent with the other matching functions, return
+        # None instead of an empty list.
+        if len(matches) == 0:
+            return None
+        return matches
+
+    def _match_pattern(self, gf, pattern_root):
+        """Try to match the query pattern starting at the provided root node.
+
+        Arugments:
+            gf (GraphFrame): the GraphFrame being queried.
+            pattern_root (Node): the root node of the subgraph that is being queried.
+
+        Returns:
+            (list): A list of lists representing the paths rooted at "pattern_root" that match the query.
+        """
+        assert isinstance(pattern_root, Node)
+        # Starting query node
+        pattern_idx = 1
+        # Starting matching pattern
+        matches = [[pattern_root]]
+        while pattern_idx < len(self.query_pattern):
+            # Get the wildcard type
+            wcard, _ = self.query_pattern[pattern_idx]
+            new_matches = []
+            # Consider each existing match individually so that more
+            # nodes can be added to them.
+            for m in matches:
+                sub_match = []
+                # Get the portion of the subgraph that matches the next
+                # part of the query.
+                if wcard == ".":
+                    s = self._match_1(gf, m[-1], pattern_idx)
+                    if s is None:
+                        sub_match.append(s)
+                    else:
+                        sub_match.extend(s)
+                elif wcard == "*":
+                    for child in sorted(m[-1].children, key=traversal_order):
+                        s = self._match_0_or_more(gf, child, pattern_idx)
+                        if s is None:
+                            sub_match.append(s)
+                        else:
+                            sub_match.extend(s)
+                elif wcard == "+":
+                    for child in sorted(m[-1].children, key=traversal_order):
+                        s = self._match_1_or_more(gf, child, pattern_idx)
+                        if s is None:
+                            sub_match.append(s)
+                        else:
+                            sub_match.extend(s)
+                else:
+                    raise InvalidQueryFilter(
+                        'Query wildcards must be one of ".", "*", or "+"'
+                    )
+                # Merge the next part of the match path with the
+                # existing part.
+                for s in sub_match:
+                    if s is not None:
+                        new_matches.append(m + s)
+            # Overwrite the old matches with the updated matches
+            matches = new_matches
+            # If all the existing partial matches were not able to be
+            # expanded into full matches, return None.
+            if len(matches) == 0:
+                return None
+            # Update the query node
+            pattern_idx += 1
+        return matches
+
+    def _apply_impl(self, gf, node, visited, matches):
+        """Traverse the subgraph with the specified root, and collect all paths that match the query.
+
+        Arugments:
+            gf (GraphFrame): the GraphFrame being queried.
+            node (Node): the root node of the subgraph that is being queried.
+            visited (set): a set that keeps track of what nodes have been visited in the traversal to minimize the amount of work that is repeated.
+            matches (list): the list in which the final set of matches are stored.
+        """
+        # If the node has already been visited (or is None for some
+        # reason), skip it.
+        if node is None or node._hatchet_nid in visited:
+            return
+        # Cache the node if it's not already cached
+        if node._hatchet_nid not in self.search_cache:
+            self._cache_node(gf, node)
+        # If the node matches the starting/root node of the query,
+        # try to get all query matches in the subgraph rooted at
+        # this node.
+        if 0 in self.search_cache[node._hatchet_nid]:
+            sub_match = self._match_pattern(gf, node)
+            if sub_match is not None:
+                matches.extend(sub_match)
+        # Note that the node is now visited.
+        visited.add(node._hatchet_nid)
+        # Continue the Depth First Search.
+        for child in sorted(node.children, key=traversal_order):
+            self._apply_impl(gf, child, visited, matches)
+
+
+class InvalidQueryPath(Exception):
+    """Raised when a query does not have the correct syntax"""
+
+
+class InvalidQueryFilter(Exception):
+    """Raised when a query filter does not have a valid syntax"""

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from hatchet import GraphFrame, QueryMatcher
-from hatchet.graphframe import InvalidFilter
+from hatchet.graphframe import InvalidFilter, EmptyFilter
 from hatchet.frame import Frame
 from hatchet.graph import Graph
 from hatchet.node import Node
@@ -474,6 +474,19 @@ def test_filter_bad_argument(mock_graph_literal):
     fake_filter = {"bad": "filter"}
     with pytest.raises(InvalidFilter):
         gf.filter(fake_filter)
+
+
+def test_filter_emtpy_graphframe(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    empty_filter = [
+        {"name": "waldo"},
+        "+",
+        {"time (inc)": ">= 20.0"},
+        "+",
+        {"time (inc)": 7.5, "time": 7.5},
+    ]
+    with pytest.raises(EmptyFilter):
+        gf.filter(empty_filter)
 
 
 def test_tree(mock_graph_literal):

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -1,0 +1,432 @@
+# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+import re
+
+from hatchet import GraphFrame
+from hatchet.node import traversal_order
+from hatchet.query_matcher import QueryMatcher, InvalidQueryFilter, InvalidQueryPath
+
+
+def test_construct_high_level_api():
+    mock_node_mpi = {"name": "MPI_Bcast"}
+    mock_node_ibv = {"name": "ibv_reg_mr"}
+    mock_node_time_true = {"time (inc)": 0.1}
+    mock_node_time_false = {"time (inc)": 0.001}
+    path1 = [{"name": "MPI_[_a-zA-Z]*"}, "*", {"name": "ibv[_a-zA-Z]*"}]
+    path2 = [{"name": "MPI_[_a-zA-Z]*"}, 2, {"name": "ibv[_a-zA-Z]*"}]
+    path3 = [
+        {"name": "MPI_[_a-zA-Z]*"},
+        ("+", {"time (inc)": ">= 0.1"}),
+        {"name": "ibv[_a-zA-Z]*"},
+    ]
+    path4 = [
+        {"name": "MPI_[_a-zA-Z]*"},
+        (3, {"time (inc)": 0.1}),
+        {"name": "ibv[_a-zA-Z]*"},
+    ]
+    query1 = QueryMatcher(path1)
+    query2 = QueryMatcher(path2)
+    query3 = QueryMatcher(path3)
+    query4 = QueryMatcher(path4)
+
+    assert query1.query_pattern[0][0] == "."
+    assert query1.query_pattern[0][1](mock_node_mpi)
+    assert not query1.query_pattern[0][1](mock_node_ibv)
+    assert not query1.query_pattern[0][1](mock_node_time_true)
+    assert query1.query_pattern[1][0] == "*"
+    assert query1.query_pattern[1][1](mock_node_mpi)
+    assert query1.query_pattern[1][1](mock_node_ibv)
+    assert query1.query_pattern[1][1](mock_node_time_true)
+    assert query1.query_pattern[1][1](mock_node_time_false)
+    assert query1.query_pattern[2][0] == "."
+
+    assert query2.query_pattern[0][0] == "."
+    assert query2.query_pattern[1][0] == "."
+    assert query2.query_pattern[1][1](mock_node_mpi)
+    assert query2.query_pattern[1][1](mock_node_ibv)
+    assert query2.query_pattern[1][1](mock_node_time_true)
+    assert query2.query_pattern[1][1](mock_node_time_false)
+    assert query2.query_pattern[2][0] == "."
+    assert query2.query_pattern[2][1](mock_node_mpi)
+    assert query2.query_pattern[2][1](mock_node_ibv)
+    assert query2.query_pattern[2][1](mock_node_time_true)
+    assert query2.query_pattern[2][1](mock_node_time_false)
+    assert query2.query_pattern[3][0] == "."
+
+    assert query3.query_pattern[0][0] == "."
+    assert query3.query_pattern[1][0] == "+"
+    assert not query3.query_pattern[1][1](mock_node_mpi)
+    assert not query3.query_pattern[1][1](mock_node_ibv)
+    assert query3.query_pattern[1][1](mock_node_time_true)
+    assert not query3.query_pattern[1][1](mock_node_time_false)
+    assert query3.query_pattern[2][0] == "."
+
+    assert query4.query_pattern[0][0] == "."
+    assert query4.query_pattern[1][0] == "."
+    assert not query4.query_pattern[1][1](mock_node_mpi)
+    assert not query4.query_pattern[1][1](mock_node_ibv)
+    assert query4.query_pattern[1][1](mock_node_time_true)
+    assert not query4.query_pattern[1][1](mock_node_time_false)
+    assert query4.query_pattern[2][0] == "."
+    assert not query4.query_pattern[2][1](mock_node_mpi)
+    assert not query4.query_pattern[2][1](mock_node_ibv)
+    assert query4.query_pattern[2][1](mock_node_time_true)
+    assert not query4.query_pattern[2][1](mock_node_time_false)
+    assert query4.query_pattern[3][0] == "."
+    assert not query4.query_pattern[3][1](mock_node_mpi)
+    assert not query4.query_pattern[3][1](mock_node_ibv)
+    assert query4.query_pattern[3][1](mock_node_time_true)
+    assert not query4.query_pattern[3][1](mock_node_time_false)
+    assert query4.query_pattern[4][0] == "."
+
+    invalid_path = [
+        {"name": "MPI_[_a-zA-Z]*"},
+        ({"bad": "wildcard"}, {"time (inc)": 0.1}),
+        {"name": "ibv[_a-zA-Z]*"},
+    ]
+    with pytest.raises(InvalidQueryPath):
+        _ = QueryMatcher(invalid_path)
+
+    invalid_path = [["name", "MPI_[_a-zA-Z]*"], "*", {"name": "ibv[_a-zA-Z]*"}]
+    with pytest.raises(InvalidQueryPath):
+        _ = QueryMatcher(invalid_path)
+
+
+def test_construct_low_level_api():
+    mock_node_mpi = {"name": "MPI_Bcast"}
+    mock_node_ibv = {"name": "ibv_reg_mr"}
+    mock_node_time_true = {"time (inc)": 0.1}
+    mock_node_time_false = {"time (inc)": 0.001}
+
+    def mpi_filter(df_row):
+        if "name" not in df_row:
+            return False
+        if re.match(r"MPI_[_a-zA-Z]*\Z", df_row["name"]) is not None:
+            return True
+        return False
+
+    def ibv_filter(df_row):
+        if "name" not in df_row:
+            return False
+        if re.match(r"ibv[_a-zA-Z]*\Z", df_row["name"]) is not None:
+            return True
+        return False
+
+    def time_ge_filter(df_row):
+        if "time (inc)" not in df_row:
+            return False
+        return df_row["time (inc)"] >= 0.1
+
+    def time_eq_filter(df_row):
+        if "time (inc)" not in df_row:
+            return False
+        return df_row["time (inc)"] == 0.1
+
+    query = QueryMatcher()
+
+    query.match(filter_func=mpi_filter).rel("*").rel(filter_func=ibv_filter)
+    assert query.query_pattern[0][0] == "."
+    assert query.query_pattern[0][1](mock_node_mpi)
+    assert not query.query_pattern[0][1](mock_node_ibv)
+    assert not query.query_pattern[0][1](mock_node_time_true)
+    assert query.query_pattern[1][0] == "*"
+    assert query.query_pattern[1][1](mock_node_mpi)
+    assert query.query_pattern[1][1](mock_node_ibv)
+    assert query.query_pattern[1][1](mock_node_time_true)
+    assert query.query_pattern[1][1](mock_node_time_false)
+    assert query.query_pattern[2][0] == "."
+
+    query.match(filter_func=mpi_filter).rel(2).rel(filter_func=ibv_filter)
+    assert query.query_pattern[0][0] == "."
+    assert query.query_pattern[1][0] == "."
+    assert query.query_pattern[1][1](mock_node_mpi)
+    assert query.query_pattern[1][1](mock_node_ibv)
+    assert query.query_pattern[1][1](mock_node_time_true)
+    assert query.query_pattern[1][1](mock_node_time_false)
+    assert query.query_pattern[2][0] == "."
+    assert query.query_pattern[2][1](mock_node_mpi)
+    assert query.query_pattern[2][1](mock_node_ibv)
+    assert query.query_pattern[2][1](mock_node_time_true)
+    assert query.query_pattern[2][1](mock_node_time_false)
+    assert query.query_pattern[3][0] == "."
+
+    query.match(filter_func=mpi_filter).rel("+", time_ge_filter).rel(
+        filter_func=ibv_filter
+    )
+    assert query.query_pattern[0][0] == "."
+    assert query.query_pattern[1][0] == "+"
+    assert not query.query_pattern[1][1](mock_node_mpi)
+    assert not query.query_pattern[1][1](mock_node_ibv)
+    assert query.query_pattern[1][1](mock_node_time_true)
+    assert not query.query_pattern[1][1](mock_node_time_false)
+    assert query.query_pattern[2][0] == "."
+
+    query.match(filter_func=mpi_filter).rel(3, time_eq_filter).rel(
+        filter_func=ibv_filter
+    )
+    assert query.query_pattern[0][0] == "."
+    assert query.query_pattern[1][0] == "."
+    assert not query.query_pattern[1][1](mock_node_mpi)
+    assert not query.query_pattern[1][1](mock_node_ibv)
+    assert query.query_pattern[1][1](mock_node_time_true)
+    assert not query.query_pattern[1][1](mock_node_time_false)
+    assert query.query_pattern[2][0] == "."
+    assert not query.query_pattern[2][1](mock_node_mpi)
+    assert not query.query_pattern[2][1](mock_node_ibv)
+    assert query.query_pattern[2][1](mock_node_time_true)
+    assert not query.query_pattern[2][1](mock_node_time_false)
+    assert query.query_pattern[3][0] == "."
+    assert not query.query_pattern[3][1](mock_node_mpi)
+    assert not query.query_pattern[3][1](mock_node_ibv)
+    assert query.query_pattern[3][1](mock_node_time_true)
+    assert not query.query_pattern[3][1](mock_node_time_false)
+    assert query.query_pattern[4][0] == "."
+
+
+def test_node_caching(mock_graph_literal):
+    path = [{"name": "fr[a-z]+"}, ("+", {"time (inc)": ">= 25.0"}), {"name": "baz"}]
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    node = gf.graph.roots[0].children[2].children[0]
+
+    query = QueryMatcher(path)
+    query._cache_node(gf, node)
+
+    assert 0 in query.search_cache[node._hatchet_nid]
+    assert 1 in query.search_cache[node._hatchet_nid]
+    assert 2 not in query.search_cache[node._hatchet_nid]
+
+
+def test_match_0_or_more_wildcard(mock_graph_literal):
+    path = [
+        {"name": "qux"},
+        ("*", {"time (inc)": "> 10"}),
+        {"name": "gr[a-z]+", "time (inc)": "<= 10"},
+    ]
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    node = gf.graph.roots[0].children[1]
+    none_node = gf.graph.roots[0].children[2].children[0].children[1].children[0]
+
+    correct_paths = [
+        [
+            node.children[0],
+            node.children[0].children[0],
+            node.children[0].children[0].children[0],
+            # node.children[0].children[0].children[0].children[1],
+        ],
+        [
+            node.children[0],
+            node.children[0].children[0],
+            # node.children[0].children[0].children[1],
+        ],
+    ]
+
+    query = QueryMatcher(path)
+    matched_paths = []
+    for child in sorted(node.children, key=traversal_order):
+        match = query._match_0_or_more(gf, child, 1)
+        if match is not None:
+            matched_paths.extend(match)
+
+    assert sorted(matched_paths, key=len) == sorted(correct_paths, key=len)
+    assert query._match_0_or_more(gf, none_node, 1) is None
+
+
+def test_match_1_or_more_wildcard(mock_graph_literal):
+    path = [
+        {"name": "qux"},
+        ("+", {"time (inc)": "> 10"}),
+        {"name": "gr[a-z]+", "time (inc)": "<= 10"},
+    ]
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    node = gf.graph.roots[0].children[1]
+    none_node = gf.graph.roots[0].children[2].children[0].children[1].children[0]
+
+    correct_paths = [
+        [
+            node.children[0],
+            node.children[0].children[0],
+            node.children[0].children[0].children[0],
+            # node.children[0].children[0].children[0].children[1],
+        ],
+        [
+            node.children[0],
+            node.children[0].children[0],
+            # node.children[0].children[0].children[1],
+        ],
+    ]
+
+    query = QueryMatcher(path)
+    matched_paths = []
+    for child in sorted(node.children, key=traversal_order):
+        match = query._match_1_or_more(gf, child, 1)
+        if match is not None:
+            matched_paths.extend(match)
+
+    assert matched_paths == correct_paths
+    assert query._match_1_or_more(gf, none_node, 1) is None
+
+    zero_match_path = [
+        {"name": "qux"},
+        ("+", {"time (inc)": "> 50"}),
+        {"name": "gr[a-z]+", "time (inc)": "<= 10"},
+    ]
+    zero_match_node = gf.graph.roots[0].children[0]
+    query = QueryMatcher(zero_match_path)
+    assert query._match_1_or_more(gf, zero_match_node, 1) is None
+
+
+def test_match_1(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    path = [
+        {"name": "qux"},
+        ("*", {"time (inc)": "> 10"}),
+        {"name": "gr[a-z]+", "time (inc)": "<= 10.0"},
+    ]
+    query = QueryMatcher(path)
+
+    assert query._match_1(gf, gf.graph.roots[0].children[0], 2) == [
+        [gf.graph.roots[0].children[0].children[1]]
+    ]
+    assert query._match_1(gf, gf.graph.roots[0], 2) is None
+
+
+def test_match(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    root = gf.graph.roots[0].children[2]
+
+    path0 = [
+        {"name": "waldo"},
+        "+",
+        {"time (inc)": ">= 20.0"},
+        "+",
+        {"time (inc)": 5.0, "time": 5.0},
+    ]
+    match0 = [
+        [
+            root,
+            root.children[0],
+            root.children[0].children[1],
+            root.children[0].children[1].children[0],
+            root.children[0].children[1].children[0].children[0],
+        ]
+    ]
+    query0 = QueryMatcher(path0)
+    assert query0._match_pattern(gf, root) == match0
+
+    path1 = [
+        {"name": "waldo"},
+        ("+", {}),
+        {"time (inc)": ">= 20.0"},
+        "+",
+        {"time (inc)": 7.5, "time": 7.5},
+    ]
+    query1 = QueryMatcher(path1)
+    assert query1._match_pattern(gf, root) is None
+
+
+def test_apply(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    path = [
+        {"time (inc)": ">= 30.0"},
+        (2, {"name": "[^b][a-z]+"}),
+        ("*", {"name": "[^b][a-z]+"}),
+        {"name": "gr[a-z]+"},
+    ]
+    root = gf.graph.roots[0]
+    match = [
+        [
+            root,
+            root.children[1],
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[1],
+        ],
+        [
+            root.children[1],
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[1],
+        ],
+    ]
+    query = QueryMatcher(path)
+
+    assert query.apply(gf) == match
+
+    path = [{"time (inc)": ">= 30.0"}, ".", {"name": "bar"}, "*"]
+    match = [
+        [
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[0],
+        ],
+        [
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+    ]
+    query = QueryMatcher(path)
+    assert query.apply(gf) == match
+
+    path = [{"name": "foo"}, {"name": "bar"}, {"time": 5.0}]
+    match = [[root, root.children[0], root.children[0].children[0]]]
+    query = QueryMatcher(path)
+    assert query.apply(gf) == match
+
+    path = [{"name": "foo"}, {"name": "qux"}, ("+", {"time (inc)": "> 15.0"})]
+    match = [
+        [
+            root,
+            root.children[1],
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+        ],
+        [
+            root,
+            root.children[1],
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+        ],
+    ]
+    query = QueryMatcher(path)
+    assert query.apply(gf) == match
+
+    path = [{"name": "this"}, ("*", {"name": "is"}), {"name": "nonsense"}]
+
+    query = QueryMatcher(path)
+
+    assert query.apply(gf) == []
+
+    path = [{"name": 5}, "*", {"name": "whatever"}]
+    query = QueryMatcher(path)
+    with pytest.raises(InvalidQueryFilter):
+        query.apply(gf)
+
+    path = [{"time": "badstring"}, "*", {"name": "whatever"}]
+    query = QueryMatcher(path)
+    with pytest.raises(InvalidQueryFilter):
+        query.apply(gf)
+
+    class DummyType:
+        def __init__(self):
+            self.x = 5.0
+            self.y = -1
+            self.z = "hello"
+
+    bad_field_test_dict = list(mock_graph_literal)
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
+        "list"
+    ] = DummyType()
+    gf = GraphFrame.from_literal(bad_field_test_dict)
+    path = [{"name": "foo"}, {"name": "bar"}, {"list": DummyType()}]
+    query = QueryMatcher(path)
+    with pytest.raises(InvalidQueryFilter):
+        query.apply(gf)

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -216,13 +216,8 @@ def test_match_0_or_more_wildcard(mock_graph_literal):
             node.children[0],
             node.children[0].children[0],
             node.children[0].children[0].children[0],
-            # node.children[0].children[0].children[0].children[1],
         ],
-        [
-            node.children[0],
-            node.children[0].children[0],
-            # node.children[0].children[0].children[1],
-        ],
+        [node.children[0], node.children[0].children[0]],
     ]
 
     query = QueryMatcher(path)
@@ -251,13 +246,8 @@ def test_match_1_or_more_wildcard(mock_graph_literal):
             node.children[0],
             node.children[0].children[0],
             node.children[0].children[0].children[0],
-            # node.children[0].children[0].children[0].children[1],
         ],
-        [
-            node.children[0],
-            node.children[0].children[0],
-            # node.children[0].children[0].children[1],
-        ],
+        [node.children[0], node.children[0].children[0]],
     ]
 
     query = QueryMatcher(path)
@@ -430,3 +420,31 @@ def test_apply(mock_graph_literal):
     query = QueryMatcher(path)
     with pytest.raises(InvalidQueryFilter):
         query.apply(gf)
+
+
+def test_apply_indices(calc_pi_hpct_db):
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+    main = gf.graph.roots[0].children[0]
+    path = [
+        {"name": "[0-9]*:?MPI_.*"},
+        ("*", {"name": "^((?!MPID).)*"}),
+        {"name": "[0-9]*:?MPID.*"},
+    ]
+    matches = [
+        [
+            main.children[0],
+            main.children[0].children[0],
+            main.children[0].children[0].children[0],
+            main.children[0].children[0].children[0].children[0],
+        ],
+        [
+            main.children[1],
+            main.children[1].children[0],
+            main.children[1].children[0].children[0],
+        ],
+    ]
+    query = QueryMatcher(path)
+    assert query.apply(gf) == matches
+
+    gf.drop_index_levels()
+    assert query.apply(gf) == matches


### PR DESCRIPTION
Resolves #70 

This PR adds an initial implementation of a Graph-based Query Language to Hatchet. The language allows for path-based filtering of a GraphFrame through two overloads of the `GraphFrame.filter` function.

The query language has two API levels: a high-level API and a low-level API.

#### High-Level API

The high-level API uses a simple language syntax based on built-in Python data structures. A high-level query is stored in a Python list. Each element of a list represents a node that must be matched in the query. Nodes in a high-level query can be represented in either a full or short-hand form:

##### Full Form:

A full form query node is a tuple containing two elements:
1. A wildcard specifier
2. A filter dictionary

A wildcard specifier can either be a string with a value of "." (match 1 node), "+" (match 1 or more nodes), or "*" (match 0 or more nodes) or an integer (match a fixed number of nodes). The filter is a dictionary and is described below.

##### Short-Hand Form:

A short-hand form query node is just one of the parts of a full form node. Valid short-hand nodes are:
* A string wildcard specifier (one of ".", "+", or "*") (uses an always true filter)
* An integer (match a fixed number of nodes) (uses an always true filter)
* A filter dictionary (matches a single node)

##### Filter Dictionary

A filter dictionary describes the requirements that a node must meet to match a node in a query. The keys in a filter dictionary must match columns names in a GraphFrame's Pandas DataFrame. The types of the values in a filter dictionary are dependent on the types of the data being referred to by the keys.
* If a node attribute (value corresponding with the filter dictionary's key) is a string, the value in the filter dictionary must be a regex-compatible string. Internally, the value in the filter dictionary will be passed as the first argument to Python's `re.match` function.
* If a node attribute is a Real number (int or float), there are two options for the value in the filter dictionary:
  * The value is a string starting starting with a valid Python comparison operator (e.g. `>`, `<`, `>=`, `==`, etc.). In this case, the attribute value is prepended to this string, and the entire modified string is run through Python's `eval` function to determine the boolean value of the filter.
  * The value is a Real number. In this case, the value is used for an equivalence check with the attribute's value.

Currently, if there are multiple key-value pairs in the filter dictionary, a boolean value will be obtained from each pair, and the final output of the filter will be the result of applying a logical AND operation across all booleans.

Once you construct your query list, you simply pass it to the `GraphFrame.filter` function. As with the current version of this function, you must follow a call to `GraphFrame.filter` with a call to `GraphFrame.squash` to update the graph.

#### Low-Level API

The low-level API uses a fluent-design that leverages lambdas/callables to expand on the filtering capabilities of the query. When using the low-level API, the first step is to create a `QueryMatcher` object. This class manages everything regarding the query language, and it is even used internally by the high-level API. Once you have a `QueryMatcher` object, you use the following two functions to build your query:
* `match`: reset the query and add a new root node to the query.
* `rel`: add a new node to the query.

Both of these function accept the following two arguments:
1. Wildcard (type: string or int, default="."): a value indicating the number of GraphFrame nodes to match with the new query node. This is the same as the wildcard specifier in the high-level API.
2. Filter_Func (type: callable, default=`lambda row: True`): a callable representing the filter for the query node. Values passed to this argument have the following two restrictions:
  * Must accept a single argument: a Pandas Series representing a row in the GraphFrame's Pandas DataFrame.
  * Must return a boolean.

As with the high-level API, to apply the query to a GraphFrame, you simply pass the `QueryMatcher` object to the `GraphFrame.filter` function. As with the current version of this function, you must follow a call to `GraphFrame.filter` with a call to `GraphFrame.squash` to update the graph.