### PR TITLE
Parallel Implementation of Basic Filter Function

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -39,7 +39,8 @@ except ImportError:
 
 
 def parallel_apply(filter, subframe, q):
-    """A function called in parallel which uses pandas apply on a subframe and returns the results via multiprocessing queue function."""
+    """A function called in parallel which uses pandas apply
+    on a subframe and returns the results via multiprocessing queue function."""
     filtered_rows = subframe.apply(filter, axis=1)
     filtered_sf = subframe[filtered_rows]
     q.put(filtered_sf)
@@ -327,6 +328,8 @@ class GraphFrame:
             # appending onto a frame of increasing size.
             for p in processes:
                 returns.append(q.get())
+
+            for p in processes:
                 p.join()
 
             filtered_df = pd.concat(returns)

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -39,6 +39,7 @@ def parallel_apply(filter, subframe):
     filtered_rows = subframe.apply(filter, axis=1)
     print("End ", mp.current_process().pid)
     return filtered_rows
+    filtered_rows = subframe.apply(filter, axis=1)
 
 class GraphFrame:
     """An input dataset is read into an object of this type, which includes a graph

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -294,7 +294,7 @@ class GraphFrame:
 
         self.dataframe = agg_df
 
-    def filter(self, filter_obj, squash=True, parallel=False, num_procs=mp.cpu_count()):
+    def filter(self, filter_obj, squash=True, num_procs=mp.cpu_count()):
         """Filter the dataframe using a user-supplied function.
 
         Note: Operates in parallel on user-supplied lambda functions.
@@ -312,7 +312,7 @@ class GraphFrame:
 
         if callable(filter_obj):
             # pandas filter
-            if parallel:
+            if num_procs > 1:
                 q = Queue()
                 processes = []
                 returns = []

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -34,7 +34,9 @@ except ImportError:
     raise
 
 def parallel_apply(filter, subframe):
+    print("Start ", mp.current_process().pid)
     filtered_rows = subframe.apply(filter, axis=1)
+    print("End ", mp.current_process().pid)
     return filtered_rows
 
 class GraphFrame:
@@ -305,6 +307,9 @@ class GraphFrame:
             func = partial(parallel_apply, filter_obj)
 
             filtered_rows = pd.concat(p.map(func, subframes))
+            # result = p.map_async(func, subframes)
+            #
+            # filtered_rows = pd.concat(result.get())
             filtered_df = dataframe_copy[filtered_rows]
             #
             # filtered_rows = dataframe_copy.apply(filter_obj, axis=1)

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -32,12 +32,12 @@ except ImportError:
     raise
 
 
-def parallel_apply(filter, subframe, queue):
-    """A function called in parallel which uses pandas apply
-    on a subframe and returns the results via multiprocessing queue function."""
-    filtered_rows = subframe.apply(filter, axis=1)
-    filtered_sf = subframe[filtered_rows]
-    queue.put(filtered_sf)
+def parallel_apply(filter_function, dataframe, queue):
+    """A function called in parallel, which does a pandas apply on part of a
+    dataframe and returns the results via multiprocessing queue function."""
+    filtered_rows = dataframe.apply(filter_function, axis=1)
+    filtered_df = dataframe[filtered_rows]
+    queue.put(filtered_df)
 
 
 class GraphFrame:
@@ -305,27 +305,30 @@ class GraphFrame:
         filtered_df = None
 
         if callable(filter_obj):
-            # pandas filter
+            # applying pandas filter using the callable function
             if num_procs > 1:
+                # perform filter in parallel (default)
                 queue = mp.Queue()
                 processes = []
                 returned_frames = []
                 subframes = np.array_split(dataframe_copy, num_procs)
 
-                # Manually create a number of processes equal to the number of logical cpus available
-                for proc_num in range(num_procs):
+                # Manually create a number of processes equal to the number of
+                # logical cpus available
+                for pid in range(num_procs):
                     process = mp.Process(
                         target=parallel_apply,
-                        args=(filter_obj, subframes[proc_num], queue),
+                        args=(filter_obj, subframes[pid], queue),
                     )
                     process.start()
                     processes.append(process)
 
