### PR TITLE
update console to check for 0 instead of blank in _missing_node column

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -181,7 +181,7 @@ class ConsoleRenderer:
 
             if "_missing_node" in dataframe.columns:
                 left_or_right = dataframe.loc[df_index, "_missing_node"]
-                if left_or_right == "":
+                if left_or_right == 0:
                     lr_decorator = ""
                 elif left_or_right == "L":
                     lr_decorator = u" {c.left}{decorator}{c.end}".format(


### PR DESCRIPTION
Valid values in _missing_node column are "R", "L", and 0, updated for
optimizing unify. Fixes #260.