### PR TITLE
Updates to timemory reader

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -143,7 +143,7 @@ class GraphFrame:
         return PyinstrumentReader(filename).read()
 
     @staticmethod
-    def from_timemory(input=None, select=None):
+    def from_timemory(input=None, select=None, *_args, **_kwargs):
         """Read in timemory data.
 
         Links:
@@ -195,14 +195,16 @@ class GraphFrame:
 
         if input is not None:
             try:
-                return TimemoryReader(input, select).read()
+                return TimemoryReader(input, select, *_args, **_kwargs).read()
             except IOError:
                 pass
         else:
             try:
                 import timemory
 
-                TimemoryReader(timemory.get(hierarchy=True), select).read()
+                TimemoryReader(
+                    timemory.get(hierarchy=True), select, *_args, **_kwargs
+                ).read()
             except ImportError:
                 print(
                     "Error! timemory could not be imported. Provide filename, file stream, or dict."

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -143,7 +143,7 @@ class GraphFrame:
         return PyinstrumentReader(filename).read()
 
     @staticmethod
-    def from_timemory(input=None, select=None, *_args, **_kwargs):
+    def from_timemory(input=None, select=None, **_kwargs):
         """Read in timemory data.
 
         Links:
@@ -189,22 +189,31 @@ class GraphFrame:
                 available upon request via a GitHub Issue.
 
             select (list of str):
-                A list of strings which match the component enumeration names
+                A list of strings which match the component enumeration names, e.g. ["cpu_clock"].
+
+            per_thread (boolean):
+                Ensures that when applying filters to the graphframe, frames with
+                identical name/file/line/etc. info but from different threads are not
+                combined
+
+            per_rank (boolean):
+                Ensures that when applying filters to the graphframe, frames with
+                identical name/file/line/etc. info but from different ranks are not
+                combined
+
         """
         from .readers.timemory_reader import TimemoryReader
 
         if input is not None:
             try:
-                return TimemoryReader(input, select, *_args, **_kwargs).read()
+                return TimemoryReader(input, select, **_kwargs).read()
             except IOError:
                 pass
         else:
             try:
                 import timemory
 
-                TimemoryReader(
-                    timemory.get(hierarchy=True), select, *_args, **_kwargs
-                ).read()
+                TimemoryReader(timemory.get(hierarchy=True), select, **_kwargs).read()
             except ImportError:
                 print(
                     "Error! timemory could not be imported. Provide filename, file stream, or dict."

--- a/hatchet/readers/timemory_reader.py
+++ b/hatchet/readers/timemory_reader.py
@@ -15,9 +15,10 @@ from ..util.timer import Timer
 
 
 class TimemoryReader:
-    """Read in timemory JSON output
+    """Read in timemory JSON output"""
 
