### PR TITLE
Add a MPI-aware reader for cprofile

### DIFF
--- a/hatchet/readers/cprofile_reader.py
+++ b/hatchet/readers/cprofile_reader.py
@@ -76,16 +76,12 @@ class CProfileReaderBase(object):
         graph = Graph(roots)
         graph.enumerate_traverse()
 
-        dataframe = pd.DataFrame.from_dict(
-            data=list(self.name_to_dict.values())
-        )
+        dataframe = pd.DataFrame.from_dict(data=list(self.name_to_dict.values()))
         index = ["node"]
         dataframe.set_index(index, inplace=True)
         dataframe.sort_index(inplace=True)
 
-        return hatchet.graphframe.GraphFrame(
-            graph, dataframe, ["time"], ["time (inc)"]
-        )
+        return hatchet.graphframe.GraphFrame(graph, dataframe, ["time"], ["time (inc)"])
 
 
 class CProfileReader(CProfileReaderBase):
@@ -146,9 +142,7 @@ class CProfileReader(CProfileReaderBase):
         # We iterate through each function/node in our stats dict
         for dst_module_data, dst_stats in stats_dict.items():
             dst_name = dst_module_data[NameData.FNCNAME]
-            dst_hnode = self._create_node_and_row(
-                dst_module_data, dst_name, stats_dict
-            )
+            dst_hnode = self._create_node_and_row(dst_module_data, dst_name, stats_dict)
 
             # get all parents of our current destination node
             # create source nodes and link with destination node
@@ -208,7 +202,7 @@ class MPICProfileReader(CProfileReaderBase):
 
     def _add_node_metadata(self, stat_name, stat_module_data, rank, stats, hnode):
         """
-        Puts all the metadata associated with a node in a dictionary to insert 
+        Puts all the metadata associated with a node in a dictionary to insert
         into pandas.
         """
         node_dict = {

--- a/hatchet/readers/cprofile_reader.py
+++ b/hatchet/readers/cprofile_reader.py
@@ -43,12 +43,37 @@ class NameData:
     FNCNAME = 2
 
 
-class CProfileReader:
-    def __init__(self, filename):
-        self.pstats_file = filename
-
+class CProfileReaderBase(object):
+    def __init__(self):
         self.name_to_hnode = {}
         self.name_to_dict = {}
+
+    def _create_node_and_row(self, fn_data, fn_name, stats_dict):
+        """
+        Description: Takes a profiled function as specified in a pstats file
+        and creates a node for it and adds a new line of metadata to our
+        dataframe if it does not exist.
+        """
+        raise NotImplementedError("_create_node_and_row")
+
+    def _get_src(self, stat):
+        """Gets the source/parent of our current desitnation node"""
+        return stat[StatData.SRCNODE]
+
+    def _add_node_metadata(self, stat_name, stat_module_data, stats, hnode):
+        """Puts all the metadata associated with a node in a dictionary to insert into pandas."""
+        raise NotImplementedError("_add_node_metadata")
+
+    def create_graph(self):
+        """Performs the creation of our node graph"""
+        raise NotImplementedError("create_graph")
+
+
+class CProfileReader(CProfileReaderBase):
+    def __init__(self, filename):
+        super().__init__()
+        self.pstats_file = filename
+
 
     def _create_node_and_row(self, fn_data, fn_name, stats_dict):
         """
@@ -73,10 +98,6 @@ class CProfileReader:
             self._add_node_metadata(u_fn_name, fn_data, fn_stats, fn_hnode)
 
         return fn_hnode
-
-    def _get_src(self, stat):
-        """Gets the source/parent of our current desitnation node"""
-        return stat[StatData.SRCNODE]
 
     def _add_node_metadata(self, stat_name, stat_module_data, stats, hnode):
         """Puts all the metadata associated with a node in a dictionary to insert into pandas."""


### PR DESCRIPTION
I have been working on a way of analyzing cProfile data generated by separate MPI ranks. For example, one of the projects I work with already has some cProfile code built into it, and each rank will produce a `cpu_{COMM_WORLD.Get_rank()}.prof` file. Now I want to use hatchet to look for load-imbalances and performance variability between each rank.

I have two sample cProfile files here: https://bitbucket.org/jpblaschke/mpi-cprofile/downloads/ which can be read using:
```python
from hatchet.readers.cprofile_reader import MPICProfileReader

pstat_root = # path to .prof files
#Note: the list passed to MPICProfileReader needs to be in order of rank -- don't use Glob without sorting!
gf = MPICProfileReader(
    [
        join(pstat_root, "cpu_0.prof"),
        join(pstat_root,  "cpu_1.prof"),
    ]
).read()
```

Let me know what you think. I was initially experimenting with creating the graphs separately for each file, but I couldn't get them merged without a bunch of `_missing_nodes`.

In care you want to take a look @cscully-allison @jrmadsen @bhatele 