### PR TITLE
bugfix: query nodes with a metric that fall within a range

### DIFF
--- a/hatchet/query_matcher.py
+++ b/hatchet/query_matcher.py
@@ -87,7 +87,19 @@ class QueryMatcher:
                             else:
                                 matches = matches and False
                         elif isinstance(df_row[k], Real):
-                            if isinstance(v, str) and v.lower().startswith(compops):
+                            if isinstance(v, list):
+                                for i in v:
+                                    if isinstance(i, str) and i.lower().startswith(compops):
+                                        matches = matches and eval("{} {}".format(df_row[k], i))
+                                    elif isinstance(i, Real):
+                                        matches = matches and (df_row[k] == i)
+                                    else:
+                                        raise InvalidQueryFilter(
+                                            "Attribute {} has a numeric type. Valid filters for this attribute are a string starting with a comparison operator or a real number.".format(
+                                                k
+                                            )
+                                        )
+                            elif isinstance(v, str) and v.lower().startswith(compops):
                                 matches = matches and eval("{} {}".format(df_row[k], v))
                             elif isinstance(v, Real):
                                 matches = matches and (df_row[k] == v)


### PR DESCRIPTION
For specifying multiple values (i.e., > 5 and < 10) for the same key (i.e.,
time), put the values into a list. Otherwise, only the second value is
considered if identical keys are found.

This query looks for a single node with name starting with "gr" and inclusive time less than or equal to 10. It can be specified as such because the keys are unique.
```
query = [
    {"name": "gr[a-z]+", "time (inc)": "<= 10"}
]
```

Looking for a node with time greater than 5 and less than 10 should be specified as a list, and not a dict with identical keys:
```
query = [ 
    {"time": ["> 5", "< 10"]}
]  
``` 

Will resolve #302.