### PR TITLE
Check divide by 0 case when computing node colors for metric

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -215,7 +215,10 @@ class ConsoleRenderer:
         return result
 
     def _ansi_color_for_metric(self, metric):
-        proportion_of_total = metric / self.max_metric
+        if self.max_metric != 0:
+            proportion_of_total = metric / self.max_metric
+        else:
+            proportion_of_total = metric / 1
 
         if proportion_of_total > 0.9:
             return self.colors.colormap[0]


### PR DESCRIPTION
The tree printout compares each node's metric to the max metric value to
determine what color the node should be. This fix handles when the max metric
value is 0 (avoids divide by 0 error). Fixes #195.