### PR TITLE
WIP: Auto-Detect profile format

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -81,22 +81,22 @@ class GraphFrame:
         """Read a database directory and automatically detect the data format.
 
         Arguments:
-            dirname_or_data (str): path to the database directory  
+            dirname_or_data (str): path to the database directory
             args (str): args need to be provided based on the respective function signature of GraphFrame.from_*profile_format*.
         """
         import os
+
         assert isinstance(dirname_or_data, (str, list, dict))
 
         FROM_DATABASE_MAPPER = {
-            'hpctoolkit': GraphFrame.from_hpctoolkit,
-            'caliper': GraphFrame.from_caliper,
-            'caliper_json': GraphFrame.from_caliper_json,
-            'gprof_dot': GraphFrame.from_gprof_dot,
-            'cprofile': GraphFrame.from_cprofile,
-            'pyinstrument': GraphFrame.from_pyinstrument,
-            'timemory': GraphFrame.from_timemory,
-            'literal': GraphFrame.from_literal,
-            'lists': GraphFrame.from_lists,
+            "hpctoolkit": GraphFrame.from_hpctoolkit,
+            "caliper": GraphFrame.from_caliper,
+            "caliper_json": GraphFrame.from_caliper_json,
+            "gprof_dot": GraphFrame.from_gprof_dot,
+            "cprofile": GraphFrame.from_cprofile,
+            "pyinstrument": GraphFrame.from_pyinstrument,
+            "timemory": GraphFrame.from_timemory,
+            "literal": GraphFrame.from_literal,
         }
 
         profile_format = GraphFrame._detect_profile_format(dirname_or_data)
@@ -115,7 +115,7 @@ class GraphFrame:
             "caliper": if file extension is .cali
             "caliper_json": if file extension is .json and matches schema
         """
-        import os 
+        import os
         import json
         import jsonschema
 
@@ -126,78 +126,83 @@ class GraphFrame:
                 "columns": {"type": "array"},
                 "column_metadata": {"type": "array"},
                 "nodes": {"type": "array"},
-            }
+            },
         }
 
         _SCHEMA_PYINSTRUMENT = {
             "type": "object",
-             "properties": {
+            "properties": {
                 "start_time": {"type": "number"},
                 "duration": {"type": "number"},
                 "sample_count": {"type": " number"},
                 "program": {"type": "string"},
                 "cpu_time": {"type": "number"},
-                "root_frame": {"type": "object"}
-            }
+                "root_frame": {"type": "object"},
+            },
         }
 
         _SCHEMA_TIMEMORY = {
             "type": "object",
-             "properties": {
-                "timemory": {"type": "object"}
-            }
+            "properties": {"timemory": {"type": "object"}},
         }
 
         if isinstance(dirname_or_data, list):
-            return 'lists'
-
-        if isinstance(dirname_or_data, dict):
-            return 'literal'
+            return "literal"
 
         # Determine dirname_or_data is a str
         if isinstance(dirname_or_data, str):
-            
+
             # check if it is a directory.
             # Formats in directory: hpctoolkit
             if os.path.isdir(dirname_or_data):
-                _metric_db_files = [f for f in os.listdir(dirname_or_data) if f.endswith('.metric-db')] 
-                _experiment_xml_files = [f for f in os.listdir(dirname_or_data) if f.endswith('experiment.xml')]
+                _metric_db_files = [
+                    f for f in os.listdir(dirname_or_data) if f.endswith(".metric-db")
+                ]
+                _experiment_xml_files = [
+                    f
+                    for f in os.listdir(dirname_or_data)
+                    if f.endswith("experiment.xml")
+                ]
 
                 if len(_metric_db_files) == 0:
-                    raise ValueError("No metric-db files detected inside the provided path.")
+                    raise ValueError(
+                        "No metric-db files detected inside the provided path."
+                    )
 
                 if len(_experiment_xml_files) == 0:
-                    raise ValueError("No experiment.xml file detected inside the provided path.")
-                
-                return 'hpctoolkit'
-                
+                    raise ValueError(
+                        "No experiment.xml file detected inside the provided path."
+                    )
+
+                return "hpctoolkit"
 
             # check if it is a file
             if os.path.isfile(dirname_or_data):
                 _file_name, _file_ext = os.path.splitext(dirname_or_data)
 
-                if _file_ext == "cali":
-                    return 'caliper'
-                elif _file_ext == "pstats":
-                    return 'pstats'
-                elif _file_ext == "dot":
-                    return 'grpof'
-                elif _file_ext == 'json':
+                if _file_ext == ".cali":
+                    return "caliper"
+                elif _file_ext == ".pstats":
+                    return "cprofile"
+                elif _file_ext == ".dot" or "dot" in _file_name.split("."):
+                    return "gprof_dot"
+                elif _file_ext == ".json":
                     # TODO: Check if we can just load the key and dtype of JSON.
                     # We could also be unnecessarily read the data again.
                     try:
-                        _data=json.loads(dirname_or_data)
+                        _data = json.loads(dirname_or_data)
                     except ValueError as err:
                         print(err)
                         return False
 
                     if jsonschema.validate(instance=_data, schema=_SCHEMA_CALIPER_JSON):
-                        return 'caliper_json'
-                    elif jsonschema.validate(instance=_data, schema=_SCHEMA_PYINSTRUMENT):
-                        return 'pyinstrument'
+                        return "caliper_json"
+                    elif jsonschema.validate(
+                        instance=_data, schema=_SCHEMA_PYINSTRUMENT
+                    ):
+                        return "pyinstrument"
                     elif jsonschema.validate(instance=_data, schema=_SCHEMA_TIMEMORY):
-                        return 'timemory'
-
+                        return "timemory"
 
     @staticmethod
     def from_hpctoolkit(dirname):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -77,40 +77,30 @@ class GraphFrame:
         self.inc_metrics = [] if inc_metrics is None else inc_metrics
 
     @staticmethod
-    def from_path(dirname_or_data, query="", profile_format=None):
+    def from_path(dirname_or_data, *args):
         """Read a database directory and automatically detect the data format.
 
         Arguments:
             dirname_or_data (str): path to the database directory  
