### PR TITLE
Profiler Refactor and Redesign

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -641,7 +641,7 @@ class GraphFrame:
 
     def to_literal(self, name="name", rank=0, thread=0):
         """Format this graph as a list of dictionaries for Roundtrip
-           visualizations.
+        visualizations.
         """
         graph_literal = []
         visited = []

--- a/hatchet/readers/caliper_reader.py
+++ b/hatchet/readers/caliper_reader.py
@@ -162,8 +162,7 @@ class CaliperReader:
         return list_roots
 
     def read(self):
-        """ Read the caliper JSON file to extract the calling context tree.
-        """
+        """Read the caliper JSON file to extract the calling context tree."""
         with self.timer.phase("read json"):
             self.read_json_sections()
 

--- a/hatchet/tests/conftest.py
+++ b/hatchet/tests/conftest.py
@@ -135,7 +135,7 @@ def calc_pi_callgrind_dot(data_dir, tmpdir):
 
 @pytest.fixture
 def mock_graph_literal():
-    """ Creates a mock tree
+    """Creates a mock tree
 
     Metasyntactic variables: https://www.ietf.org/rfc/rfc3092.txt
     """

--- a/hatchet/tests/graph.py
+++ b/hatchet/tests/graph.py
@@ -10,7 +10,7 @@ from hatchet.graph import Graph
 
 def test_from_lists():
     """Ensure we can traverse roots in correct order without repeating a
-       shared subdag.
+    shared subdag.
     """
     d = Node(Frame(name="d"))
     diamond_subdag = Node.from_lists(("a", ("b", d), ("c", d)))

--- a/hatchet/tests/profiler.py
+++ b/hatchet/tests/profiler.py
@@ -1,80 +1,116 @@
+import hatchet as ht
 import pstats
 import os
 from hatchet.util.profiler import Profiler
 
 
+decorated_calls = [
+    "copy",
+    "deepcopy",
+    "drop_index_levels",
+    "filter",
+    "squash",
+    "tree",
+    "to_dot",
+    "__add__",
+    "__imul__",
+    "__isub__",
+    "traverse",
+    "copy",
+    "__len__",
+]
+
+
 def f():
+    """Dummy function for profiling"""
     for i in range(1000):
         for j in range(1000):
             i * j
 
 
-def test_start():
+def test_profiler():
+    """ Test the profiler start/stop, ensure that f() has been profiled """
     prf = Profiler()
-    prf.start()
-    prf.end()
-    t_1 = prf.getRuntime()
 
     prf.start()
     f()
-    prf.end()
-    t_2 = prf.getRuntime()
-    assert t_1 != t_2
+    prf.stop()
+
+    sts = pstats.Stats(prf._prf)
+    assert "stats" in sts.__dict__
+
+    fn_names = []
+    for stat in sts.__dict__["stats"]:
+        fn_names.append(stat[2])
+
+    assert "f" in fn_names
+
+    assert isinstance(prf.__str__(), str)
+    assert "(f)" in prf.__str__()
+
+    os.remove(prf._output + ".pstats")
 
 
-def test_end():
+def test_write_file():
+    """Test that write_to_file, writes a profile to the correct file."""
     prf = Profiler()
+
     prf.start()
     f()
-    prf.end()
-    t_1 = pstats.Stats(prf.prf).__dict__["total_tt"]
-    t_2 = pstats.Stats(prf.prf).__dict__["total_tt"]
-    assert t_1 == t_2
+    prf.stop()
+
+    prf.write_to_file("test.pstats")
+
+    assert os.path.exists("test.pstats")
+
+    sts = pstats.Stats("test.pstats")
+    fn_names = []
+    for stat in sts.__dict__["stats"]:
+        fn_names.append(stat[2])
+
+    assert "f" in fn_names
+
+    os.remove("test.pstats")
+    os.remove(prf._output + ".pstats")
 
 
-def test_reset():
+def test_profiling_calc_pi(calc_pi_hpct_db):
+    """Test debug wrapper as called from hpctoolkit."""
     prf = Profiler()
+    output_file = prf._output + ".pstats"
+
     prf.start()
-    f()
-    prf.end()
-    prf.reset()
+    gf = ht.GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
 
-    assert {} == prf.prf.__dict__
+    gf.copy()
+    gf2 = gf.deepcopy()
+    gf.tree()
+    gf.to_dot()
 
+    gf3 = gf + gf2
+    gf *= gf2
+    gf3 -= gf2
 
-def test_getters():
-    runs = 3
+    gf.graph.traverse()
+    gf.graph.copy()
+    len(gf.graph)
 
-    prf = Profiler()
-    for i in range(runs):
-        prf.start()
-        f()
-        prf.end()
+    gf2 = gf.filter(lambda x: x["time"] > 0.01)
 
-    assert prf.getRuntime() == pstats.Stats(prf.prf).__dict__["total_tt"]
-    assert (
-        prf.getAverageRuntime(runs) == pstats.Stats(prf.prf).__dict__["total_tt"] / runs
-    )
-    assert prf.getRuntime() != prf.getAverageRuntime(runs)
+    gf2.squash()
+    gf.drop_index_levels()
 
+    prf.stop()
 
-def test_f_output():
-    runs = 3
-    file = "test.txt"
-    prf = Profiler()
-    global f
+    assert os.path.exists(output_file)
 
-    for i in range(runs):
-        prf.start()
-        f()
-        prf.end()
+    sts = pstats.Stats(output_file)
 
-    prf.dumpAverageStats("cumulative", file, runs)
-    assert os.path.exists(file)
+    fn_names = []
+    for stat in sts.__dict__["stats"]:
+        fn_names.append(stat[2])
 
-    with open(file, "r") as f:
-        lines = f.readlines()
+    for call in decorated_calls:
+        assert call in fn_names
 
-    assert "Averaged over {} trials".format(runs) in lines[2]
-
-    os.remove(file)
+    os.remove(output_file)

--- a/hatchet/util/profiler.py
+++ b/hatchet/util/profiler.py
@@ -34,12 +34,12 @@ def print_incomptable_msg(stats_file):
 class Profiler:
     """
     Wrapper class around cProfile.
-    Exports a pstats file to be read by hpctoolkit.
+    Exports a pstats file to be read by the pstats reader.
     """
 
     def __init__(self):
         self._prf = cProfile.Profile()
-        self._output = "hatchet_profile"
+        self._output = "hatchet-profile"
         self._active = False
 
     def start(self):
@@ -48,7 +48,7 @@ class Profiler:
         """
         if self._active:
             print(
-                "Start dissallowed in scope where profile is running. Please add Profiler.stop() before attempting start."
+                "Start dissallowed in scope where profiler is running. Please add Profiler.stop() before attempting start."
             )
             raise
 
@@ -70,7 +70,7 @@ class Profiler:
         """
         if self._active:
             print(
-                "Reset dissallowed in scope where profile is running. Please add Profiler.stop() before attempting reset."
+                "Reset dissallowed in scope where profiler is running. Please add Profiler.stop() before attempting reset."
             )
             raise
 


### PR DESCRIPTION
Branch for the profiler refactor and redesign. The timer class was integrated with the profiler on a separate branch but I have rolled that back per @bhatele 's suggestion since hierarchical data is encoded in the cprofile by default with callee-caller relationships. The timer class has returned to be a separate class and now the profiler writes a cprofile object to a binary file which can be read with the pstats library. The unit tests are currently dummies until the design of this class if finalized.