### PR TITLE
Fix roundtrip table columns to be more flexible

### DIFF
--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -655,7 +655,17 @@
             }
             nodeStr += '</tr>';
             for (var i = 0; i < numNodes; i++) {
-                nodeStr += '<tr><td>' + nodeList[i].data.name + '</td><td>' + nodeList[i].data.metrics.time + 's </td><td>' + nodeList[i].data.metrics["time (inc)"] + 's</td></tr>';
+                for (var j = 0; j < metricColumns.length; j++) {
+                    if (j == 0) {
+                        nodeStr += '<tr><td>' + nodeList[i].data.name + '</td><td>' + nodeList[i].data.metrics[metricColumns[j]] + '</td><td>';
+                    }
+                    else if (j == metricColumns.length - 1) {
+                        nodeStr += nodeList[i].data.metrics[metricColumns[j]] + '</td></tr>';
+                    }
+                    else {
+                        nodeStr += nodeList[i].data.metrics[metricColumns[j]];
+                    }
+                }
             }
             nodeStr = nodeStr + '</table>';
             return nodeStr;


### PR DESCRIPTION
For each node, print its data according to the ordering of the columns in the
dataframe. Remove "s" units from time metrics, so that metadata from other
readers can be printed as well. Fixes #262.