### PR TITLE
Add support for non-DataFrame data to high-level query language

### DIFF
--- a/hatchet/query_matcher.py
+++ b/hatchet/query_matcher.py
@@ -5,7 +5,9 @@
 
 from numbers import Real
 import re
+import pandas as pd
 from pandas import DataFrame
+from pandas.core.indexes.multi import MultiIndex
 
 from .node import Node, traversal_order
 
@@ -40,8 +42,33 @@ class QueryMatcher:
                 first_no_drop_indices = {"val": True}
 
                 def filter_series(df_row):
+                    node = df_row.name
                     matches = True
                     for k, v in attr_filter.items():
+                        if k == "depth":
+                            if isinstance(v, str) and v.lower().startswith(compops):
+                                matches = matches and eval("{} {}".format(node._depth, v))
+                            elif isinstance(v, Real):
+                                matches = matches and (node._depth == v)
+                            else:
+                                raise InvalidQueryFilter(
+                                    "Attribute {} has a numeric type. Valid filters for this attribute are a string starting with a comparison operator or a real number.".format(
+                                        k
+                                    )
+                                )
+                            continue
+                        if k == "node_id":
+                            if isinstance(v, str) and v.lower().startswith(compops):
+                                matches = matches and eval("{} {}".format(node._hatchet_nid, v))
+                            elif isinstance(v, Real):
+                                matches = matches and (node._hatchet_nid == v)
+                            else:
+                                raise InvalidQueryFilter(
+                                    "Attribute {} has a numeric type. Valid filters for this attribute are a string starting with a comparison operator or a real number.".format(
+                                        k
+                                    )
+                                )
+                            continue
                         if k not in df_row.keys():
                             return False
                         if isinstance(df_row[k], str):
@@ -94,7 +121,32 @@ class QueryMatcher:
                         )
                         first_no_drop_indices["val"] = False
                     matches = True
+                    node = df_row.name.to_frame().index[0][0]
                     for k, v in attr_filter.items():
+                        if k == "depth":
+                            if isinstance(v, str) and v.lower().startswith(compops):
+                                matches = matches and eval("{} {}".format(node._depth, v))
+                            elif isinstance(v, Real):
+                                matches = matches and (node._depth == v)
+                            else:
+                                raise InvalidQueryFilter(
+                                    "Attribute {} has a numeric type. Valid filters for this attribute are a string starting with a comparison operator or a real number.".format(
+                                        k
+                                    )
+                                )
+                            continue
+                        if k == "node_id":
+                            if isinstance(v, str) and v.lower().startswith(compops):
+                                matches = matches and eval("{} {}".format(node._hatchet_nid, v))
+                            elif isinstance(v, Real):
+                                matches = matches and (node._hatchet_nid == v)
+                            else:
+                                raise InvalidQueryFilter(
+                                    "Attribute {} has a numeric type. Valid filters for this attribute are a string starting with a comparison operator or a real number.".format(
+                                        k
+                                    )
+                                )
+                            continue
                         if k not in df_row.columns:
                             return False
                         if df_row[k].apply(type).eq(str).all():
@@ -232,7 +284,12 @@ class QueryMatcher:
         # query nodes the current node matches.
         for i, node_query in enumerate(self.query_pattern):
             _, filter_func = node_query
-            if filter_func(gf.dataframe.loc[node]):
+            row = None
+            if isinstance(gf.dataframe.index, MultiIndex):
+                row = pd.concat([gf.dataframe.loc[node]], keys=[node], names=["node"])
+            else:
+                row = gf.dataframe.loc[node]
+            if filter_func(row):
                 matches.append(i)
         self.search_cache[node._hatchet_nid] = matches
 

--- a/hatchet/query_matcher.py
+++ b/hatchet/query_matcher.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+from itertools import groupby
 from numbers import Real
 import re
 import pandas as pd
@@ -42,10 +43,10 @@ class QueryMatcher:
                 first_no_drop_indices = {"val": True}
 
                 def filter_series(df_row):
-                    node = df_row.name
                     matches = True
                     for k, v in attr_filter.items():
                         if k == "depth":
