### PR TITLE
literal reader: can define nodes to be duplicated

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -134,116 +134,11 @@ class GraphFrame:
 
     @staticmethod
     def from_literal(graph_dict):
-        """Create a GraphFrame from a list of dictionaries.
+        """Create a GraphFrame from a list of dictionaries."""
+        # import this lazily to avoid circular dependencies
+        from .readers.literal_reader import LiteralReader
 
-        TODO: calculate inclusive metrics automatically.
-
-        Example:
-
-        .. code-block:: console
-
-            dag_ldict = [
-                {
-                    "name": "A",
-                    "type": "function",
-                    "metrics": {"time (inc)": 130.0, "time": 0.0},
-                    "children": [
-                        {
-                            "name": "B",
-                            "type": "function",
-                            "metrics": {"time (inc)": 20.0, "time": 5.0},
-                            "children": [
-                                {
-                                    "name": "C",
-                                    "type": "function",
-                                    "metrics": {"time (inc)": 5.0, "time": 5.0},
-                                    "children": [
-                                        {
-                                            "name": "D",
-                                            "type": "function",
-                                            "metrics": {"time (inc)": 8.0, "time": 1.0},
-                                        }
-                                    ],
-                                }
-                            ],
-                        },
-                        {
-                            "name": "E",
-                            "type": "function",
-                            "metrics": {"time (inc)": 55.0, "time": 10.0},
-                            "children": [
-                                {
-                                    "name": "H",
-                                    "type": "function",
-                                    "metrics": {"time (inc)": 1.0, "time": 9.0}
-                                }
-                            ],
-                        },
-                    ],
-                }
-            ]
-
-        Return:
-            (GraphFrame): graphframe containing data from dictionaries
-        """
-
-        def parse_node_literal(child_dict, hparent):
-            """Create node_dict for one node and then call the function
-            recursively on all children.
-            """
-
-            hnode = Node(
-                Frame({"name": child_dict["name"], "type": child_dict["type"]}), hparent
-            )
-
-            node_dicts.append(
-                dict(
-                    {"node": hnode, "name": child_dict["name"]}, **child_dict["metrics"]
-                )
-            )
-            hparent.add_child(hnode)
-
-            if "children" in child_dict:
-                for child in child_dict["children"]:
-                    parse_node_literal(child, hnode)
-
-        list_roots = []
-        node_dicts = []
-
-        # start with creating a node_dict for each root
-        for i in range(len(graph_dict)):
-            graph_root = Node(
-                Frame({"name": graph_dict[i]["name"], "type": graph_dict[i]["type"]}),
-                None,
-            )
-
-            node_dict = {"node": graph_root, "name": graph_dict[i]["name"]}
-            node_dict.update(**graph_dict[i]["metrics"])
-            node_dicts.append(node_dict)
-
-            list_roots.append(graph_root)
-
-            # call recursively on all children of root
-            if "children" in graph_dict[i]:
-                for child in graph_dict[i]["children"]:
-                    parse_node_literal(child, graph_root)
-
-        graph = Graph(list_roots)
-        graph.enumerate_traverse()
-
-        exc_metrics = []
-        inc_metrics = []
-        for key in graph_dict[i]["metrics"].keys():
-            if "(inc)" in key:
-                inc_metrics.append(key)
-            else:
-                exc_metrics.append(key)
-
-        dataframe = pd.DataFrame(data=node_dicts)
-        dataframe.set_index(["node"], inplace=True)
-        dataframe.sort_index(inplace=True)
-
-        return GraphFrame(graph, dataframe, exc_metrics, inc_metrics)
+        return LiteralReader(graph_dict).read()
 
     @staticmethod
     def from_lists(*lists):
@@ -726,14 +621,19 @@ class GraphFrame:
             node_name = self.dataframe.loc[df_index, name]
 
             node_dict["name"] = node_name
