### PR TITLE
Extend tree() to support visualizing 2 metrics

### DIFF
--- a/docs/examples/read/dag_literal.py
+++ b/docs/examples/read/dag_literal.py
@@ -164,4 +164,4 @@ if __name__ == "__main__":
 
     # Printout the graph component of the GraphFrame.
     # Because no metric parameter is specified, ``time`` is used by default.
-    print(gf.tree())
+    print(gf.tree(metric_column=["time (inc)", "time"]))

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -5,6 +5,7 @@
 
 import sys
 import traceback
+import warnings
 
 from collections import defaultdict
 
@@ -675,6 +676,12 @@ class GraphFrame:
             unicode = False
         elif sys.version_info.major == 3:
             unicode = True
+
+        if isinstance(metric_column, list) and len(metric_column) > 2:
+            warnings.warn(
+                "More than 2 metrics specified in metric_column=. Tree() will only show 2 metrics at a time. The remaining metrics will not be shown.",
+                SyntaxWarning,
+            )
 
         return ConsoleRenderer(unicode=unicode, color=color).render(
             self.graph.roots,


### PR DESCRIPTION
Adds secondary_metric_column= parameter to tree() to view another metric.
Default argument is no secondary metric.

Resolves #254

* Support n metrics?
* Different color map for each metric?
* Should additional metrics be placed to the right of the name? Should additional metrics be captured in a list of parenthesis?

As an example: `print(gf.tree(secondary_metric_column="time (inc)"))`
![Screen Shot 2021-01-13 at 10 36 51 AM](https://user-images.githubusercontent.com/5253432/104494427-487e8b80-558b-11eb-8213-88d05b32751e.png)

Caliper example: `print(gf.tree(metric_column="time (inc)", secondary_metric_column="sum#sum#time.duration"))`
![Screen Shot 2021-01-13 at 10 40 51 AM](https://user-images.githubusercontent.com/5253432/104494857-dfe3de80-558b-11eb-852d-3f0b141500cd.png)

