### PR TITLE
Fixes a Couple of Query Language Bugs Concerning the * Wildcard

### DIFF
--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -306,7 +306,7 @@ def test_match(mock_graph_literal):
         ]
     ]
     query0 = QueryMatcher(path0)
-    assert query0._match_pattern(gf, root) == match0
+    assert query0._match_pattern(gf, root, 0) == match0
 
     path1 = [
         {"name": "waldo"},
@@ -316,7 +316,7 @@ def test_match(mock_graph_literal):
         {"time (inc)": 7.5, "time": 7.5},
     ]
     query1 = QueryMatcher(path1)
-    assert query1._match_pattern(gf, root) is None
+    assert query1._match_pattern(gf, root, 0) is None
 
 
 def test_apply(mock_graph_literal):
@@ -392,7 +392,6 @@ def test_apply(mock_graph_literal):
     path = [{"name": "this"}, ("*", {"name": "is"}), {"name": "nonsense"}]
 
     query = QueryMatcher(path)
-
     assert query.apply(gf) == []
 
     path = [{"name": 5}, "*", {"name": "whatever"}]
@@ -420,6 +419,54 @@ def test_apply(mock_graph_literal):
     query = QueryMatcher(path)
     with pytest.raises(InvalidQueryFilter):
         query.apply(gf)
+
+    path = ["*", {"name": "bar"}, {"name": "grault"}, "*"]
+    match = [
+        [root, root.children[0], root.children[0].children[1]],
+        [root.children[0], root.children[0].children[1]],
+        [
+            root,
+            root.children[1],
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+        [
+            root.children[1],
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+        [
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+        [
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+        [
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+        [
+            gf.graph.roots[1],
+            gf.graph.roots[1].children[0],
+            gf.graph.roots[1].children[0].children[1],
+        ],
+        [gf.graph.roots[1].children[0], gf.graph.roots[1].children[0].children[1]],
+    ]
+    query = QueryMatcher(path)
+    assert sorted(query.apply(gf)) == sorted(match)
+
+    path = ["*", {"name": "bar"}, {"name": "grault"}, "+"]
+    query = QueryMatcher(path)
+    assert query.apply(gf) == []
 
 
 def test_apply_indices(calc_pi_hpct_db):


### PR DESCRIPTION
While using the query language, I tracked down two edge-case bug that slipped through my earlier testing. The bugs involve using the * wildcard as the first or last element of the query path.

In the case where the * wildcard was the first element of the query, `QueryMatcher` was incorrectly requiring there to be at least one match for that wildcard. In other words, the * wildcard was being treated as a + wildcard. This was causing `QueryMatcher` to not produce an exhaustive list of all matching paths (what it's supposed to do), which could have led to an incomplete set of filtered nodes.

Similarly, in the case where the * wildcard was the last element of the query, `QueryMatcher` was incorrectly requiring there to be at least one match for that wildcard. This was more problematic than the first-element case, though, because`QueryMatcher` was throwing out the entire matched path if this condition was not met.

This pull request fixes both of these bugs and adds new code to the `test_apply` function in `tests/query.py` to cover these edge cases.