+            for i in hnode.frame.attrs.keys():
+                node_dict[i] = hnode.frame.attrs[i]
             node_dict["metrics"] = metrics_to_dict(hnode)
 
-            if hnode.children and hnode not in visited:
-                visited.append(hnode)
-                node_dict["children"] = []
+            if hnode.children:
+                if hnode not in visited:
+                    visited.append(hnode)
+                    node_dict["children"] = []
 
-                for child in sorted(hnode.children, key=lambda n: n.frame):
-                    node_dict["children"].append(add_nodes(child))
+                    for child in sorted(hnode.children, key=lambda n: n.frame):
+                        node_dict["children"].append(add_nodes(child))
+                else:
+                    node_dict["duplicate"] = True
 
             return node_dict
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -621,19 +621,14 @@ class GraphFrame:
             node_name = self.dataframe.loc[df_index, name]
 
             node_dict["name"] = node_name
-            for i in hnode.frame.attrs.keys():
-                node_dict[i] = hnode.frame.attrs[i]
             node_dict["metrics"] = metrics_to_dict(hnode)
 
-            if hnode.children:
-                if hnode not in visited:
-                    visited.append(hnode)
-                    node_dict["children"] = []
+            if hnode.children and hnode not in visited:
+                visited.append(hnode)
+                node_dict["children"] = []
 
-                    for child in sorted(hnode.children, key=lambda n: n.frame):
-                        node_dict["children"].append(add_nodes(child))
-                else:
-                    node_dict["duplicate"] = True
+                for child in sorted(hnode.children, key=lambda n: n.frame):
+                    node_dict["children"].append(add_nodes(child))
 
             return node_dict
 

--- a/hatchet/readers/literal_reader.py
+++ b/hatchet/readers/literal_reader.py
@@ -1,0 +1,147 @@
+# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import pandas as pd
+
+import hatchet.graphframe
+from hatchet.node import Node
+from hatchet.graph import Graph
+from hatchet.frame import Frame
+
+
+class LiteralReader:
+    """Create a GraphFrame from a list of dictionaries.
+
+    TODO: calculate inclusive metrics automatically.
+
+    Example:
+
+    .. code-block:: console
+
+        dag_ldict = [
+            {
+                "name": "A",
+                "type": "function",
+                "metrics": {"time (inc)": 130.0, "time": 0.0},
+                "children": [
+                    {
+                        "name": "B",
+                        "type": "function",
+                        "metrics": {"time (inc)": 20.0, "time": 5.0},
+                        "children": [
+                            {
+                                "name": "C",
+                                "type": "function",
+                                "metrics": {"time (inc)": 5.0, "time": 5.0},
+                                "children": [
+                                    {
+                                        "name": "D",
+                                        "type": "function",
+                                        "metrics": {"time (inc)": 8.0, "time": 1.0},
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "name": "E",
+                        "type": "function",
+                        "metrics": {"time (inc)": 55.0, "time": 10.0},
+                        "children": [
+                            {
+                                "name": "H",
+                                "type": "function",
+                                "metrics": {"time (inc)": 1.0, "time": 9.0}
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+
+    Return:
+        (GraphFrame): graphframe containing data from dictionaries
+    """
+
+    def __init__(self, graph_dict):
+        """Read from list of dictionaries.
+
+        graph_dict (dict): List of dictionaries encoding nodes.
+        """
+        self.graph_dict = graph_dict
+
+    def parse_node_literal(self, frame_to_node_dict, node_dicts, child_dict, hparent):
+        """Create node_dict for one node and then call the function
+        recursively on all children.
+        """
+        frame = None
+        if "duplicate" not in child_dict:
+            frame = Frame({"name": child_dict["name"]})
+            hnode = Node(frame, hparent)
+
+            node_dict = dict(
+                {"node": hnode, "name": child_dict["name"]}, **child_dict["metrics"]
+            )
+
+            node_dicts.append(node_dict)
+            frame_to_node_dict[frame] = hnode
+        elif "duplicate" in child_dict:
+            frame = Frame({"name": child_dict["name"]})
+            hnode = frame_to_node_dict.get(frame)
+            if not hnode:
+                hnode = Node(frame, hparent)
+                node_dict = dict(
+                    {"node": hnode, "name": child_dict["name"]}, **child_dict["metrics"]
+                )
+                node_dicts.append(node_dict)
+                frame_to_node_dict[frame] = hnode
+
+        hparent.add_child(hnode)
+
+        if "children" in child_dict:
+            for child in child_dict["children"]:
+                self.parse_node_literal(frame_to_node_dict, node_dicts, child, hnode)
+
+    def read(self):
+        list_roots = []
+        node_dicts = []
+        frame_to_node_dict = {}
+        frame = None
+
+        # start with creating a node_dict for each root
+        for i in range(len(self.graph_dict)):
+            frame = Frame({"name": self.graph_dict[i]["name"]})
+            graph_root = Node(frame, None)
+
+            node_dict = {"node": graph_root, "name": self.graph_dict[i]["name"]}
+            node_dict.update(**self.graph_dict[i]["metrics"])
+            node_dicts.append(node_dict)
+
+            list_roots.append(graph_root)
+            frame_to_node_dict[frame] = graph_root
+
+            # call recursively on all children of root
+            if "children" in self.graph_dict[i]:
+                for child in self.graph_dict[i]["children"]:
+                    self.parse_node_literal(
+                        frame_to_node_dict, node_dicts, child, graph_root
+                    )
+
+        graph = Graph(list_roots)
+        graph.enumerate_traverse()
+
+        exc_metrics = []
+        inc_metrics = []
+        for key in self.graph_dict[i]["metrics"].keys():
+            if "(inc)" in key:
+                inc_metrics.append(key)
+            else:
+                exc_metrics.append(key)
+
+        dataframe = pd.DataFrame(data=node_dicts)
+        dataframe.set_index(["node"], inplace=True)
+        dataframe.sort_index(inplace=True)
+
+        return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics)

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -195,4 +195,6 @@ def test_graphframe_to_literal(lulesh_caliper_json):
     gf = GraphFrame.from_caliper_json(str(lulesh_caliper_json))
     graph_literal = gf.to_literal()
 
