### PR TITLE
Changed some absolute import to relative imports

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from hatchet.version import __version__
+from ..version import __version__
 
 import numpy as np
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -19,7 +19,7 @@ from .util.dot import trees_to_dot
 from .util.deprecated import deprecated_params
 
 try:
-    import hatchet.cython_modules.libs.graphframe_modules as _gfm_cy
+    from .cython_modules.libs import graphframe_modules as _gfm_cy
 except ImportError:
     print("-" * 80)
     print(


### PR DESCRIPTION
So I have added hatchet as a git submodule to timemory and basically am doing:

```cmake
# if not run from Spack and not from PyPi
if(NOT SKBUILD AND NOT SPACK_BUILD AND TIMEMORY_BUILD_PYTHON_HATCHET)
    # run python setup.py build_ext --inplace
    # copy hatchet directory to timemory/hatchet
endif()
```

thus, there is a pristine copy of hatchet as `timemory.hatchet`. These two changes were necessary for `import timemory.hatchet` to work though, all the other `import hatchet.XYZ` are not invoked via `hatchet/__init__.py`.

Then, I compensate for the `import hatchet.XYZ` later in `timemory/__init__.py` via this (lmk if you think this is problematic in any way):

```python
# try to import the local hatchet first
try:
    from . import hatchet as local_hatchet

    sys.modules["timemory.hatchet"] = local_hatchet
except (ImportError) as e:
    pass

# try to import real hatchet
try:
    if "hatchet" not in sys.modules:
        import hatchet as global_hatchet

        sys.modules["hatchet"] = global_hatchet
except (ImportError):
    pass

# if real hatchet doesn't exist, set the local one as the global
try:
    if "hatchet" not in sys.modules and "timemory.hatchet" in sys.modules:
        sys.modules["hatchet"] = sys.modules["timemory.hatchet"]
except (KeyError):
    pass
```

It appears that this _should_ not cause any problems via testing with this script:

```python
import timemory
import hatchet

print("{}\n{}".format(
    hatchet.__file__, 
    timemory.hatchet.__file__))
```

With hatchet and timemory's hatchet installed:

```console
/Users/jrmadsen/Library/Python/3.8/lib/python/site-packages/hatchet-1.3.0-py3.8-macosx-10.15-x86_64.egg/hatchet/__init__.py
/Users/jrmadsen/devel/c++/qt-timemory-hatchet/gcc-RelWithDebInfo/timemory/hatchet/__init__.py
```

with just timemory installed:

```console
/Users/jrmadsen/devel/c++/qt-timemory-hatchet/gcc-RelWithDebInfo/timemory/hatchet/__init__.py
/Users/jrmadsen/devel/c++/qt-timemory-hatchet/gcc-RelWithDebInfo/timemory/hatchet/__init__.py
```