-                # Stores filtered sunframes in a list: 'returns', for pandas concatenation
-                # This intermediary list is used because pandas concat is faster when
-                # called only once on a list of dataframes, than when called multiple times
-                # appending onto a frame of increasing size.
-                for proc in range(num_procs):
+                # Stores filtered subframes in a list: 'returned_frames', for
+                # pandas concatenation. This intermediary list is used because
+                # pandas concat is faster when called only once on a list of
+                # dataframes, than when called multiple times appending onto a
+                # frame of increasing size.
+                for pid in range(num_procs):
                     returned_frames.append(queue.get())
 
                 for proc in processes:
@@ -334,11 +337,12 @@ class GraphFrame:
                 filtered_df = pd.concat(returned_frames)
 
             else:
-                # non parallel condition
+                # perform filter sequentiually if num_procs = 1
                 filtered_rows = dataframe_copy.apply(filter_obj, axis=1)
                 filtered_df = dataframe_copy[filtered_rows]
 
         elif isinstance(filter_obj, list) or isinstance(filter_obj, QueryMatcher):
+            # use a callpath query to apply the filter
             query = filter_obj
             if isinstance(filter_obj, list):
                 query = QueryMatcher(filter_obj)

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -39,7 +39,6 @@ def parallel_apply(filter, subframe):
     filtered_rows = subframe.apply(filter, axis=1)
     print("End ", mp.current_process().pid)
     return filtered_rows
-    filtered_rows = subframe.apply(filter, axis=1)
 
 class GraphFrame:
     """An input dataset is read into an object of this type, which includes a graph

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -22,10 +22,6 @@ from .external.console import ConsoleRenderer
 from .util.dot import trees_to_dot
 from .util.deprecated import deprecated_params
 
-from .util.timer import Timer
-
-T = Timer()
-
 try:
     import hatchet.cython_modules.libs.graphframe_modules as _gfm_cy
 except ImportError:

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -35,9 +35,9 @@ except ImportError:
     raise
 
 def parallel_apply(filter, subframe):
-    print("Start ", mp.current_process().pid)
+    print("Start ", mp.current_process().pid, flush=True)
     filtered_rows = subframe.apply(filter, axis=1)
-    print("End ", mp.current_process().pid)
+    print("End ", mp.current_process().pid, flush=True)
     return filtered_rows
 
 class GraphFrame:

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -13,6 +13,7 @@ from functools import partial
 import pandas as pd
 import numpy as np
 import multiprocess as mp
+import psutil
 
 from .node import Node
 from .graph import Graph
@@ -303,7 +304,8 @@ class GraphFrame:
 
         if callable(filter_obj):
             subframes = np.array_split(dataframe_copy, mp.cpu_count())
-            p = mp.Pool(mp.cpu_count())
+            print(mp.cpu_count(), psutil.cpu_count(logical=False))
+            p = mp.Pool(psutil.cpu_count(logical=False))
             func = partial(parallel_apply, filter_obj)
 
             filtered_rows = pd.concat(p.map(func, subframes))

--- a/hatchet/readers/hpctoolkit_reader.py
+++ b/hatchet/readers/hpctoolkit_reader.py
@@ -74,6 +74,7 @@ def read_metricdb_file(args):
     arr[rank_offset : rank_offset + num_nodes, 3] = rank
     arr[rank_offset : rank_offset + num_nodes, 4] = thread
 
+
 class HPCToolkitReader:
     """Read in the various sections of an HPCToolkit experiment.xml file and
     metric-db files.

--- a/hatchet/readers/hpctoolkit_reader.py
+++ b/hatchet/readers/hpctoolkit_reader.py
@@ -49,6 +49,7 @@ def init_shared_array(buf_):
 
 
 def read_metricdb_file(args):