-    assert len(graph_literal) == len(gf.graph.roots)
+    gf2 = GraphFrame.from_literal(graph_literal)
+
+    assert len(gf.graph) == len(gf2.graph)

--- a/hatchet/tests/conftest.py
+++ b/hatchet/tests/conftest.py
@@ -717,3 +717,124 @@ def mock_dag_literal_module_more_complex():
     ]
 
     return dag_ldict
+
+
+@pytest.fixture
+def mock_graph_literal_duplicates():
+    """Creates a mock tree with duplicate nodes."""
+    graph_dict = [
+        {
+            "name": "a",
+            "type": "function",
+            "metrics": {"time (inc)": 130.0, "time": 0.0},
+            "children": [
+                {
+                    "name": "b",
+                    "type": "function",
+                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                    "children": [
+                        {
+                            "name": "d",
+                            "type": "function",
+                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                            "children": [
+                                {
+                                    "name": "e",
+                                    "type": "function",
+                                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                                },
+                                {
+                                    "name": "f",
+                                    "type": "function",
+                                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                                },
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "name": "c",
+                    "type": "function",
+                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                    "children": [
+                        {
+                            "name": "a",
+                            "duplicate": "True",
+                            "type": "function",
+                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                        },
+                        {
+                            "name": "d",
+                            "duplicate": "True",
+                            "type": "function",
+                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                        },
+                    ],
+                },
+            ],
+        }
+    ]
+
+    return graph_dict
+
+
+@pytest.fixture
+def mock_graph_literal_duplicate_first():
+    """Creates a mock tree with node with duplicate first."""
+    graph_dict = [
+        {
+            "name": "a",
+            "duplicate": True,
+            "type": "function",
+            "metrics": {"time (inc)": 130.0, "time": 0.0},
+            "children": [
+                {
+                    "name": "b",
+                    "duplicate": True,
+                    "type": "function",
+                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                    "children": [
+                        {
+                            "name": "d",
+                            "duplicate": True,
+                            "type": "function",
+                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                            "children": [
+                                {
+                                    "name": "e",
+                                    "type": "function",
+                                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                                },
+                                {
+                                    "name": "f",
+                                    "type": "function",
+                                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                                },
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "name": "c",
+                    "type": "function",
+                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                    "children": [
+                        {
+                            "name": "a",
+                            "duplicate": "True",
+                            "type": "function",
+                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                        },
+                        {
+                            "name": "d",
+                            "duplicate": "True",
+                            "type": "function",
+                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                        },
+                    ],
+                },
+            ],
+        }
+    ]
+
+    return graph_dict

--- a/hatchet/tests/graph_literal.py
+++ b/hatchet/tests/graph_literal.py
@@ -17,4 +17,25 @@ def test_graphframe_to_literal(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     graph_literal = gf.to_literal()
 
-    assert len(graph_literal) == len(mock_graph_literal) == len(gf.graph.roots)
+    test_literal_output = gf.from_literal(graph_literal)
+
+    assert len(test_literal_output.graph.roots) == len(gf.graph.roots)
+    assert len(test_literal_output.graph) == len(gf.graph)
+
+
+def test_with_duplicates(mock_graph_literal_duplicates):
+    gf = GraphFrame.from_literal(mock_graph_literal_duplicates)
+
+    assert len(gf.graph) == 6
+
+    graph_literal = gf.to_literal()
+    assert mock_graph_literal_duplicates.sort() == graph_literal.sort()
+
+
+def test_with_duplicate_in_first_node(mock_graph_literal_duplicate_first):
+    gf = GraphFrame.from_literal(mock_graph_literal_duplicate_first)
+
+    assert len(gf.graph) == 6
+
+    graph_literal = gf.to_literal()
+    assert mock_graph_literal_duplicate_first.sort() == graph_literal.sort()

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -976,11 +976,11 @@ def test_output_with_cycle_graphs():
     assert "d" in a_c_children
     assert "d" in a_b_children
 
-    # check certian edges are in dot
+    # check certain edges are in dot
     for edge in dot_edges:
         assert edge in dotout
 
-    # check that a certian number of occurences
+    # check that a certain number of occurences
     # of same node are in tree indicating multiple
     # edges
     assert treeout.count("a") == 2

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -198,11 +198,15 @@ def test_graphframe_to_literal(data_dir, calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
     graph_literal = gf.to_literal()
 
-    assert len(graph_literal) == len(gf.graph.roots)
+    gf2 = GraphFrame.from_literal(graph_literal)
+
+    assert len(gf.graph) == len(gf2.graph)
 
 
 def test_graphframe_to_literal_with_threads(data_dir, osu_allgather_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(osu_allgather_hpct_db))
     graph_literal = gf.to_literal()
 
-    assert len(graph_literal) == len(gf.graph.roots)
+    gf2 = GraphFrame.from_literal(graph_literal)
+
+    assert len(gf.graph) == len(gf2.graph)

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -117,4 +117,6 @@ def test_graphframe_to_literal(hatchet_pyinstrument_json):
     gf = GraphFrame.from_pyinstrument(str(hatchet_pyinstrument_json))
     graph_literal = gf.to_literal()
 
-    assert len(graph_literal) == len(gf.graph.roots)
+    gf2 = GraphFrame.from_literal(graph_literal)
+
+    assert len(gf.graph) == len(gf2.graph)


### PR DESCRIPTION
- move literal reader to reader directory
- literal nodes can have a "duplicate: True field indicating that Hatchet
  should not create a new node object (it has already been created and should
  be re-used)

Fixes #239 