### PR TITLE
use a decorator for warning about deprecated parameters

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -15,6 +15,7 @@ from .frame import Frame
 from .query_matcher import QueryMatcher
 from .external.console import ConsoleRenderer
 from .util.dot import trees_to_dot
+from .util.deprecated import deprecated_params
 
 
 class GraphFrame:
@@ -538,6 +539,16 @@ class GraphFrame:
         self.graph = union_graph
         other.graph = union_graph
 
+    @deprecated_params(
+        metric="metric_column",
+        name="name_column",
+        expand_names="expand_name",
+        context="context_column",
+        invert_colors="invert_colormap",
+        color="",
+        threshold="",
+        unicode="",
+    )
     def tree(
         self,
         metric_column="time",
@@ -550,16 +561,21 @@ class GraphFrame:
         depth=10000,
         highlight_name=True,
         invert_colormap=False,
+        color=None,  # removed
+        threshold=None,  # removed
+        unicode=None,  # removed
     ):
         """Format this graphframe as a tree and return the resulting string."""
         color = sys.stdout.isatty()
+        shell = None
 
         if color is False:
             try:
                 import IPython
+
+                shell = IPython.get_ipython().__class__.__name__
             except ImportError:
                 pass
-            shell = IPython.get_ipython().__class__.__name__
             # Test if running in a Jupyter notebook or qtconsole
             if shell == "ZMQInteractiveShell":
                 color = True

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -723,3 +723,22 @@ def test_depth(mock_graph_literal):
 
     assert nnodes_depth_2 == 7
     assert max_depth == 5
+
+
+def test_tree_deprecated_parameters(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+
+    with pytest.warns(FutureWarning):
+        gf.tree(color=True, metric="time")
+
+    with pytest.warns(FutureWarning):
+        gf.tree(invert_colors=True)
+
+    with pytest.warns(FutureWarning):
+        gf.tree(name="name")
+
+    with pytest.warns(FutureWarning):
+        gf.tree(threshold=0.2)
+
+    with pytest.raises(TypeError):
+        gf.tree(metric="time", metric_column="time")

--- a/hatchet/util/deprecated.py
+++ b/hatchet/util/deprecated.py
@@ -1,0 +1,44 @@
+# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import functools
+import warnings
+
+
+def deprecated_params(**old_to_new):
+    def deco(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            rename_kwargs(f.__name__, old_to_new, kwargs)
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return deco
+
+
+def rename_kwargs(fname, old_to_new, kwargs):
+    for old, new in old_to_new.items():
+        if old in kwargs:
+            if new in kwargs:
+                raise TypeError(
+                    '{}() received both "{}=" and "{}=".'.format(fname, old, new)
+                )
+
+            # if parameter has been removed
+            if not new:
+                warnings.warn(
+                    '{}() parameter "{}=" has been removed.'.format(fname, old),
+                    FutureWarning,
+                )
+            # if parameter has been deprecated and renamed
+            else:
+                warnings.warn(
+                    '{}() parameter "{}=" has been deprecated, please use "{}=".'.format(
+                        fname, old, new
+                    ),
+                    FutureWarning,
+                )
+                kwargs[new] = kwargs.pop(old)


### PR DESCRIPTION
add decorator to tree() printout regarding name change in some parameters, resolves #194 

- [x] test warnings in terminal output -- success
- [x] test warnings in jupyter notebook -- all warnings used to be disabled by default, had to add the following to the notebook to see the hatchet warnings (and other system warnings), but this seems resolved now
```
import warnings
warnings.filterwarnings('always')
```

How can we warn users from jupyter that parameters are deprecated?

From https://www.python.org/dev/peps/pep-0565/
DeprecationWarning: reported by default for code that runs directly in the __main__ module (as such code is considered relatively unlikely to have a dedicated test suite), but hidden by default for code in other modules. The intended audience is Python developers that are at risk of upgrades to their dependencies (including upgrades to Python itself) breaking their software (e.g. developers using Python to script environments where someone else is in control of the timing of dependency upgrades).

FutureWarning: reported by default for all code. The intended audience is users of applications written in Python, rather than other Python developers (e.g. warning about use of a deprecated setting in a configuration file format).

For library and framework authors that want to ensure their API compatibility warnings are more reliably seen by their users, the recommendation is to use a custom warning class that derives from DeprecationWarning in Python 3.7+, and from FutureWarning in earlier versions.