-    Arguments:
+    def __init__(self, input, select=None, **_kwargs):
+        """Arguments:
         input (str or file-stream or dict or None):
             Valid argument types are:
 
@@ -37,9 +38,8 @@ class TimemoryReader:
             Ensures that when applying filters to the graphframe, frames with
             identical name/file/line/etc. info but from different ranks are not
             combined
-    """
+        """
 
-    def __init__(self, input, select=None, **_kwargs):
         if isinstance(input, dict):
             self.graph_dict = input
         elif isinstance(input, str) and input.endswith("json"):

--- a/hatchet/readers/timemory_reader.py
+++ b/hatchet/readers/timemory_reader.py
@@ -17,7 +17,7 @@ from ..util.timer import Timer
 class TimemoryReader:
     """Read in timemory JSON output"""
 
-    def __init__(self, input, select=None):
+    def __init__(self, input, select=None, per_thread=False, per_rank=False):
         if isinstance(input, dict):
             self.graph_dict = input
         elif isinstance(input, str) and input.endswith("json"):
@@ -32,8 +32,12 @@ class TimemoryReader:
         self.timer = Timer()
         self.metric_cols = []
         self.properties = {}
-        self.include_tid = False
-        self.include_nid = False
+        self.include_tid = True
+        self.include_nid = True
+        # the per_thread and per_rank settings make sure that
+        # squashing doesn't collapse the threads/ranks
+        self.per_thread = per_thread
+        self.per_rank = per_rank
         if select is None:
             self.select = select
         elif isinstance(select, list):
@@ -104,9 +108,17 @@ class TimemoryReader:
 
             _tmp = None
             for _pattern in [
+                # [func][file]
+                r"(^\[)(?P<func>.*)(\]\[)(?P<file>.*)(\]$)",
+                # label  [func/file:line]
                 r"(?P<head>.+)([ \t]+)\[(?P<func>\S+)([/])(?P<file>\S+):(?P<line>[0-9]+)\]$",
+                # func@file:line/tail
+                # func/file:line/tail
                 r"(?P<func>\S+)([@/])(?P<file>\S+):(?P<line>[0-9]+)[/]*(?P<tail>.*)",
+                # func@file/tail
+                # func/file/tail
                 r"(?P<func>\S+)([@/])(?P<file>\S+)([/])(?P<tail>.*)",
+                # func:line/tail
                 r"(?P<func>\S+):(?P<line>[0-9]+)([/]*)(?P<tail>.*)",
             ]:
                 _tmp = process_regex(re.search(_pattern, _itr))
@@ -165,6 +177,18 @@ class TimemoryReader:
                     _ret["{}.{}".format(_key, _suffix[i])] = v
             return _ret
 
+        def collapse_ids(_obj):
+            """node/rank/thread id may be int, array of ints, or None.
+            This function generates a consistent form which is not numerical to
+            avoid groupby(...).sum() from producing something nonsensical but
+            the entry is still hashable
+            """
+            if isinstance(_obj, list):
+                return ",".join([f"{x}" for x in _obj]).strip(",")
+            elif _obj is not None:
+                return f"{_obj}"
+            return None
+
         def parse_node(_key, _dict, _hparent, _rank):
             """Create node_dict for one node and then call the function
             recursively on all children.
@@ -181,50 +205,60 @@ class TimemoryReader:
 
             _prop = self.properties[_key]
             _keys, _extra = get_keys(_dict["node"]["prefix"])
-            if _rank is not None:
-                _keys["nid"] = _rank
-                self.include_nid = True
+
+            _tid_dict = _keys if self.per_thread else _extra
+            _rank_dict = _keys if self.per_rank else _extra
+
+            # handle the rank
+            _rank_dict["rank"] = collapse_ids(_rank)
+            if _rank_dict["rank"] is None:
+                del _rank_dict["rank"]
+                self.include_nid = False
+
+            # extract some relevant data
+            _tid_dict["tid"] = collapse_ids(_dict["node"]["tid"])
+            _extra["pid"] = collapse_ids(_dict["node"]["pid"])
             _extra["count"] = _dict["node"]["inclusive"]["entry"]["laps"]
-            _extra["tid"] = _dict["node"]["tid"]
-            _extra["pid"] = _dict["node"]["pid"]
-            # aggregated results have a list of threads and processes
-            if len(_extra["tid"]) == 1:
-                _keys["tid"] = _extra["tid"][0]
-                del _extra["tid"]
-                self.include_tid = True
-            if len(_extra["pid"]) == 1:
-                _extra["pid"] = _extra["pid"][0]
+
+            # this is the name for the metrics
             _labels = None if "type" not in _prop else _prop["type"]
-            # if the data is multi-dimensional
+            # if the labels are not a single string, they are multi-dimensional
             _md = True if not isinstance(_labels, str) else False
 
+            # create the node
             _hnode = Node(Frame(_keys), _hparent)
 
+            # remove some spurious data from inclusive/exclusive stats
             _remove = ["cereal_class_version", "count"]
             _inc_stats = remove_keys(_dict["node"]["inclusive"]["stats"], _remove)
             _exc_stats = remove_keys(_dict["node"]["exclusive"]["stats"], _remove)
 
+            # if multi-dimensions, create alternative "sum.<...>", etc. labels + data
             if _md:
                 _suffix = get_md_suffix(_labels)
                 _exc_stats = get_md_entries(_exc_stats, _suffix)
                 _inc_stats = get_md_entries(_inc_stats, _suffix)
 
