### PR TITLE
Fix error where the same function in different files would clobber nodes in cprofiles

### DIFF
--- a/hatchet/readers/cprofile_reader.py
+++ b/hatchet/readers/cprofile_reader.py
@@ -70,7 +70,7 @@ class CProfileReader:
 
             # lookup stat data for source here
             fn_stats = stats_dict[fn_data]
-            self._add_node_metadata(fn_name, fn_data, fn_stats, fn_hnode)
+            self._add_node_metadata(u_fn_name, fn_data, fn_stats, fn_hnode)
 
         return fn_hnode
 


### PR DESCRIPTION
The previous version was using the function name as a key for the `name_to_dict` in cProfile profiles -- this had the effect that identically-named functions would collide, clobbering the previous entry.

Using the `u_fn_name` prevents these collisions.