+                            node = df_row.name
                             if isinstance(v, str) and v.lower().startswith(compops):
                                 matches = matches and eval("{} {}".format(node._depth, v))
                             elif isinstance(v, Real):
@@ -58,6 +59,7 @@ class QueryMatcher:
                                 )
                             continue
                         if k == "node_id":
+                            node = df_row.name
                             if isinstance(v, str) and v.lower().startswith(compops):
                                 matches = matches and eval("{} {}".format(node._hatchet_nid, v))
                             elif isinstance(v, Real):
@@ -463,6 +465,7 @@ class QueryMatcher:
                 for s in sub_match:
                     if s is not None:
                         new_matches.append(m + s)
+                new_matches = [l for l, _ in groupby(new_matches)]
             # Overwrite the old matches with the updated matches
             matches = new_matches
             # If all the existing partial matches were not able to be

--- a/hatchet/query_matcher.py
+++ b/hatchet/query_matcher.py
@@ -48,7 +48,9 @@ class QueryMatcher:
                         if k == "depth":
                             node = df_row.name
                             if isinstance(v, str) and v.lower().startswith(compops):
-                                matches = matches and eval("{} {}".format(node._depth, v))
+                                matches = matches and eval(
+                                    "{} {}".format(node._depth, v)
+                                )
                             elif isinstance(v, Real):
                                 matches = matches and (node._depth == v)
                             else:
@@ -61,7 +63,9 @@ class QueryMatcher:
                         if k == "node_id":
                             node = df_row.name
                             if isinstance(v, str) and v.lower().startswith(compops):
-                                matches = matches and eval("{} {}".format(node._hatchet_nid, v))
+                                matches = matches and eval(
+                                    "{} {}".format(node._hatchet_nid, v)
+                                )
                             elif isinstance(v, Real):
                                 matches = matches and (node._hatchet_nid == v)
                             else:
@@ -127,7 +131,9 @@ class QueryMatcher:
                     for k, v in attr_filter.items():
                         if k == "depth":
                             if isinstance(v, str) and v.lower().startswith(compops):
-                                matches = matches and eval("{} {}".format(node._depth, v))
+                                matches = matches and eval(
+                                    "{} {}".format(node._depth, v)
+                                )
                             elif isinstance(v, Real):
                                 matches = matches and (node._depth == v)
                             else:
@@ -139,7 +145,9 @@ class QueryMatcher:
                             continue
                         if k == "node_id":
                             if isinstance(v, str) and v.lower().startswith(compops):
-                                matches = matches and eval("{} {}".format(node._hatchet_nid, v))
+                                matches = matches and eval(
+                                    "{} {}".format(node._hatchet_nid, v)
+                                )
                             elif isinstance(v, Real):
                                 matches = matches and (node._hatchet_nid == v)
                             else:
@@ -465,7 +473,7 @@ class QueryMatcher:
                 for s in sub_match:
                     if s is not None:
                         new_matches.append(m + s)
-                new_matches = [l for l, _ in groupby(new_matches)]
+                new_matches = [uniq_match for uniq_match, _ in groupby(new_matches)]
             # Overwrite the old matches with the updated matches
             matches = new_matches
             # If all the existing partial matches were not able to be

--- a/hatchet/readers/cprofile_reader.py
+++ b/hatchet/readers/cprofile_reader.py
@@ -57,9 +57,7 @@ class CProfileReader:
         dataframe if it does not exist.
         """
         u_fn_name = "{}:{}:{}".format(
-            fn_name,
-            fn_data[NameData.FILE].split("/")[-1],
-            fn_data[NameData.LINE],
+            fn_name, fn_data[NameData.FILE].split("/")[-1], fn_data[NameData.LINE],
         )
         fn_hnode = self.name_to_hnode.get(u_fn_name)
 

--- a/hatchet/readers/cprofile_reader.py
+++ b/hatchet/readers/cprofile_reader.py
@@ -57,8 +57,8 @@ class CProfileReader:
         dataframe if it does not exist.
         """
         u_fn_name = "{}:{}:{}".format(
-            fn_name, 
-            fn_data[NameData.FILE].split("/")[-1], 
+            fn_name,
+            fn_data[NameData.FILE].split("/")[-1],
             fn_data[NameData.LINE],
         )
         fn_hnode = self.name_to_hnode.get(u_fn_name)

