### PR TITLE
Added check to to_dot and tree methods so nodes are only visited once.

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -37,6 +37,7 @@ class ConsoleRenderer:
         self.unicode = unicode
         self.color = color
         self.colors = self.colors_enabled if color else self.colors_disabled
+        self.visited = []
 
     def render(self, roots, dataframe, **kwargs):
         result = self.render_preamble()
@@ -198,20 +199,24 @@ class ConsoleRenderer:
             else:
                 indents = {"├": u"|- ", "│": u"|  ", "└": u"`- ", " ": u"   "}
 
-            sorted_children = sorted(node.children, key=lambda n: n.frame)
-            if sorted_children:
-                last_child = sorted_children[-1]
+            # ensures that we never revisit nodes in the case of
+            # large complex graphs
+            if node not in self.visited:
+                self.visited.append(node)
+                sorted_children = sorted(node.children, key=lambda n: n.frame)
+                if sorted_children:
+                    last_child = sorted_children[-1]
 
-            for child in sorted_children:
-                if child is not last_child:
-                    c_indent = child_indent + indents["├"]
-                    cc_indent = child_indent + indents["│"]
-                else:
-                    c_indent = child_indent + indents["└"]
-                    cc_indent = child_indent + indents[" "]
-                result += self.render_frame(
-                    child, dataframe, indent=c_indent, child_indent=cc_indent
-                )
+                for child in sorted_children:
+                    if child is not last_child:
+                        c_indent = child_indent + indents["├"]
+                        cc_indent = child_indent + indents["│"]
+                    else:
+                        c_indent = child_indent + indents["└"]
+                        cc_indent = child_indent + indents[" "]
+                    result += self.render_frame(
+                        child, dataframe, indent=c_indent, child_indent=cc_indent
+                    )
         else:
             result = ""
             indents = {"├": u"", "│": u"", "└": u"", " ": u""}

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -217,7 +217,7 @@ class GraphFrame:
 
         df = pd.DataFrame({"node": list(graph.traverse())})
         df["time"] = [1.0] * len(graph)
-        df["name"] = [n.frame['name'] for n in graph.traverse()]
+        df["name"] = [n.frame["name"] for n in graph.traverse()]
         df.set_index(["node"], inplace=True)
         df.sort_index(inplace=True)
 
@@ -643,6 +643,7 @@ class GraphFrame:
            visualizations.
         """
         graph_literal = []
+        visited = []
 
         def metrics_to_dict(hnode):
             if (
@@ -684,7 +685,8 @@ class GraphFrame:
             node_dict["name"] = node_name
             node_dict["metrics"] = metrics_to_dict(hnode)
 
-            if hnode.children:
+            if hnode.children and hnode not in visited:
+                visited.append(hnode)
                 node_dict["children"] = []
 
                 for child in sorted(hnode.children, key=lambda n: n.frame):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -217,6 +217,7 @@ class GraphFrame:
 
         df = pd.DataFrame({"node": list(graph.traverse())})
         df["time"] = [1.0] * len(graph)
+        df["name"] = [n.frame['name'] for n in graph.traverse()]
         df.set_index(["node"], inplace=True)
         df.sort_index(inplace=True)
 

--- a/hatchet/node.py
+++ b/hatchet/node.py
@@ -219,7 +219,10 @@ In the above examples, the 'a' represents a Node with its
 
         def _from_lists(lists, parent):
             if isinstance(lists, (tuple, list)):
-                node = Node(Frame(name=lists[0]))
+                if isinstance(lists[0], Node):
+                    node = lists[0]
+                elif isinstance(lists[0], str):
+                    node = Node(Frame(name=lists[0]))
                 children = lists[1:]
                 for val in children:
                     _ = _from_lists(val, node)


### PR DESCRIPTION
During the development of the pstats reader, I produced a very complex graph with about 1500 nodes and 3000 edges. I mitigated issues of infinite loops which occurred when outputting this graph by detecting and pruning back edges with a DFS. However, due to the complexity of this graph, at least one loop remained which only occurred when nodes were visited more than once. After consulting with Stephanie, we concluded that, just so long as we continue to draw every edge between nodes, it is not crucial that we fully revisit a node if we have already done so. Accordingly, I added a few lines in `to_dot` and `graphframe.tree` which check if a node has been visited before exploring that nodes children, thereby preventing any opportunity for looping but still allowing for all edges to be drawn.

This visited check doesn't change the output of the tree visualizations. It fixes the `max depth recursion reached` error when printing a graph with cycles.