### PR TITLE
add graphframe offset and scale APIs

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -5,7 +5,6 @@
 
 import sys
 import traceback
-import warnings
 
 from collections import defaultdict
 
@@ -1063,67 +1062,65 @@ class GraphFrame:
         new_gf.drop_index_levels()
         return new_gf
 
-    def offset(self, metric_column, offset, result_column, overwrite=False):
-        """Offset metric_column by a value.
+    def offset(self, metric_column, by, result_column=None, inplace=False):
+        """Offset column by a value.
 
         Arguments:
             self (graphframe): self's graphframe
             metric_column (str): dataframe column to offset
-            offset (int or float, +/-): offset value
-            result_column (str): name of column for result (if different than metric_column)
-            overwrite (boolean, optional): if True, overwrite metric_column
-
-        Return:
-            self's graphframe
-        """
-        warnings.filterwarnings("error")
-
-        # validate metric_column
-        if metric_column not in self.dataframe.columns:
-            raise ValueError("Invalid column specified.")
-
-        # warn if trying to overwrite metric_column
-        if metric_column == result_column and not overwrite:
-            warnings.warn(
-                'metric_column= and result_column= have the same value. The result of the offset will replace the column values in "{}". If you want to do this, please add "overwrite=True" to the parameter list and re-run this function. Otherwise, change the value of "result_column=" and re-run.'.format(
-                    metric_column
-                ),
-                SyntaxWarning,
-            )
-
-        self.dataframe[result_column] = self.dataframe[metric_column].apply(
-            lambda x: x + offset
-        )
-
-    def scale(self, metric_column, scalar, result_column, overwrite=False):
-        """Scale metric_column by a value.
-
-        Arguments:
-            self (graphframe): self's graphframe
-            metric_column (str): dataframe column to offset
-            scalar (int or float, +/-): scalar value
-            result_column (str): name of column for result
-            overwrite (boolean, optional): if True, overwrite metric_column
+            by (int or float, +/-): offset value
+            result_column (str, optional): name of column for result (if different than metric_column)
+            inplace (boolean): if True, modifies the DataFrame in place
 
         Return:
             self's graphframe
         """
         # validate metric_column
-        if metric_column not in self.dataframe.columns:
-            raise ValueError("Invalid column specified.")
+        if metric_column not in self.inc_metrics + self.exc_metrics:
+            raise ValueError("offset() requires a numeric column.")
 
-        # warn if trying to overwrite metric_column
-        if metric_column == result_column and not overwrite:
-            warnings.warn(
-                'metric_column= and result_column= have the same value. The result of scaling will replace the column values in "{}". If you want to do this, please add "overwrite=True" to the parameter list and re-run this function. Otherwise, change the value of "result_column=" and re-run.'.format(
-                    metric_column
-                ),
-                SyntaxWarning,
+        if not inplace and not result_column:
+            raise ValueError("Missing column name for offset results.")
+
+        if inplace:
+            self.dataframe[metric_column] = self.dataframe[metric_column].apply(
+                lambda x: x + by
+            )
+        else:
+            self.dataframe[result_column] = self.dataframe[metric_column].apply(
+                lambda x: x + by
             )
 
-        self.dataframe[result_column] = self.dataframe[metric_column].apply(
-            lambda x: x * scalar
-        )
+        return self
+
+    def scale(self, metric_column, by, result_column=None, inplace=False):
+        """Scale column by a value.
+
+        Arguments:
+            self (graphframe): self's graphframe
+            metric_column (str): dataframe column to scale
+            by (int or float, +/-): scalar value
+            result_column (str, optional): name of column for result
+            inplace (boolean): if True, modifies the DataFrame in place
+
+        Return:
+            self's graphframe
+        """
+        # validate metric_column
+        if metric_column not in self.inc_metrics + self.exc_metrics:
+            raise ValueError("scale() requires a numeric column.")
+
+        if not inplace and not result_column:
+            raise ValueError("Missing column name for scaled results.")
+
+        if inplace:
+            self.dataframe[metric_column] = self.dataframe[metric_column].apply(
+                lambda x: x * by
+            )
+        else:
+            self.dataframe[result_column] = self.dataframe[metric_column].apply(
+                lambda x: x * by
+            )
 
         return self
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -1062,6 +1062,50 @@ class GraphFrame:
         new_gf.drop_index_levels()
         return new_gf
 
+    def offset(self, metric_column, offset, result_col_name):
+        """Offset metric_column by a value.
+
+        Arguments:
+            self (graphframe): self's graphframe
+            metric_column (str): dataframe column to offset
+            offset (int or float, +/-): offset value
+            result_col_name (str): name of column for result
+
+        Return:
+            self's graphframe
+        """
+        # validate metric_column
+        if metric_column not in self.dataframe.columns:
+            raise ValueError("Invalid column specified.")
+
+        self.dataframe[result_col_name] = self.dataframe[metric_column].apply(
+            lambda x: x + offset
+        )
+
+        return self
+
+    def scale(self, metric_column, scalar, result_col_name):
+        """Scale metric_column by a value.
+
+        Arguments:
+            self (graphframe): self's graphframe
+            metric_column (str): dataframe column to offset
+            scalar (int or float, +/-): scalar value
+            result_col_name (str): name of column for result
+
+        Return:
+            self's graphframe
+        """
+        # validate metric_column
+        if metric_column not in self.dataframe.columns:
+            raise ValueError("Invalid column specified.")
+
+        self.dataframe[result_col_name] = self.dataframe[metric_column].apply(
+            lambda x: x * scalar
+        )
+
+        return self
+
     def add(self, other):
         """Returns the column-wise sum of two graphframes as a new graphframe.
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -5,6 +5,7 @@
 
 import sys
 import traceback
