### PR TITLE
Quick fix to install script and associated setup documentation.

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -36,11 +36,13 @@ This will create a directory called ``hatchet``.
 Install and Build Hatchet
 -------------------------
 
-To build hatchet and update your PYTHONPATH, run the folllowing bash script from the hatchet root directory:
+To build hatchet and update your PYTHONPATH, run the following bash script from the hatchet root directory:
 
 .. code-block:: console
 
-    $ ./install.sh
+    $ source ./install.sh
+
+Note: The ``source`` keyword is required to update your PYTHONPATH environment variable. It is not necessary if you have already manually added the hatchet directory in your PYTHONPATH.
 
 Alternatively, you can install hatchet using pip:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -36,13 +36,16 @@ This will create a directory called ``hatchet``.
 Install and Build Hatchet
 -------------------------
 
-To build hatchet and update your PYTHONPATH, run the following bash script from the hatchet root directory:
+To build hatchet and update your PYTHONPATH, run the following shell script
+from the hatchet root directory:
 
 .. code-block:: console
 
     $ source ./install.sh
 
-Note: The ``source`` keyword is required to update your PYTHONPATH environment variable. It is not necessary if you have already manually added the hatchet directory in your PYTHONPATH.
+Note: The ``source`` keyword is required to update your PYTHONPATH environment
+variable. It is not necessary if you have already manually added the hatchet
+directory to your PYTHONPATH.
 
 Alternatively, you can install hatchet using pip:
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
-#!/bin/bash
+#!/bin/sh
+
 if [[ "$PYTHONPATH" != *"$PWD"* ]]; then
-	export PYTHONPATH=$PWD:$PYTHONPATH
+	PYTHONPATH=$PWD:$PYTHONPATH
 fi
+
 python setup.py build_ext --inplace 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-if grep -q "$PWD" <<< "$PTYHONPATH"; then
-	export PYTHONPATH
-else 
+if [[ "$PYTHONPATH" != *"$PWD"* ]]; then
 	export PYTHONPATH=$PWD:$PYTHONPATH
 fi
 python setup.py build_ext --inplace 


### PR DESCRIPTION
This is just a quick fix and refactor to the install script. It also now builds both python2.7 and python3 versions of the cython extensions in the same script just to simplify development workflows. I also noticed that the logic of the export command was fundamentally wrong without `sourcing` the bash script so I modified the docs to reflect the need to call `source` on the script if users which to have their PYTHONPATH automatically updated.