--- a/hatchet/readers/cprofile_reader.py
+++ b/hatchet/readers/cprofile_reader.py
@@ -57,7 +57,9 @@ class CProfileReader:
         dataframe if it does not exist.
         """
         u_fn_name = "{}:{}:{}".format(
-            fn_name, fn_data[NameData.FILE].split("/")[-1], fn_data[NameData.LINE],
+            fn_name, 
+            fn_data[NameData.FILE].split("/")[-1], 
+            fn_data[NameData.LINE],
         )
         fn_hnode = self.name_to_hnode.get(u_fn_name)
 

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -530,6 +530,10 @@ def test_high_level_depth(mock_graph_literal):
     ]
     assert sorted(query.apply(gf)) == sorted(matches)
 
+    with pytest.raises(InvalidQueryFilter):
+        query = QueryMatcher([{"depth": "hello"}])
+        query.apply(gf)
+
 
 def test_high_level_hatchet_nid(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
@@ -547,6 +551,10 @@ def test_high_level_hatchet_nid(mock_graph_literal):
 
     query = QueryMatcher([{"node_id": 0}])
     assert query.apply(gf) == [[gf.graph.roots[0]]]
+
+    with pytest.raises(InvalidQueryFilter):
+        query = QueryMatcher([{"node_id": "hello"}])
+        query.apply(gf)
 
 
 def test_high_level_depth_index_levels(calc_pi_hpct_db):
@@ -568,6 +576,10 @@ def test_high_level_depth_index_levels(calc_pi_hpct_db):
     matches = [[root]]
     assert query.apply(gf) == matches
 
+    with pytest.raises(InvalidQueryFilter):
+        query = QueryMatcher([{"depth": "hello"}])
+        query.apply(gf)
+
 
 def test_high_level_node_id_index_levels(calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
@@ -586,3 +598,7 @@ def test_high_level_node_id_index_levels(calc_pi_hpct_db):
     query = QueryMatcher([("*", {"node_id": 0})])
     matches = [[root]]
     assert query.apply(gf) == matches
+
+    with pytest.raises(InvalidQueryFilter):
+        query = QueryMatcher([{"node_id": "hello"}])
+        query.apply(gf)

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -496,141 +496,54 @@ def test_apply_indices(calc_pi_hpct_db):
     gf.drop_index_levels()
     assert query.apply(gf) == matches
 
+
 def test_high_level_depth(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
-    query = QueryMatcher([
-        ("*", {"depth": 1})
-    ])
+    query = QueryMatcher([("*", {"depth": 1})])
     roots = gf.graph.roots
     matches = [[c] for r in roots for c in r.children]
     assert query.apply(gf) == matches
 
-    query = QueryMatcher([
-        ("*", {"depth": "<= 2"})
-    ])
+    query = QueryMatcher([("*", {"depth": "<= 2"})])
     matches = [
-        [
-            roots[0],
-            roots[0].children[0],
-            roots[0].children[0].children[0]
-        ],
-        [
-            roots[0].children[0],
-            roots[0].children[0].children[0]
-        ],
-        [
-            roots[0].children[0].children[0]
-        ],
-        [
-            roots[0],
-            roots[0].children[0],
-            roots[0].children[0].children[1]
-        ],
-        [
-            roots[0].children[0],
-            roots[0].children[0].children[1]
-        ],
-        [
-            roots[0].children[0].children[1]
-        ],
-        [
-            roots[0],
-            roots[0].children[1],
-            roots[0].children[1].children[0]
-        ],
-        [
-            roots[0].children[1],
-            roots[0].children[1].children[0]
-        ],
-        [
-            roots[0].children[1].children[0]
-        ],
-        [
-            roots[0],
-            roots[0].children[2],
-            roots[0].children[2].children[0]
-        ],
-        [
-            roots[0].children[2],
-            roots[0].children[2].children[0]
-        ],
-        [
-            roots[0].children[2].children[0]
-        ],
-        [
-            roots[0],
-            roots[0].children[2],
-            roots[0].children[2].children[1]
-        ],
-        [
-            roots[0].children[2],
-            roots[0].children[2].children[1]
-        ],
-        [
-            roots[0].children[2].children[1]
-        ],
-        [
-            roots[1],
-            roots[1].children[0],
-            roots[1].children[0].children[0]
-        ],
-        [
-            roots[1].children[0],
-            roots[1].children[0].children[0]
-        ],
-        [
-            roots[1].children[0].children[0]
-        ],
-        [
-            roots[1],
-            roots[1].children[0],
-            roots[1].children[0].children[1]
-        ],
-        [
-            roots[1].children[0],
-            roots[1].children[0].children[1]
-        ],
-        [
-            roots[1].children[0].children[1]
-        ]
+        [roots[0], roots[0].children[0], roots[0].children[0].children[0]],
+        [roots[0].children[0], roots[0].children[0].children[0]],
+        [roots[0].children[0].children[0]],
+        [roots[0], roots[0].children[0], roots[0].children[0].children[1]],
+        [roots[0].children[0], roots[0].children[0].children[1]],
+        [roots[0].children[0].children[1]],
+        [roots[0], roots[0].children[1], roots[0].children[1].children[0]],
+        [roots[0].children[1], roots[0].children[1].children[0]],
+        [roots[0].children[1].children[0]],
+        [roots[0], roots[0].children[2], roots[0].children[2].children[0]],
+        [roots[0].children[2], roots[0].children[2].children[0]],
+        [roots[0].children[2].children[0]],
+        [roots[0], roots[0].children[2], roots[0].children[2].children[1]],
+        [roots[0].children[2], roots[0].children[2].children[1]],
+        [roots[0].children[2].children[1]],
+        [roots[1], roots[1].children[0], roots[1].children[0].children[0]],
+        [roots[1].children[0], roots[1].children[0].children[0]],
+        [roots[1].children[0].children[0]],
+        [roots[1], roots[1].children[0], roots[1].children[0].children[1]],
+        [roots[1].children[0], roots[1].children[0].children[1]],
+        [roots[1].children[0].children[1]],
     ]
     assert sorted(query.apply(gf)) == sorted(matches)
+
 
 def test_high_level_hatchet_nid(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
-    query = QueryMatcher([
-        ("*", {"node_id": ">= 20"})
-    ])
+    query = QueryMatcher([("*", {"node_id": ">= 20"})])
     root = gf.graph.roots[1]
     matches = [
-        [
-            root,
-            root.children[0],
-            root.children[0].children[0]
-        ],
-        [
-            root.children[0],
-            root.children[0].children[0]
-        ],
-        [
-            root.children[0].children[0]
-        ],
-        [
-            root,
-            root.children[0],
-            root.children[0].children[1]
-        ],
-        [
-            root.children[0],
-            root.children[0].children[1]
-        ],
-        [
-            root.children[0].children[1]
-        ]
+        [root, root.children[0], root.children[0].children[0]],
+        [root.children[0], root.children[0].children[0]],
+        [root.children[0].children[0]],
+        [root, root.children[0], root.children[0].children[1]],
+        [root.children[0], root.children[0].children[1]],
+        [root.children[0].children[1]],
     ]
     assert sorted(query.apply(gf)) == sorted(matches)
 
-    query = QueryMatcher([
-        {"node_id": 0}
-    ])
+    query = QueryMatcher([{"node_id": 0}])
     assert query.apply(gf) == [[gf.graph.roots[0]]]

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -495,3 +495,142 @@ def test_apply_indices(calc_pi_hpct_db):
 
     gf.drop_index_levels()
     assert query.apply(gf) == matches
+
+def test_high_level_depth(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query = QueryMatcher([
+        ("*", {"depth": 1})
+    ])
+    roots = gf.graph.roots
+    matches = [[c] for r in roots for c in r.children]
+    assert query.apply(gf) == matches
+
+    query = QueryMatcher([
+        ("*", {"depth": "<= 2"})
+    ])
+    matches = [
+        [
+            roots[0],
+            roots[0].children[0],
+            roots[0].children[0].children[0]
+        ],
+        [
+            roots[0].children[0],
+            roots[0].children[0].children[0]
+        ],
+        [
+            roots[0].children[0].children[0]
+        ],
+        [
+            roots[0],
+            roots[0].children[0],
+            roots[0].children[0].children[1]
+        ],
+        [
+            roots[0].children[0],
+            roots[0].children[0].children[1]
+        ],
+        [
+            roots[0].children[0].children[1]
+        ],
+        [
+            roots[0],
+            roots[0].children[1],
+            roots[0].children[1].children[0]
+        ],
+        [
+            roots[0].children[1],
+            roots[0].children[1].children[0]
+        ],
+        [
+            roots[0].children[1].children[0]
+        ],
+        [
+            roots[0],
+            roots[0].children[2],
+            roots[0].children[2].children[0]
+        ],
+        [
+            roots[0].children[2],
+            roots[0].children[2].children[0]
+        ],
+        [
+            roots[0].children[2].children[0]
+        ],
+        [
+            roots[0],
+            roots[0].children[2],
+            roots[0].children[2].children[1]
+        ],
+        [
+            roots[0].children[2],
+            roots[0].children[2].children[1]
+        ],
+        [
+            roots[0].children[2].children[1]
+        ],
+        [
+            roots[1],
+            roots[1].children[0],
+            roots[1].children[0].children[0]
+        ],
+        [
+            roots[1].children[0],
+            roots[1].children[0].children[0]
+        ],
+        [
+            roots[1].children[0].children[0]
+        ],
+        [
+            roots[1],
+            roots[1].children[0],
+            roots[1].children[0].children[1]
+        ],
+        [
+            roots[1].children[0],
+            roots[1].children[0].children[1]
+        ],
+        [
+            roots[1].children[0].children[1]
+        ]
+    ]
+    assert sorted(query.apply(gf)) == sorted(matches)
+
+def test_high_level_hatchet_nid(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query = QueryMatcher([
+        ("*", {"node_id": ">= 20"})
+    ])
+    root = gf.graph.roots[1]
+    matches = [
+        [
+            root,
+            root.children[0],
+            root.children[0].children[0]
+        ],
+        [
+            root.children[0],
+            root.children[0].children[0]
+        ],
+        [
+            root.children[0].children[0]
+        ],
+        [
+            root,
+            root.children[0],
+            root.children[0].children[1]
+        ],
+        [
+            root.children[0],
+            root.children[0].children[1]
+        ],
+        [
+            root.children[0].children[1]
+        ]
+    ]
+    assert sorted(query.apply(gf)) == sorted(matches)
+
+    query = QueryMatcher([
+        {"node_id": 0}
+    ])
+    assert query.apply(gf) == [[gf.graph.roots[0]]]

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -571,8 +571,8 @@ def test_high_level_node_id_index_levels(calc_pi_hpct_db):
 
     query = QueryMatcher([("*", {"node_id": "<= 2"})])
     matches = [
-        [root, root.children[0],],
-        [root.children[0],],
+        [root, root.children[0]],
+        [root.children[0]],
         [root, root.children[0], root.children[0].children[0]],
         [root.children[0], root.children[0].children[0]],
         [root.children[0].children[0]],

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -564,6 +564,10 @@ def test_high_level_depth_index_levels(calc_pi_hpct_db):
     ]
     assert sorted(query.apply(gf)) == sorted(matches)
 
+    query = QueryMatcher([("*", {"depth": 0})])
+    matches = [[root]]
+    assert query.apply(gf) == matches
+
 
 def test_high_level_node_id_index_levels(calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
@@ -578,3 +582,7 @@ def test_high_level_node_id_index_levels(calc_pi_hpct_db):
         [root.children[0].children[0]],
     ]
     assert sorted(query.apply(gf)) == sorted(matches)
+
+    query = QueryMatcher([("*", {"node_id": 0})])
+    matches = [[root]]
+    assert query.apply(gf) == matches

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -547,3 +547,66 @@ def test_high_level_hatchet_nid(mock_graph_literal):
 
     query = QueryMatcher([{"node_id": 0}])
     assert query.apply(gf) == [[gf.graph.roots[0]]]
+
+
+def test_high_level_depth_index_levels(calc_pi_hpct_db):
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+    root = gf.graph.roots[0]
+
+    query = QueryMatcher([("*", {"depth": "<= 2"})])
+    matches = [
+        [
+            root,
+            root.children[0],
+            root.children[0].children[0]
+        ],
+        [
+            root.children[0],
+            root.children[0].children[0]
+        ],
+        [
+            root.children[0].children[0]
+        ],
+        [
+            root,
+            root.children[0],
+            root.children[0].children[1]
+        ],
+        [
+            root.children[0],
+            root.children[0].children[1]
+        ],
+        [
+            root.children[0].children[1]
+        ]
+    ]
+    assert sorted(query.apply(gf)) == sorted(matches)
+
+
+def test_high_level_node_id_index_levels(calc_pi_hpct_db):
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+    root = gf.graph.roots[0]
+
+    query = QueryMatcher([("*", {"node_id": "<= 2"})])
+    matches = [
+        [
+            root,
+            root.children[0],
+        ],
+        [
+            root.children[0],
+        ],
+        [
+            root,
+            root.children[0],
+            root.children[0].children[0]
+        ],
+        [
+            root.children[0],
+            root.children[0].children[0]
+        ],
+        [
+            root.children[0].children[0]
+        ]
+    ]
+    assert sorted(query.apply(gf)) == sorted(matches)

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -555,30 +555,12 @@ def test_high_level_depth_index_levels(calc_pi_hpct_db):
 
     query = QueryMatcher([("*", {"depth": "<= 2"})])
     matches = [
-        [
-            root,
-            root.children[0],
-            root.children[0].children[0]
-        ],
-        [
-            root.children[0],
-            root.children[0].children[0]
-        ],
-        [
-            root.children[0].children[0]
-        ],
-        [
-            root,
-            root.children[0],
-            root.children[0].children[1]
-        ],
-        [
-            root.children[0],
-            root.children[0].children[1]
-        ],
-        [
-            root.children[0].children[1]
-        ]
+        [root, root.children[0], root.children[0].children[0]],
+        [root.children[0], root.children[0].children[0]],
+        [root.children[0].children[0]],
+        [root, root.children[0], root.children[0].children[1]],
+        [root.children[0], root.children[0].children[1]],
+        [root.children[0].children[1]],
     ]
     assert sorted(query.apply(gf)) == sorted(matches)
 
@@ -589,24 +571,10 @@ def test_high_level_node_id_index_levels(calc_pi_hpct_db):
 
     query = QueryMatcher([("*", {"node_id": "<= 2"})])
     matches = [
-        [
-            root,
-            root.children[0],
-        ],
-        [
-            root.children[0],
-        ],
-        [
-            root,
-            root.children[0],
-            root.children[0].children[0]
-        ],
-        [
-            root.children[0],
-            root.children[0].children[0]
-        ],
-        [
-            root.children[0].children[0]
-        ]
+        [root, root.children[0],],
+        [root.children[0],],
+        [root, root.children[0], root.children[0].children[0]],
+        [root.children[0], root.children[0].children[0]],
+        [root.children[0].children[0]],
     ]
     assert sorted(query.apply(gf)) == sorted(matches)


### PR DESCRIPTION
Resolves #212 

After reviewing the available node data not stored within the DataFrame, I added the following new "keywords" to the high-level query language:
1. `depth`
2. `node_id`

These are now reserved keywords for high-level query language filters (i.e., keys in the filter dictionary). The `depth` keyword will query the node's depth (`node_obj._depth` in the source code), and the `node_id` keyword will query the node's Hatchet Node ID (`node_obj._hatchet_nid` in the source code). Both of these attributes are treated like any other numeric attribute. As a result, you can match either an exact value (i.e., `{"depth": 5}`) or a comparison (i.e., `{"depth": ">= 5"}`).