### PR TITLE
insert nan as the values for missing nodes

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -838,11 +838,11 @@ class GraphFrame:
                 [chr(n) for n in self_missing_node]
             )
 
-        # for nodes that only exist in other, set the metric to be 0 (since
+        # for nodes that only exist in other, set the metric to be nan (since
         # it's a missing node in self)
         # replaces individual metric assignments with np.zeros
         for j in all_metrics:
-            other_not_in_self[j] = np.zeros(onis_len)
+            other_not_in_self[j] = np.full(onis_len, np.nan)
 
         # append missing rows (nodes that exist in other, but not in self) to self's
         # dataframe

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -726,7 +726,7 @@ def test_sub_decorator(small_mock1, small_mock2, small_mock3):
         invert_colormap=False,
     )
     assert "0.000 C" in output
-    assert u"-5.000 D ▶" in output
+    assert u"nan D ▶" in output
     assert u"10.000 H ◀" in output
 
     gf5 = gf1 - gf3


### PR DESCRIPTION
When performing a mathematical operation on two graphframes, and a node is
contained in 1 graphframe but not another, the resulting value will also be
nan.

10 - 5 = 5
10 - nan = nan
nan / 3 = nan

Todo:
- [x] update tests (based on discussion below)
- [x] determine if nan should be its own color (external to the existing colormap)
