### PR TITLE
Added hatchet node ids to literal output

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -775,6 +775,7 @@ class GraphFrame:
             node_dict["name"] = node_name
             node_dict["frame"] = hnode.frame.attrs
             node_dict["metrics"] = metrics_to_dict(hnode)
+            node_dict["metrics"]["_hatchet_nid"] = hnode._hatchet_nid
 
             if hnode.children and hnode not in visited:
                 visited.append(hnode)

--- a/hatchet/readers/literal_reader.py
+++ b/hatchet/readers/literal_reader.py
@@ -66,19 +66,20 @@ class LiteralReader:
         """
         self.graph_dict = graph_dict
 
-    def parse_node_literal(self, frame_to_node_dict, node_dicts, child_dict, hparent):
+    def parse_node_literal(self, frame_to_node_dict, node_dicts, child_dict, hparent, seen_nids):
         """Create node_dict for one node and then call the function
         recursively on all children.
         """
 
         # pull out _hatchet_nid if it exists
         # it wont interfere with current operations yet this way
-        if "_hatchet_nid" in node_dicts:
-            node_dicts.pop("_hatchet_nid")
+        hnid = -1
+        if "_hatchet_nid" in child_dict['metrics']:
+            hnid = child_dict['metrics']["_hatchet_nid"]
 
         frame = Frame(child_dict["frame"])
-        if "duplicate" not in child_dict:
-            hnode = Node(frame, hparent)
+        if hnid not in seen_nids:
+            hnode = Node(frame, hparent, hnid=hnid)
 
             # depending on the node type, the name may not be in the frame
             node_name = child_dict["frame"].get("name")
@@ -91,38 +92,34 @@ class LiteralReader:
 
             node_dicts.append(node_dict)
             frame_to_node_dict[frame] = hnode
-        elif "duplicate" in child_dict:
+
+            if hnid != -1:
+                seen_nids.append(hnid)
+
+        else:
             hnode = frame_to_node_dict.get(frame)
-            if not hnode:
-                hnode = Node(frame, hparent)
-
-                # depending on the node type, the name may not be in the frame
-                node_name = child_dict["frame"].get("name")
-                if not node_name:
-                    node_name = child_dict["name"]
-
-                node_dict = dict(
-                    {"node": hnode, "name": node_name}, **child_dict["metrics"]
-                )
-                node_dicts.append(node_dict)
-                frame_to_node_dict[frame] = hnode
 
         hparent.add_child(hnode)
 
         if "children" in child_dict:
             for child in child_dict["children"]:
-                self.parse_node_literal(frame_to_node_dict, node_dicts, child, hnode)
+                self.parse_node_literal(frame_to_node_dict, node_dicts, child, hnode, seen_nids)
 
     def read(self):
         list_roots = []
         node_dicts = []
         frame_to_node_dict = {}
         frame = None
+        seen_nids = []
+        hnid = -1
 
         # start with creating a node_dict for each root
         for i in range(len(self.graph_dict)):
+            if "_hatchet_nid" in self.graph_dict[i]["metrics"]:
+                hnid =  self.graph_dict[i]["metrics"]["_hatchet_nid"]
+                seen_nids.append(hnid)
             frame = Frame(self.graph_dict[i]["frame"])
-            graph_root = Node(frame, None)
+            graph_root = Node(frame, None, hnid=hnid)
 
             # depending on the node type, the name may not be in the frame
             node_name = self.graph_dict[i]["frame"].get("name")
@@ -141,11 +138,16 @@ class LiteralReader:
             if "children" in self.graph_dict[i]:
                 for child in self.graph_dict[i]["children"]:
                     self.parse_node_literal(
-                        frame_to_node_dict, node_dicts, child, graph_root
+                        frame_to_node_dict, node_dicts, child, graph_root, seen_nids
                     )
 
         graph = Graph(list_roots)
-        graph.enumerate_traverse()
+
+        # test if nids are already loaded
+        if -1 in [n._hatchet_nid for n in graph.traverse()]:
+            graph.enumerate_traverse()
+        else:
+            graph.enumerate_depth()
 
         exc_metrics = []
         inc_metrics = []

--- a/hatchet/readers/literal_reader.py
+++ b/hatchet/readers/literal_reader.py
@@ -74,7 +74,8 @@ class LiteralReader:
         """
 
         # pull out _hatchet_nid if it exists
-        # it wont interfere with current operations yet this way
+        # so it will not be inserted into dataframe like 
+        # a normal metric
         hnid = -1
         if "_hatchet_nid" in child_dict["metrics"]:
             hnid = child_dict["metrics"]["_hatchet_nid"]