-            query (str): 
-            profile_format (str): Override for the profile_format, if detection
-            of format fails. 
+            args (str): args need to be provided based on the respective function signature of GraphFrame.from_*profile_format*.
         """
-        assert isinstance(dirname_or_data, str)
-        assert isinstance(query, str)
-        assert isinstance(profile_format, str or None)
+        import os
+        assert isinstance(dirname_or_data, (str, list, dict))
 
         FROM_DATABASE_MAPPER = {
-            'hpctoolkit': GraphFrame.from_hpctoolkit(dirname_or_data),
-            'caliper': GraphFrame.from_caliper(dirname_or_data, query),
-            'caliper_json': GraphFrame.from_caliper_json(dirname_or_data),
-            'gprof_dot': GraphFrame.from_gprof_dot(dirname_or_data),
-            'cprofile': GraphFrame.from_cprofile(dirname_or_data),
-            'pyinstrument': GraphFrame.from_pyinstrument(dirname_or_data),
-            'timemory': GraphFrame.from_timemory(dirname_or_data),
-            'literal': GraphFrame.from_literal(dirname_or_data),
-            'lists': GraphFrame.from_lists(dirname_or_data),
+            'hpctoolkit': GraphFrame.from_hpctoolkit,
+            'caliper': GraphFrame.from_caliper,
+            'caliper_json': GraphFrame.from_caliper_json,
+            'gprof_dot': GraphFrame.from_gprof_dot,
+            'cprofile': GraphFrame.from_cprofile,
+            'pyinstrument': GraphFrame.from_pyinstrument,
+            'timemory': GraphFrame.from_timemory,
+            'literal': GraphFrame.from_literal,
+            'lists': GraphFrame.from_lists,
         }
 
-        if profile_format is not None:
-            return FROM_DATABASE_MAPPER[profile_format]
-
         profile_format = GraphFrame._detect_profile_format(dirname_or_data)
-
-        if len(query) > 0:
-            assert profile_format == "caliper"
-
-        return FROM_DATABASE_MAPPER[profile_format]
+        return FROM_DATABASE_MAPPER[profile_format](dirname_or_data, *args)
 
     @staticmethod
     def _detect_profile_format(dirname_or_data):
@@ -158,14 +148,14 @@ class GraphFrame:
             }
         }
 
-        if type(dirname_or_data) == 'list':
+        if isinstance(dirname_or_data, list):
             return 'lists'
 
-        if type(dirname_or_data) == 'dict':
+        if isinstance(dirname_or_data, dict):
             return 'literal'
 
         # Determine dirname_or_data is a str
-        if type(dirname_or_data) == 'str':
+        if isinstance(dirname_or_data, str):
             
             # check if it is a directory.
             # Formats in directory: hpctoolkit
@@ -207,7 +197,7 @@ class GraphFrame:
                         return 'pyinstrument'
                     elif jsonschema.validate(instance=_data, schema=_SCHEMA_TIMEMORY):
                         return 'timemory'
-            
+
 
     @staticmethod
     def from_hpctoolkit(dirname):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -84,8 +84,6 @@ class GraphFrame:
             dirname_or_data (str): path to the database directory
             args (str): args need to be provided based on the respective function signature of GraphFrame.from_*profile_format*.
         """