+            # add ".inc" to the end of every column that represents an inclusive stat
             _inc_stats = patch_keys(_inc_stats, ".inc")
             _exc_stats = patch_keys(_exc_stats, "")
 
-            add_metrics(_extra)
+            # add the inclusive and exclusive columns to the list of relevant column names
             add_metrics(_exc_stats)
             add_metrics(_inc_stats)
 
+            # add an entry for the node
             node_dicts.append(
                 dict({"node": _hnode, **_keys}, **_extra, **_exc_stats, **_inc_stats)
             )
 
+            # set the node as the root or as a child
             if _hparent is None:
                 list_roots.append(_hnode)
             else:
                 _hparent.add_child(_hnode)
 
+            # recursion
             if "children" in _dict:
                 for _child in _dict["children"]:
                     parse_node(_key, _child, _hnode, _rank)
@@ -239,10 +273,10 @@ class TimemoryReader:
             if _nchild == 0:
                 print("Skipping {}...".format(_key))
                 return
-            if _rank is not None:
-                print("Adding {} for rank {}...".format(_key, _rank))
-            else:
-                print("Adding {}...".format(_key))
+            # if _rank is not None:
+            #    print("Adding {} for rank {}...".format(_key, _rank))
+            # else:
+            #    print("Adding {}...".format(_key))
 
             if _dict["node"]["hash"] > 0:
                 parse_node(_key, _dict, None, _rank)
@@ -316,7 +350,7 @@ class TimemoryReader:
             else:
                 # read in MPI results
                 if "mpi" in itr:
-                    print("Reading MPI...")
+                    # print("Reading MPI...")
                     read_graph(key, itr["mpi"], 0)
                 # if MPI and UPC++, report ranks
                 # offset by MPI_Comm_size


### PR DESCRIPTION
- added support for another format of the labels used by compiler instrumentation
- fixed some issues with operators: +, -, etc. was not previously supported
- commented some debugging statements

I added the `per_thread` and `per_rank` option to the timemory reader ctor because I've noticed that unless the `tid` and/or `rank` are included in the `Node`, when I apply any filtering, squashing results in the per-thread and per-rank data being combined. This creates an issue, particularly when I do something like (using the command-line tool I have recently written):

```console
$ python -m timemory.analyze ./peak_rss.tree.json --expression 'x > 0.1 && x < 0.19' -m sum.inc

0.340 mpi_tests.per_thread/0 [master_thread]
└─ 0.279 run_fibonacci <unknown>
   └─ 0.270 time_fibonacci mpi_tests.cpp
      └─ 0.229 fibonacci/41 <unknown>
         └─ 0.229 fibonacci/40 <unknown>

Legend (Metric: sum.inc)
█ 0.33 - 0.34
█ 0.31 - 0.33
█ 0.28 - 0.31
█ 0.26 - 0.28
█ 0.24 - 0.26
█ 0.23 - 0.24

name User code    ◀  Only in left graph    ▶  Only in right graph
```

Which make it appear that the `--expression` did not work (since _all_ of the values are > 0.19) but with this change now I can bypass that squash and get the correct output:

```console
$ python -m timemory.analyze ./peak_rss.tree.json --expression 'x > 0.1 && x < 0.19' -m sum.inc --per-thread --per-rank

0.168 mpi_tests.per_thread/0 [master_thread]
└─ 0.143 run_fibonacci <unknown>
   └─ 0.139 time_fibonacci mpi_tests.cpp
      └─ 0.127 fibonacci/41 <unknown>
         └─ 0.127 fibonacci/40 <unknown>
0.172 mpi_tests.per_thread/0 [master_thread]
└─ 0.135 run_fibonacci <unknown>
   └─ 0.131 time_fibonacci mpi_tests.cpp
      └─ 0.102 fibonacci/41 <unknown>
         └─ 0.102 fibonacci/40 <unknown>

Legend (Metric: sum.inc)
█ 0.17 - 0.17
█ 0.15 - 0.17
█ 0.14 - 0.15
█ 0.12 - 0.14
█ 0.11 - 0.12
█ 0.10 - 0.11

name User code    ◀  Only in left graph    ▶  Only in right graph
```