--- a/hatchet/readers/literal_reader.py
+++ b/hatchet/readers/literal_reader.py
@@ -66,7 +66,9 @@ class LiteralReader:
         """
         self.graph_dict = graph_dict
 
-    def parse_node_literal(self, frame_to_node_dict, node_dicts, child_dict, hparent, seen_nids):
+    def parse_node_literal(
+        self, frame_to_node_dict, node_dicts, child_dict, hparent, seen_nids
+    ):
         """Create node_dict for one node and then call the function
         recursively on all children.
         """
@@ -74,8 +76,8 @@ class LiteralReader:
         # pull out _hatchet_nid if it exists
         # it wont interfere with current operations yet this way
         hnid = -1
-        if "_hatchet_nid" in child_dict['metrics']:
-            hnid = child_dict['metrics']["_hatchet_nid"]
+        if "_hatchet_nid" in child_dict["metrics"]:
+            hnid = child_dict["metrics"]["_hatchet_nid"]
 
         frame = Frame(child_dict["frame"])
         if hnid not in seen_nids:
@@ -103,7 +105,9 @@ class LiteralReader:
 
         if "children" in child_dict:
             for child in child_dict["children"]:
-                self.parse_node_literal(frame_to_node_dict, node_dicts, child, hnode, seen_nids)
+                self.parse_node_literal(
+                    frame_to_node_dict, node_dicts, child, hnode, seen_nids
+                )
 
     def read(self):
         list_roots = []
@@ -116,7 +120,7 @@ class LiteralReader:
         # start with creating a node_dict for each root
         for i in range(len(self.graph_dict)):
             if "_hatchet_nid" in self.graph_dict[i]["metrics"]:
-                hnid =  self.graph_dict[i]["metrics"]["_hatchet_nid"]
+                hnid = self.graph_dict[i]["metrics"]["_hatchet_nid"]
                 seen_nids.append(hnid)
             frame = Frame(self.graph_dict[i]["frame"])
             graph_root = Node(frame, None, hnid=hnid)

--- a/hatchet/readers/literal_reader.py
+++ b/hatchet/readers/literal_reader.py
@@ -70,6 +70,12 @@ class LiteralReader:
         """Create node_dict for one node and then call the function
         recursively on all children.
         """
+
+        # pull out _hatchet_nid if it exists
+        # it wont interfere with current operations yet this way
+        if "_hatchet_nid" in node_dicts:
+            node_dicts.pop("_hatchet_nid")
+
         frame = Frame(child_dict["frame"])
         if "duplicate" not in child_dict:
             hnode = Node(frame, hparent)

--- a/hatchet/readers/literal_reader.py
+++ b/hatchet/readers/literal_reader.py
@@ -74,8 +74,8 @@ class LiteralReader:
         """
 
         # pull out _hatchet_nid if it exists
-        # so it will not be inserted into dataframe like 
-        # a normal metric
+        # so it will not be inserted into
+        # dataframe like a normal metric
         hnid = -1
         if "_hatchet_nid" in child_dict["metrics"]:
             hnid = child_dict["metrics"]["_hatchet_nid"]

