### PR TITLE
Sort nodes in graph union

### DIFF
--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -221,7 +221,11 @@ class Graph:
                     new_node = old_to_new.get(id(self_child))
                     if not new_node:
                         new_node = make_node(self_child)
-                        _merge(self_child.children, (), new_node)
+                        _merge(
+                            sorted(self_child.children, key=lambda n: n.frame),
+                            (),
+                            new_node,
+                        )
                     connect(parent, new_node)
                     self_child = next(self_children, None)
 
@@ -230,7 +234,11 @@ class Graph:
                     new_node = old_to_new.get(id(other_child))
                     if not new_node:
                         new_node = make_node(other_child)
-                        _merge((), other_child.children, new_node)
+                        _merge(
+                            (),
+                            sorted(other_child.children, key=lambda n: n.frame),
+                            new_node,
+                        )
                     connect(parent, new_node)
                     other_child = next(other_children, None)
 
@@ -256,7 +264,11 @@ class Graph:
                     else:
                         other_side = []
 
-                    _merge(self_side, other_side, new_node)
+                    _merge(
+                        sorted(self_side, key=lambda n: n.frame),
+                        sorted(other_side, key=lambda n: n.frame),
+                        new_node,
+                    )
 
                     connect(parent, new_node)
                     self_child = next(self_children, None)
@@ -267,7 +279,11 @@ class Graph:
                 new_node = old_to_new.get(id(self_child))
                 if not new_node:
                     new_node = make_node(self_child)
-                    _merge(self_child.children, (), new_node)
+                    _merge(
+                        sorted(self_child.children, key=lambda n: n.frame),
+                        (),
+                        new_node,
+                    )
                 connect(parent, new_node)
                 self_child = next(self_children, None)
 
@@ -275,14 +291,22 @@ class Graph:
                 new_node = old_to_new.get(id(other_child))
                 if not new_node:
                     new_node = make_node(other_child)
-                    _merge((), other_child.children, new_node)
+                    _merge(
+                        (),
+                        sorted(other_child.children, key=lambda n: n.frame),
+                        new_node,
+                    )
                 connect(parent, new_node)
                 other_child = next(other_children, None)
 
             return new_children
 
         # First establish which nodes correspond to each other
-        new_roots = _merge(self.roots, other.roots, None)
+        new_roots = _merge(
+            sorted(self.roots, key=lambda n: n.frame),
+            sorted(other.roots, key=lambda n: n.frame),
+            None,
+        )
 
         graph = Graph(new_roots)
         graph.enumerate_traverse()

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -676,6 +676,12 @@ class GraphFrame:
             new_df["_missing_node"] = ""
             other_not_in_self = other_not_in_self.join(new_df)
 
+            # add a new column to self if other has nodes not in self
+            if self_not_in_other.empty:
+                new_df = pd.DataFrame(index=self.dataframe.index)
+                new_df["_missing_node"] = ""
+                self.dataframe = self.dataframe.join(new_df)
+
         # for nodes that only exist in self, set value to be "L" indicating
         # it exists in left graphframe
         for i in self_not_in_other.index:

--- a/hatchet/node.py
+++ b/hatchet/node.py
@@ -159,6 +159,9 @@ class Node:
     def __lt__(self, other):
         return self._hatchet_nid < other._hatchet_nid
 
+    def __gt__(self, other):
+        return self._hatchet_nid > other._hatchet_nid
+
     def __str__(self):
         """Returns a string representation of the node."""
         return str(self.frame)


### PR DESCRIPTION
The current `union` traverses nodes, which may have different ordering. By sorting nodes in the union, we guarantee that nodes that are the same between graphs are compared correctly.