+import warnings
 
 from collections import defaultdict
 
@@ -1062,36 +1063,47 @@ class GraphFrame:
         new_gf.drop_index_levels()
         return new_gf
 
-    def offset(self, metric_column, offset, result_col_name):
+    def offset(self, metric_column, offset, result_column, overwrite=False):
         """Offset metric_column by a value.
 
         Arguments:
             self (graphframe): self's graphframe
             metric_column (str): dataframe column to offset
             offset (int or float, +/-): offset value
-            result_col_name (str): name of column for result
+            result_column (str): name of column for result (if different than metric_column)
+            overwrite (boolean, optional): if True, overwrite metric_column
 
         Return:
             self's graphframe
         """
+        warnings.filterwarnings("error")
+
         # validate metric_column
         if metric_column not in self.dataframe.columns:
             raise ValueError("Invalid column specified.")
 
-        self.dataframe[result_col_name] = self.dataframe[metric_column].apply(
+        # warn if trying to overwrite metric_column
+        if metric_column == result_column and not overwrite:
+            warnings.warn(
+                'metric_column= and result_column= have the same value. The result of the offset will replace the column values in "{}". If you want to do this, please add "overwrite=True" to the parameter list and re-run this function. Otherwise, change the value of "result_column=" and re-run.'.format(
+                    metric_column
+                ),
+                SyntaxWarning,
+            )
+
+        self.dataframe[result_column] = self.dataframe[metric_column].apply(
             lambda x: x + offset
         )
 
-        return self
-
-    def scale(self, metric_column, scalar, result_col_name):
+    def scale(self, metric_column, scalar, result_column, overwrite=False):
         """Scale metric_column by a value.
 
         Arguments:
             self (graphframe): self's graphframe
             metric_column (str): dataframe column to offset
             scalar (int or float, +/-): scalar value
-            result_col_name (str): name of column for result
+            result_column (str): name of column for result
+            overwrite (boolean, optional): if True, overwrite metric_column
 
         Return:
             self's graphframe
@@ -1100,7 +1112,16 @@ class GraphFrame:
         if metric_column not in self.dataframe.columns:
             raise ValueError("Invalid column specified.")
 
-        self.dataframe[result_col_name] = self.dataframe[metric_column].apply(
+        # warn if trying to overwrite metric_column
+        if metric_column == result_column and not overwrite:
+            warnings.warn(
+                'metric_column= and result_column= have the same value. The result of scaling will replace the column values in "{}". If you want to do this, please add "overwrite=True" to the parameter list and re-run this function. Otherwise, change the value of "result_column=" and re-run.'.format(
+                    metric_column
+                ),
+                SyntaxWarning,
+            )
+
+        self.dataframe[result_column] = self.dataframe[metric_column].apply(
             lambda x: x * scalar
         )
 

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1171,3 +1171,38 @@ def test_hdf_load_store(mock_graph_literal):
 
     if os.path.exists("test_gframe.hdf"):
         os.remove("test_gframe.hdf")
+
+
+def test_graphframe_offset(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+
+    gf.offset("time", 4, "offset_time_4")
+
+    assert gf.dataframe["time"].sum() == 165
+    assert gf.dataframe["offset_time_4"].sum() == 261
+    assert gf.dataframe["time (inc)"].sum() == 640
+
+    gf.offset("time", -11, "offset_time_11")
+    assert gf.dataframe["offset_time_11"].sum() == -99
+
+    with pytest.raises(ValueError):
+        gf.offset("badcol", 2, "offset_badcol")
+
+
+def test_graphframe_scale(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+
+    gf.scale("time", 3, "scale_time_3")
+
+    assert gf.dataframe["time"].sum() == 165
+    assert gf.dataframe["scale_time_3"].sum() == 495
+    assert gf.dataframe["time (inc)"].sum() == 640
+
+    gf.scale("time", -1, "scale_time_1")
+    assert gf.dataframe["scale_time_1"].sum() == -165
+
+    gf.scale("time", 0.8, "scale_time_8")
+    assert gf.dataframe["scale_time_8"].sum() == 132
+
+    with pytest.raises(ValueError):
+        gf.scale("badcol", 8, "scale_badcol")

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1176,33 +1176,33 @@ def test_hdf_load_store(mock_graph_literal):
 def test_graphframe_offset(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
 
-    gf.offset("time", 4, "offset_time_4")
+    gf.offset(metric_column="time", by=4, result_column="offset_time_4")
 
     assert gf.dataframe["time"].sum() == 165
     assert gf.dataframe["offset_time_4"].sum() == 261
     assert gf.dataframe["time (inc)"].sum() == 640
 
-    gf.offset("time", -11, "offset_time_11")
-    assert gf.dataframe["offset_time_11"].sum() == -99
+    gf.offset(metric_column="time", by=-11, inplace=True)
+    assert gf.dataframe["time"].sum() == -99
 
     with pytest.raises(ValueError):
-        gf.offset("badcol", 2, "offset_badcol")
+        gf.offset(metric_column="badcol", by=2, inplace=True)
 
 
 def test_graphframe_scale(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
 
-    gf.scale("time", 3, "scale_time_3")
+    gf.scale(metric_column="time", by=3, result_column="scale_time_3")
 
     assert gf.dataframe["time"].sum() == 165
     assert gf.dataframe["scale_time_3"].sum() == 495
     assert gf.dataframe["time (inc)"].sum() == 640
 
-    gf.scale("time", -1, "scale_time_1")
+    gf.scale(metric_column="time", by=-1, result_column="scale_time_1")
     assert gf.dataframe["scale_time_1"].sum() == -165
 
-    gf.scale("time", 0.8, "scale_time_8")
-    assert gf.dataframe["scale_time_8"].sum() == 132
+    gf.scale(metric_column="time", by=0.8, inplace=True)
+    assert gf.dataframe["time"].sum() == 132
 
     with pytest.raises(ValueError):
-        gf.scale("badcol", 8, "scale_badcol")
+        gf.scale(metric_column="badcol", by=8, inplace=True)


### PR DESCRIPTION
Introduces gf.offset(offsets) and gf.scale(offsets), where offsets is a dict of
dataframe column names and values. This returns a new graphframe instead of
modifying in place.

Resolves #257 