--- a/hatchet/tests/conftest.py
+++ b/hatchet/tests/conftest.py
@@ -671,23 +671,35 @@ def mock_graph_literal_duplicates():
     graph_dict = [
         {
             "frame": {"name": "a", "type": "function"},
-            "metrics": {"time (inc)": 130.0, "time": 0.0},
+            "metrics": {"time (inc)": 130.0, "time": 0.0, "_hatchet_nid": 0},
             "children": [
                 {
                     "frame": {"name": "b", "type": "function"},
-                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                    "metrics": {"time (inc)": 20.0, "time": 5.0, "_hatchet_nid": 1},
                     "children": [
                         {
                             "frame": {"name": "d", "type": "function"},
-                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                            "metrics": {
+                                "time (inc)": 20.0,
+                                "time": 5.0,
+                                "_hatchet_nid": 2,
+                            },
                             "children": [
                                 {
                                     "frame": {"name": "e", "type": "function"},
-                                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                                    "metrics": {
+                                        "time (inc)": 20.0,
+                                        "time": 5.0,
+                                        "_hatchet_nid": 3,
+                                    },
                                 },
                                 {
                                     "frame": {"name": "f", "type": "function"},
-                                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                                    "metrics": {
+                                        "time (inc)": 20.0,
+                                        "time": 5.0,
+                                        "_hatchet_nid": 4,
+                                    },
                                 },
                             ],
                         }
@@ -695,17 +707,23 @@ def mock_graph_literal_duplicates():
                 },
                 {
                     "frame": {"name": "c", "type": "function"},
-                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                    "metrics": {"time (inc)": 20.0, "time": 5.0, "_hatchet_nid": 5},
                     "children": [
                         {
                             "frame": {"name": "a", "type": "function"},
-                            "duplicate": "True",
-                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                            "metrics": {
+                                "time (inc)": 130.0,
+                                "time": 5.0,
+                                "_hatchet_nid": 0,
+                            },
                         },
                         {
                             "frame": {"name": "d", "type": "function"},
-                            "duplicate": "True",
-                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                            "metrics": {
+                                "time (inc)": 20.0,
+                                "time": 5.0,
+                                "_hatchet_nid": 2,
+                            },
                         },
                     ],
                 },
@@ -719,29 +737,39 @@ def mock_graph_literal_duplicates():
 @pytest.fixture
 def mock_graph_literal_duplicate_first():
     """Creates a mock tree with node with duplicate first."""
+    """Creates a mock tree with duplicate nodes."""
     graph_dict = [
         {
             "frame": {"name": "a", "type": "function"},
-            "duplicate": True,
-            "metrics": {"time (inc)": 130.0, "time": 0.0},
+            "metrics": {"time (inc)": 130.0, "time": 0.0, "_hatchet_nid": 0},
             "children": [
                 {
                     "frame": {"name": "b", "type": "function"},
-                    "duplicate": True,
-                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                    "metrics": {"time (inc)": 20.0, "time": 5.0, "_hatchet_nid": 1},
                     "children": [
                         {
                             "frame": {"name": "d", "type": "function"},
-                            "duplicate": True,
-                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                            "metrics": {
+                                "time (inc)": 20.0,
+                                "time": 5.0,
+                                "_hatchet_nid": 2,
+                            },
                             "children": [
                                 {
                                     "frame": {"name": "e", "type": "function"},
-                                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                                    "metrics": {
+                                        "time (inc)": 20.0,
+                                        "time": 5.0,
+                                        "_hatchet_nid": 3,
+                                    },
                                 },
                                 {
                                     "frame": {"name": "f", "type": "function"},
-                                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                                    "metrics": {
+                                        "time (inc)": 20.0,
+                                        "time": 5.0,
+                                        "_hatchet_nid": 4,
+                                    },
                                 },
                             ],
                         }
@@ -749,17 +777,23 @@ def mock_graph_literal_duplicate_first():
                 },
                 {
                     "frame": {"name": "c", "type": "function"},
-                    "metrics": {"time (inc)": 20.0, "time": 5.0},
+                    "metrics": {"time (inc)": 20.0, "time": 5.0, "_hatchet_nid": 5},
                     "children": [
                         {
                             "frame": {"name": "a", "type": "function"},
-                            "duplicate": "True",
-                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                            "metrics": {
+                                "time (inc)": 130.0,
+                                "time": 5.0,
+                                "_hatchet_nid": 0,
+                            },
                         },
                         {
                             "frame": {"name": "d", "type": "function"},
-                            "duplicate": "True",
-                            "metrics": {"time (inc)": 20.0, "time": 5.0},
+                            "metrics": {
+                                "time (inc)": 20.0,
+                                "time": 5.0,
+                                "_hatchet_nid": 2,
+                            },
                         },
                     ],
                 },

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1030,3 +1030,28 @@ def test_show_metric_columns(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
 
     assert sorted(gf.show_metric_columns()) == sorted(["time", "time (inc)"])
+
+
+def test_to_literal_node_ids():
+    r"""Test to_literal and from_literal with ids on a graph with cycles,
+        multiple parents and children.
+
+        a --
+       / \ /
+      b   c
+       \ /
+        d
+       / \
+      e   f
+    """
+
+    a = Node(Frame(name="a"))
+    d = Node(Frame(name="d"))
+    gf = GraphFrame.from_lists([a, ["b", [d]], ["c", [d, ["e"], ["f"]], [a]]])
+    lit_list = gf.to_literal()
+
+    gf2 = gf.from_literal(lit_list)
+    lit_list2 = gf2.to_literal()
+
+    assert lit_list == lit_list2
+>>>>>>> Fixed literal_reader to optionally support node_ids in literal

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1054,4 +1054,3 @@ def test_to_literal_node_ids():
     lit_list2 = gf2.to_literal()
 
     assert lit_list == lit_list2
->>>>>>> Fixed literal_reader to optionally support node_ids in literal


### PR DESCRIPTION
Added a line of code which added node ids to the `to_literal` output. They are a member of the `metrics` sub-dictionary right now. Per my suggestion in Issue #316. One change was made to literal_reader to ensure that they are popped off and unused in the reader so it doesn't interfere with the workings of hatchet.

Fixes #316 