### PR TITLE
literal and lists reader: make type an optional frame attribute

### DIFF
--- a/hatchet/frame.py
+++ b/hatchet/frame.py
@@ -42,6 +42,10 @@ class Frame:
         if not self.attrs:
             raise ValueError("Frame must be constructed with attributes!")
 
+        # add type to frame if type is not in the attributes dict or kwargs
+        if "type" not in self.attrs:
+            self.attrs["type"] = None
+
         self._tuple_repr = None
 
     def __eq__(self, other):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -192,9 +192,15 @@ class GraphFrame:
             recursively on all children.
             """
 
-            hnode = Node(
-                Frame({"name": child_dict["name"], "type": child_dict["type"]}), hparent
-            )
+            if "type" in child_dict:
+                hnode = Node(
+                    Frame({"name": child_dict["name"], "type": child_dict["type"]}),
+                    hparent,
+                )
+            else:
+                hnode = Node(
+                    Frame({"name": child_dict["name"], "type": "None"}), hparent
+                )
 
             node_dicts.append(
                 dict(
@@ -212,10 +218,17 @@ class GraphFrame:
 
         # start with creating a node_dict for each root
         for i in range(len(graph_dict)):
-            graph_root = Node(
-                Frame({"name": graph_dict[i]["name"], "type": graph_dict[i]["type"]}),
-                None,
-            )
+            if "type" in graph_dict[i]:
+                graph_root = Node(
+                    Frame(
+                        {"name": graph_dict[i]["name"], "type": graph_dict[i]["type"]}
+                    ),
+                    None,
+                )
+            else:
+                graph_root = Node(
+                    Frame({"name": graph_dict[i]["name"], "type": "None"}), None
+                )
 
             node_dict = {"node": graph_root, "name": graph_dict[i]["name"]}
             node_dict.update(**graph_dict[i]["metrics"])

--- a/hatchet/node.py
+++ b/hatchet/node.py
@@ -222,14 +222,16 @@ In the above examples, the 'a' represents a Node with its
                 if isinstance(lists[0], Node):
                     node = lists[0]
                 elif isinstance(lists[0], str):
-                    node = Node(Frame(name=lists[0]))
+                    node = Node(Frame(name=lists[0], type="None"))
                 children = lists[1:]
                 for val in children:
                     _ = _from_lists(val, node)
             elif isinstance(lists, str):
-                node = Node(Frame(name=lists))
+                node = Node(Frame(name=lists, type="None"))
             elif isinstance(lists, Node):
                 node = lists
+                if "type" not in node.frame.attrs.keys():
+                    node.frame.attrs["type"] = "None"
             else:
                 raise ValueError("Argument must be str, list, or Node: %s" % lists)
 

--- a/hatchet/tests/conftest.py
+++ b/hatchet/tests/conftest.py
@@ -179,7 +179,6 @@ def mock_graph_literal():
             "children": [
                 {
                     "name": "bar",
-                    "type": "function",
                     "metrics": {"time (inc)": 20.0, "time": 5.0},
                     "children": [
                         {
@@ -189,7 +188,6 @@ def mock_graph_literal():
                         },
                         {
                             "name": "grault",
-                            "type": "function",
                             "metrics": {"time (inc)": 10.0, "time": 10.0},
                         },
                     ],
@@ -201,7 +199,6 @@ def mock_graph_literal():
                     "children": [
                         {
                             "name": "quux",
-                            "type": "function",
                             "metrics": {"time (inc)": 60.0, "time": 5.0},
                             "children": [
                                 {
@@ -211,7 +208,6 @@ def mock_graph_literal():
                                     "children": [
                                         {
                                             "name": "bar",
-                                            "type": "function",
                                             "metrics": {
                                                 "time (inc)": 20.0,
                                                 "time": 5.0,
@@ -227,7 +223,6 @@ def mock_graph_literal():
                                                 },
                                                 {
                                                     "name": "grault",
-                                                    "type": "function",
                                                     "metrics": {
                                                         "time (inc)": 10.0,
                                                         "time": 10.0,
@@ -237,7 +232,6 @@ def mock_graph_literal():
                                         },
                                         {
                                             "name": "grault",
-                                            "type": "function",
                                             "metrics": {
                                                 "time (inc)": 10.0,
                                                 "time": 10.0,
@@ -323,7 +317,6 @@ def mock_graph_literal():
             "children": [
                 {
                     "name": "bar",
-                    "type": "function",
                     "metrics": {"time (inc)": 20.0, "time": 5.0},
                     "children": [
                         {
@@ -333,7 +326,6 @@ def mock_graph_literal():
                         },
                         {
                             "name": "grault",
-                            "type": "function",
                             "metrics": {"time (inc)": 10.0, "time": 10.0},
                         },
                     ],

--- a/hatchet/tests/frame.py
+++ b/hatchet/tests/frame.py
@@ -86,8 +86,14 @@ def test_values():
 
 
 def test_repr():
-    assert repr(Frame(foo="baz", bar="quux")) == "Frame({'bar': 'quux', 'foo': 'baz'})"
+    assert (
+        repr(Frame(foo="baz", bar="quux"))
+        == "Frame({'bar': 'quux', 'foo': 'baz', 'type': 'None'})"
+    )
 
 
 def test_str():
-    assert str(Frame(foo="baz", bar="quux")) == "{'bar': 'quux', 'foo': 'baz'}"
+    assert (
+        str(Frame(foo="baz", bar="quux"))
+        == "{'bar': 'quux', 'foo': 'baz', 'type': 'None'}"
+    )

--- a/hatchet/tests/node.py
+++ b/hatchet/tests/node.py
@@ -12,11 +12,11 @@ from hatchet.graph import Graph
 
 def test_from_lists():
     node = Node.from_lists("a")
-    assert node.frame == Frame(name="a")
+    assert node.frame == Frame(name="a", type="None")
 
-    a = Frame(name="a")
-    b = Frame(name="b")
-    c = Frame(name="c")
+    a = Frame(name="a", type="None")
+    b = Frame(name="b", type="None")
+    c = Frame(name="c", type="None")
 
     node = Node.from_lists(["a", ["b", "c"]])
 
@@ -63,12 +63,19 @@ def test_node_repr():
 
 
 def test_path():
-    d = Node(Frame(name="d"))
+    d = Node(Frame(name="d", type="function"))
     node = Node.from_lists(["a", ["b", d]])
 
-    assert d.path() == (Frame(name="a"), Frame(name="b"), Frame(name="d"))
-    assert d.parents[0].path() == (Frame(name="a"), Frame(name="b"))
-    assert node.path() == (Frame(name="a"),)
+    assert d.path() == (
+        Frame(name="a", type="None"),
+        Frame(name="b", type="None"),
+        Frame(name="d", type="function"),
+    )
+    assert d.parents[0].path() == (
+        Frame(name="a", type="None"),
+        Frame(name="b", type="None"),
+    )
+    assert node.path() == (Frame(name="a", type="None"),)
 
     assert d.path(attrs="name") == ("a", "b", "d")
     assert d.parents[0].path(attrs="name") == ("a", "b")
@@ -82,8 +89,16 @@ def test_paths():
         d.path()
 
     assert d.paths() == [
-        (Frame(name="a"), Frame(name="b"), Frame(name="d")),
-        (Frame(name="a"), Frame(name="c"), Frame(name="d")),
+        (
+            Frame(name="a", type="None"),
+            Frame(name="b", type="None"),
+            Frame(name="d", type="None"),
+        ),
+        (
+            Frame(name="a", type="None"),
+            Frame(name="c", type="None"),
+            Frame(name="d", type="None"),
+        ),
     ]
 
     assert d.paths(attrs="name") == [("a", "b", "d"), ("a", "c", "d")]

--- a/hatchet/tests/node.py
+++ b/hatchet/tests/node.py
@@ -59,7 +59,7 @@ def test_traverse_dag():
 
 def test_node_repr():
     d = Node(Frame(a=1, b=2, c=3))
-    assert repr(d) == "Node({'a': 1, 'b': 2, 'c': 3})"
+    assert repr(d) == "Node({'a': 1, 'b': 2, 'c': 3, 'type': None})"
 
 
 def test_path():


### PR DESCRIPTION
~If type is not defined on the node, then its type will be null.~
Updated: Using `"type": "None"` to avoid comparing `str` and `NoneType` objects in the frame attributes. This relaxes #266, which required `type` to be a node attribute.