### PR TITLE
add gf.show_metric_columns() to query dataframe columns

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -61,7 +61,7 @@ class ConsoleRenderer:
 
         if self.metric not in dataframe.columns:
             raise KeyError(
-                "metric_column={} does not exist in the dataframe, please select a valid column. See a list of the available metrics with gf.show_metric_columns().".format(
+                "metric_column={} does not exist in the dataframe, please select a valid column. See a list of the available metrics with GraphFrame.show_metric_columns().".format(
                     self.metric
                 )
             )

--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -61,7 +61,7 @@ class ConsoleRenderer:
 
         if self.metric not in dataframe.columns:
             raise KeyError(
-                "metric_column={} does not exist in the dataframe, please select a valid column.".format(
+                "metric_column={} does not exist in the dataframe, please select a valid column. See a list of the available metrics with gf.show_metric_columns().".format(
                     self.metric
                 )
             )

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -571,7 +571,7 @@ class GraphFrame:
 
     def show_metric_columns(self):
         """Returns a list of dataframe column labels."""
-        return list(self.dataframe.columns)
+        return list(self.exc_metrics + self.inc_metrics)
 
     def unify(self, other):
         """Returns a unified graphframe.

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -569,6 +569,10 @@ class GraphFrame:
         self.inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
         self.subgraph_sum(self.exc_metrics, self.inc_metrics)
 
+    def show_metric_columns(self):
+        """Returns a list of dataframe column labels."""
+        return list(self.dataframe.columns)
+
     def unify(self, other):
         """Returns a unified graphframe.
 

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1029,4 +1029,4 @@ def test_output_with_cycle_graphs():
 def test_show_metric_columns(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
 
-    assert sorted(gf.show_metric_columns()) == sorted(["name", "time", "time (inc)"])
+    assert sorted(gf.show_metric_columns()) == sorted(["time", "time (inc)"])

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1024,3 +1024,9 @@ def test_output_with_cycle_graphs():
     assert treeout.count("d") == 2
     assert treeout.count("e") == 1
     assert treeout.count("f") == 1
+
+
+def test_show_metric_columns(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+
+    assert sorted(gf.show_metric_columns()) == sorted(["name", "time", "time (inc)"])


### PR DESCRIPTION
- introduces a high-level API to get dataframe columns
- add a hint to tree visualization error if metric_column is not a valid
  dataframe column to indicate how a user can determine which metric columns
  are valid