### PR TITLE
Removes an unusued argument to the _iter_depth function in Graph.enumerate_depth

### DIFF
--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -290,18 +290,18 @@ class Graph:
         return graph
 
     def enumerate_depth(self):
-        def _iter_depth(node, parent, visited):
+        def _iter_depth(node, visited):
             for child in node.children:
                 if child not in visited:
                     visited.add(child)
                     # depth of child is depth of node + 1
                     child._depth = node._depth + 1
-                    _iter_depth(child, node, visited)
+                    _iter_depth(child, visited)
 
         visited = set()
         for root in self.roots:
             root._depth = 0  # depth of root node is 0
-            _iter_depth(root, None, visited)
+            _iter_depth(root, visited)
 
     def enumerate_traverse(self):
         if not self._check_enumerate_traverse():


### PR DESCRIPTION
Small PR that removes an unused `parent` argument to the `_iter_depth` function in `Graph.enumerate_depth`.