-        import os
-
         assert isinstance(dirname_or_data, (str, list, dict))
 
         FROM_DATABASE_MAPPER = {

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -208,7 +208,6 @@ def test_from_path_caliper_json(calc_pi_caliper_json):
 
 @pytest.mark.skipif(not which("cali-query"), reason="needs cali-query to be in path")
 def test_from_path_caliper(lulesh_caliper_cali):
-    cali_query = which("cali-query")
     grouping_attribute = "function"
     default_metric = "sum(sum#time.duration),inclusive_sum(sum#time.duration)"
     query = "select function,%s group by %s format json-split" % (

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -198,3 +198,24 @@ def test_graphframe_to_literal(lulesh_caliper_json):
     gf2 = GraphFrame.from_literal(graph_literal)
 
     assert len(gf.graph) == len(gf2.graph)
+
+
+def test_from_path_caliper_json(calc_pi_caliper_json):
+    gf = GraphFrame.from_caliper_json(str(calc_pi_caliper_json))
+
+    assert len(gf.dataframe.groupby("name")) == 100
+
+
+@pytest.mark.skipif(not which("cali-query"), reason="needs cali-query to be in path")
+def test_from_path_caliper(lulesh_caliper_cali):
+    cali_query = which("cali-query")
+    grouping_attribute = "function"
+    default_metric = "sum(sum#time.duration),inclusive_sum(sum#time.duration)"
+    query = "select function,%s group by %s format json-split" % (
+        default_metric,
+        grouping_attribute,
+    )
+
+    gf = GraphFrame.from_caliper(lulesh_caliper_cali, query)
+
+    assert len(gf.dataframe.groupby("name")) == 18

--- a/hatchet/tests/callgrind.py
+++ b/hatchet/tests/callgrind.py
@@ -44,3 +44,15 @@ def test_read_calc_pi_database(calc_pi_callgrind_dot):
         root_names.append(root.frame.attrs["name"])
 
     assert all(rt in root_names for rt in roots)
+
+
+def test_from_path_gprof_dot(calc_pi_callgrind_dot):
+    gf = GraphFrame.from_path(str(calc_pi_callgrind_dot))
+
+    assert len(gf.dataframe.groupby("name")) == 105
+
+    for col in gf.dataframe.columns:
+        if col in ("time (inc)", "time"):
+            assert gf.dataframe[col].dtype == np.float64
+        elif col in ("name", "module", "node"):
+            assert gf.dataframe[col].dtype == np.object

--- a/hatchet/tests/cprofile.py
+++ b/hatchet/tests/cprofile.py
@@ -63,3 +63,10 @@ def test_tree(hatchet_cycle_pstats):
     )
     assert "f pstats_reader_test.py" in output
     assert re.match("(.|\n)*recursive(.|\n)*recursive", output)
+
+
+def test_from_path_cprofile(hatchet_cycle_pstats):
+    gf = GraphFrame.from_path(str(hatchet_cycle_pstats))
+
+    assert len(gf.dataframe.groupby("file")) == 4
+    assert len(gf.dataframe.groupby("name")) == 9

--- a/hatchet/tests/graph_literal.py
+++ b/hatchet/tests/graph_literal.py
@@ -39,3 +39,9 @@ def test_with_duplicate_in_first_node(mock_graph_literal_duplicate_first):
 
     graph_literal = gf.to_literal()
     assert mock_graph_literal_duplicate_first.sort() == graph_literal.sort()
+
+
+def test_from_path_literal(mock_graph_literal):
+    gf = GraphFrame.from_path(mock_graph_literal)
+
+    assert len(gf.dataframe) == 24

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -210,3 +210,10 @@ def test_graphframe_to_literal_with_threads(data_dir, osu_allgather_hpct_db):
     gf2 = GraphFrame.from_literal(graph_literal)
 
     assert len(gf.graph) == len(gf2.graph)
+
+def test_from_path(calc_pi_hpct_db):
+    gf = GraphFrame.from_path(str(calc_pi_hpct_db))
+
+    assert len(gf.dataframe.groupby("module")) == 5
+    assert len(gf.dataframe.groupby("file")) == 11
+    assert len(gf.dataframe.groupby("name")) == 20

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -203,13 +203,14 @@ def test_graphframe_to_literal(data_dir, calc_pi_hpct_db):
     assert len(gf.graph) == len(gf2.graph)
 
 
-def test_graphframe_to_literal_with_threads(data_dir, osu_allgather_hpct_db):
+def test_graphframe_to_literal_with_threads(osu_allgather_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(osu_allgather_hpct_db))
     graph_literal = gf.to_literal()
 
     gf2 = GraphFrame.from_literal(graph_literal)
 
     assert len(gf.graph) == len(gf2.graph)
+
 
 def test_from_path(calc_pi_hpct_db):
     gf = GraphFrame.from_path(str(calc_pi_hpct_db))

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -120,3 +120,41 @@ def test_graphframe_to_literal(hatchet_pyinstrument_json):
     gf2 = GraphFrame.from_literal(graph_literal)
 
     assert len(gf.graph) == len(gf2.graph)
+
+
+def test_from_path(hatchet_pyinstrument_json):
+    gf = GraphFrame.from_path(str(hatchet_pyinstrument_json))
+
+    output = ConsoleRenderer(unicode=True, color=False).render(
+        gf.graph.roots,
+        gf.dataframe,
+        metric_column="time",
+        precision=3,
+        name_column="name",
+        expand_name=False,
+        context_column="file",
+        rank=0,
+        thread=0,
+        depth=10000,
+        highlight_name=False,
+        invert_colormap=False,
+    )
+    assert "0.000 <module> examples.py" in output
+    assert "0.025 read hatchet/readers/caliper_reader.py" in output
+
+    output = ConsoleRenderer(unicode=True, color=False).render(
+        gf.graph.roots,
+        gf.dataframe,
+        metric_column="time (inc)",
+        precision=3,
+        name_column="name",
+        expand_name=False,
+        context_column="file",
+        rank=0,
+        thread=0,
+        depth=10000,
+        highlight_name=False,
+        invert_colormap=False,
+    )
+    assert "0.478 <module> examples.py" in output
+    assert "0.063 from_caliper_json hatchet/graphframe.py" in output

--- a/hatchet/tests/timemory_test.py
+++ b/hatchet/tests/timemory_test.py
@@ -88,3 +88,11 @@ def test_graphframe_to_literal(timemory_json_data):
     graph_literal = gf.to_literal()
 
     assert len(graph_literal) == len(gf.graph.roots)
+
+
+@pytest.mark.skipif(not timemory_avail, reason="timemory package not available")
+def test_from_path(timemory_json_data):
+    gf = GraphFrame.from_path(str(timemory_json_data))
+    graph_literal = gf.to_literal()
+
+    assert len(graph_literal) == len(gf.graph.roots)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ numpy
 PyYAML
 cython
 multiprocess
+jsonschema


### PR DESCRIPTION
This PR implements the`GraphFrame.from_path` API, where users can pass in (any) data format (e.g., hpctoolkit, caliper, and so on). 

Implementation: `from_path` function attempts to auto-detect the data format from file structure and JSON structure (for differentiating profile formats like caliper_json, timemory, and pyinstrument). Based on the detected format, it calls `GraphFrame.from_*` respectively.

- [x] Add initial structure for the code.
- [x] Use JSONschema (https://json-schema.org/) for comparing data structure.  
- [ ] Check if we can just load the key and dtype of JSON to avoid data being read once more.
- [x] Add unit-tests for each each data format. (will possibly go to tests/{profile_format}.py).