### PR TITLE
Fixes Bug in Graph.find_merges that massively slowed down squashing

### DIFF
--- a/hatchet/graph.py
+++ b/hatchet/graph.py
@@ -70,6 +70,7 @@ class Graph:
         inverted_merges = defaultdict(
             lambda: []
         )  # merged_node -> list of corresponding old_nodes
+        processed = []
 
         def _find_child_merges(node_list):
             index = index_by("frame", node_list)
@@ -89,6 +90,8 @@ class Graph:
 
         _find_child_merges(self.roots)
         for node in self.traverse():
+            if node in processed:
+                continue
             nodes = None
             # If node is going to be merged with other nodes,
             # collect the set of those nodes' children. This is
@@ -99,10 +102,12 @@ class Graph:
                 nodes = []
                 for node_to_merge in inverted_merges[new_node]:
                     nodes.extend(node_to_merge.children)
+                processed.extend(inverted_merges[new_node])
             # If node is not going to be merged, simply get the list of
             # node's children.
             else:
                 nodes = node.children
+                processed.append(node)
             _find_child_merges(nodes)
 
         return merges


### PR DESCRIPTION
Fixes an oversight in #176.

In that PR, I addressed the bug in `Graph.find_merges` that caused nodes that would be merged to be considered independently rather than as a single node. However, I didn't add code to keep track of which nodes had already been processed by the code added for this earlier bugfix. This caused the computation to increase exponentially. For example, if a Graph had 50 nodes that merged into 1 node, my code from #176 would compute the next merge candidate set from the children of all 50 nodes each time one of those 50 nodes was encountered in the overarching traversal. This meant that I was performing 2500 computations, when my code only really needed to be performing 50.

This PR corrects this issue by adding a new list within the `Graph.find_merges` function that keeps track of which nodes have already been processed.