### PR TITLE
Fixing Bugs with Squash.

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -516,7 +516,6 @@ class GraphFrame:
             return
 
         out_columns = self._init_sum_columns(columns, out_columns)
-
         for node in self.graph.traverse():
             subgraph_nodes = list(node.traverse())
             # TODO: need a better way of aggregating inclusive metrics when
@@ -533,7 +532,7 @@ class GraphFrame:
                     if not isinstance(i, tuple):
                         i = tuple([i])
                     for col in out_columns:
-                        # The bizarre layered derefrening here is required to make the final row-index tuple a non-nested tuple
+                        # The bizarre nested dereferencing here is required to make the final row-index tuple a non-nested tuple
                         # structured like: (node, rank, thread)
                         # Originally it was (node, (rank, thread)) and this was causing problems when attempting to access the cells
                         # we were trying to sum over (RHS) and the cell we were trying to put the results into (LHS)

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -517,11 +517,7 @@ class GraphFrame:
 
         out_columns = self._init_sum_columns(columns, out_columns)
 
-        # for i, node in enumerate(self.graph.traverse()):
-        #     print(i, node)
-
         for node in self.graph.traverse():
-            # print("Node:", node)
             subgraph_nodes = list(node.traverse())
             # TODO: need a better way of aggregating inclusive metrics when
             # TODO: there is a multi-index

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -536,27 +536,16 @@ class GraphFrame:
                 for i in self.dataframe.loc[(node), out_columns].index.unique():
                     if not isinstance(i, tuple):
                         i = tuple([i])
-
-                    # TODO: if you take the list constructor away from the
-                    # TODO: assignment below, this assignment gives NaNs. Why?
-                    # print("\n","#"*100+"\nSUBGRAPH NODES", type(subframe), "\n\nSUM\n", type(sum), "\n\nDATAFRAME AT NODE {} with i {}\n".format(node, i), type(self.dataframe.loc[(node, i), out_columns]) ,'\n'+"#"*100)
-
                     for col in out_columns:
-                        print(col, type(col))
-                        # print(subgraph_nodes, type(subgraph_nodes))
-                        # # print(tuple([node])+ i)
-                        # X = self.dataframe.loc[tuple([subgraph_nodes])+i, col]
-                        # Y = self.dataframe.loc[tuple([node])+i, col]
-                        #
-                        # # print("\n\n", i, type(i), "Index NID: {} \n Name: {}".format(node._hatchet_nid, node))
-                        #
-                        # print("\nRHS\n", X, "\n\n")
-                        # print("Type: {}".format(type( X )), "\n")
-                        #
-                        # print("\nLHS\n", Y, "\n\n")
-                        # print("Type: {}".format(type(Y)), "\n")
-
-                        self.dataframe.loc[tuple([node]) + i, col] = [function(self.dataframe.loc[tuple([subgraph_nodes])+i, col])]
+                        # The bizarre layered derefrening here is required to make the final row-index tuple a non-nested tuple
+                        # structured like: (node, rank, thread)
+                        # Originally it was (node, (rank, thread)) and this was causing problems when attempting to access the cells
+                        # we were trying to sum over (RHS) and the cell we were trying to put the results into (LHS)
+                        self.dataframe.loc[tuple([node]) + i, col] = [
+                            function(
+                                self.dataframe.loc[tuple([subgraph_nodes]) + i, col]
+                            )
+                        ]
 
             else:
                 # TODO: if you take the list constructor away from the

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -516,7 +516,12 @@ class GraphFrame:
             return
 
         out_columns = self._init_sum_columns(columns, out_columns)
+
+        # for i, node in enumerate(self.graph.traverse()):
+        #     print(i, node)
+
         for node in self.graph.traverse():
+            # print("Node:", node)
             subgraph_nodes = list(node.traverse())
             # TODO: need a better way of aggregating inclusive metrics when
             # TODO: there is a multi-index
@@ -529,11 +534,30 @@ class GraphFrame:
 
             if is_index_or_multiindex:
                 for i in self.dataframe.loc[(node), out_columns].index.unique():