+    print("Start")
     """Read a single metricdb file into a 1D array."""
     filename, num_nodes, num_threads_per_rank, num_metrics, shape = args
     rank = int(
@@ -73,7 +74,7 @@ def read_metricdb_file(args):
     arr[rank_offset : rank_offset + num_nodes, 2] = range(1, num_nodes + 1)
     arr[rank_offset : rank_offset + num_nodes, 3] = rank
     arr[rank_offset : rank_offset + num_nodes, 4] = thread
-
+    print("end")
 
 class HPCToolkitReader:
     """Read in the various sections of an HPCToolkit experiment.xml file and

--- a/hatchet/readers/hpctoolkit_reader.py
+++ b/hatchet/readers/hpctoolkit_reader.py
@@ -49,7 +49,6 @@ def init_shared_array(buf_):
 
 
 def read_metricdb_file(args):
-    print("Start")
     """Read a single metricdb file into a 1D array."""
     filename, num_nodes, num_threads_per_rank, num_metrics, shape = args
     rank = int(
@@ -74,7 +73,6 @@ def read_metricdb_file(args):
     arr[rank_offset : rank_offset + num_nodes, 2] = range(1, num_nodes + 1)
     arr[rank_offset : rank_offset + num_nodes, 3] = rank
     arr[rank_offset : rank_offset + num_nodes, 4] = thread
-    print("end")
 
 class HPCToolkitReader:
     """Read in the various sections of an HPCToolkit experiment.xml file and

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -152,6 +152,8 @@ def test_subtree_product():
 
 def check_filter_no_squash(gf, filter_func, num_rows):
     """Ensure filtering and squashing results in the right Graph and GraphFrame."""
+
+    # sequential tests
     orig_graph = gf.graph.copy()
     filtered = gf.filter(filter_func, squash=False, num_procs=1)
     filtered.dataframe.reset_index(inplace=True)
@@ -172,6 +174,8 @@ def check_filter_no_squash(gf, filter_func, num_rows):
 
 def check_filter_squash(gf, filter_func, expected_graph, expected_inc_time):
     """Ensure filtering and squashing results in the right Graph and GraphFrame."""
+
+    # sequential tests
     filtered_squashed = gf.filter(filter_func, num_procs=1)
     index_names = filtered_squashed.dataframe.index.names
     filtered_squashed.dataframe.reset_index(inplace=True)

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -153,7 +153,7 @@ def test_subtree_product():
 def check_filter_no_squash(gf, filter_func, num_rows):
     """Ensure filtering and squashing results in the right Graph and GraphFrame."""
     orig_graph = gf.graph.copy()
-    filtered = gf.filter(filter_func, squash=False)
+    filtered = gf.filter(filter_func, squash=False, num_procs=1)
     filtered.dataframe.reset_index(inplace=True)
 
     assert filtered.graph is gf.graph
@@ -162,7 +162,7 @@ def check_filter_no_squash(gf, filter_func, num_rows):
 
     # parallel versions of the same test
     orig_graph = gf.graph.copy()
-    filtered = gf.filter(filter_func, squash=False, parallel=True)
+    filtered = gf.filter(filter_func, squash=False)
     filtered.dataframe.reset_index(inplace=True)
 
     assert filtered.graph is gf.graph
@@ -172,7 +172,7 @@ def check_filter_no_squash(gf, filter_func, num_rows):
 
 def check_filter_squash(gf, filter_func, expected_graph, expected_inc_time):
     """Ensure filtering and squashing results in the right Graph and GraphFrame."""
-    filtered_squashed = gf.filter(filter_func)
+    filtered_squashed = gf.filter(filter_func, num_procs=1)
     index_names = filtered_squashed.dataframe.index.names
     filtered_squashed.dataframe.reset_index(inplace=True)
 
@@ -202,7 +202,7 @@ def check_filter_squash(gf, filter_func, expected_graph, expected_inc_time):
     ]
 
     # parallel versions
-    filtered_squashed = gf.filter(filter_func, parallel=True)
+    filtered_squashed = gf.filter(filter_func)
     index_names = filtered_squashed.dataframe.index.names
     filtered_squashed.dataframe.reset_index(inplace=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ numpy
 PyYAML
 cython
 multiprocess
-psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pep8-naming
 numpy
 PyYAML
 cython
+multiprocess
+psutil


### PR DESCRIPTION
Changes:

- The original 'lambda' `filter` now breaks the hatchet dataframe into n subframes and spawns n processes to perform `apply` on each of them in parallel; where n is the number of logical cpu cores available.
-  multiprocess has been added to the requirements.txt and dependencies.
    - multiprocess is a fork of the pandas standard multiprocessing that uses `dill` instead of the `pickle` library so we can pass lambda functions to our `parallel_apply` function

Results:

In the following figure you can see the absolute runtimes of our pre-optimized and post-optimized filter function. This chart was generated from runs on a single node on Quartz. All parallel runs were executed over 72 logical cores. With this level of parallelism we can see that our filter function now runs an order of magnitude faster for each of our tested datasets.

![visualization(14)](https://user-images.githubusercontent.com/10066043/101399846-e7c1ac00-3884-11eb-87ad-503a31765936.png)

Speedup chart coming soon.