+                    if not isinstance(i, tuple):
+                        i = tuple([i])
+
                     # TODO: if you take the list constructor away from the
                     # TODO: assignment below, this assignment gives NaNs. Why?
-                    self.dataframe.loc[(node, i), out_columns] = list(
-                        function(self.dataframe.loc[(subgraph_nodes, i), columns])
-                    )
+                    # print("\n","#"*100+"\nSUBGRAPH NODES", type(subframe), "\n\nSUM\n", type(sum), "\n\nDATAFRAME AT NODE {} with i {}\n".format(node, i), type(self.dataframe.loc[(node, i), out_columns]) ,'\n'+"#"*100)
+
+                    for col in out_columns:
+                        print(col, type(col))
+                        # print(subgraph_nodes, type(subgraph_nodes))
+                        # # print(tuple([node])+ i)
+                        # X = self.dataframe.loc[tuple([subgraph_nodes])+i, col]
+                        # Y = self.dataframe.loc[tuple([node])+i, col]
+                        #
+                        # # print("\n\n", i, type(i), "Index NID: {} \n Name: {}".format(node._hatchet_nid, node))
+                        #
+                        # print("\nRHS\n", X, "\n\n")
+                        # print("Type: {}".format(type( X )), "\n")
+                        #
+                        # print("\nLHS\n", Y, "\n\n")
+                        # print("Type: {}".format(type(Y)), "\n")
+
+                        self.dataframe.loc[tuple([node]) + i, col] = [function(self.dataframe.loc[tuple([subgraph_nodes])+i, col])]
+
             else:
                 # TODO: if you take the list constructor away from the
                 # TODO: assignment below, this assignment gives NaNs. Why?

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -529,17 +529,19 @@ class GraphFrame:
 
             if is_index_or_multiindex:
                 for i in self.dataframe.loc[(node), out_columns].index.unique():
-                    if not isinstance(i, tuple):
-                        i = tuple([i])
+                    if isinstance(i, tuple):
+                        df_index1 = (node,) + i
+                        df_index2 = (subgraph_nodes,) + i
+                    else:
+                        df_index1 = (node, i)
+                        df_index2 = (subgraph_nodes, i)
+
                     for col in out_columns:
-                        # The bizarre nested dereferencing here is required to make the final row-index tuple a non-nested tuple
-                        # structured like: (node, rank, thread)
+                        # We have changed the dereferencing here to an index variable which accounts for situations where i is a tuple
                         # Originally it was (node, (rank, thread)) and this was causing problems when attempting to access the cells
                         # we were trying to sum over (RHS) and the cell we were trying to put the results into (LHS)
-                        self.dataframe.loc[tuple([node]) + i, col] = [
-                            function(
-                                self.dataframe.loc[tuple([subgraph_nodes]) + i, col]
-                            )
+                        self.dataframe.loc[df_index1, col] = [
+                            function(self.dataframe.loc[df_index2, col])
                         ]
 
             else:

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -543,7 +543,6 @@ class GraphFrame:
                         self.dataframe.loc[df_index1, col] = [
                             function(self.dataframe.loc[df_index2, col])
                         ]
-
             else:
                 # TODO: if you take the list constructor away from the
                 # TODO: assignment below, this assignment gives NaNs. Why?


### PR DESCRIPTION
1) Fixed crashing problem with squash.
2) Now verifying output

Will resolve #255 


Fix details:
In `subgraph_sum` there was a selection 
```
self.dataframe.loc[(node, i), out_columns] = list(
                        function(self.dataframe.loc[(subgraph_nodes, i), columns])
                    )
```
The function was failing here due to an occurrence where the variable `i` was a tuple representing a rank and thread pair. This nested tuple caused a the RHS and LHS of this expression to produce an incorrect query. Sometimes the LHS selection produced more than one row, other times the LHS and RHS would just crash and throw an error about how the nested `i` key could not be found in the dataframe. After significant experimentation we found that we could produce a tuples which was no longer nested by coercing the node value into a tuple and appending the rank and thread values. This made the selections consistent with occurrences where `i` was just rank alone.