### PR TITLE
New Compound Queries Feature for Query Language

### DIFF
--- a/hatchet/__init__.py
+++ b/hatchet/__init__.py
@@ -7,4 +7,4 @@
 # flake8: noqa: F401
 
 from .graphframe import GraphFrame
-from .query_matcher import QueryMatcher
+from .query import QueryMatcher

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -15,7 +15,7 @@ import multiprocess as mp
 from .node import Node
 from .graph import Graph
 from .frame import Frame
-from .query_matcher import QueryMatcher
+from .query import AbstractQuery, QueryMatcher
 from .external.console import ConsoleRenderer
 from .util.dot import trees_to_dot
 from .util.deprecated import deprecated_params
@@ -360,7 +360,8 @@ class GraphFrame:
                 filtered_rows = dataframe_copy.apply(filter_obj, axis=1)
                 filtered_df = dataframe_copy[filtered_rows]
 
-        elif isinstance(filter_obj, list) or isinstance(filter_obj, QueryMatcher):
+        # elif isinstance(filter_obj, list) or isinstance(filter_obj, QueryMatcher):
+        elif isinstance(filter_obj, list) or issubclass(type(filter_obj), AbstractQuery):
             # use a callpath query to apply the filter
             query = filter_obj
             if isinstance(filter_obj, list):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -361,14 +361,17 @@ class GraphFrame:
                 filtered_df = dataframe_copy[filtered_rows]
 
         # elif isinstance(filter_obj, list) or isinstance(filter_obj, QueryMatcher):
-        elif isinstance(filter_obj, list) or issubclass(type(filter_obj), AbstractQuery):
+        elif isinstance(filter_obj, list) or issubclass(
+            type(filter_obj), AbstractQuery
+        ):
             # use a callpath query to apply the filter
             query = filter_obj
             if isinstance(filter_obj, list):
                 query = QueryMatcher(filter_obj)
             query_matches = query.apply(self)
-            match_set = list(set().union(*query_matches))
-            filtered_df = dataframe_copy.loc[dataframe_copy["node"].isin(match_set)]
+            # match_set = list(set().union(*query_matches))
+            # filtered_df = dataframe_copy.loc[dataframe_copy["node"].isin(match_set)]
+            filtered_df = dataframe_copy.loc[dataframe_copy["node"].isin(query_matches)]
         else:
             raise InvalidFilter(
                 "The argument passed to filter must be a callable, a query path list, or a QueryMatcher object."

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -9,7 +9,7 @@ import re
 
 from hatchet import GraphFrame
 from hatchet.node import traversal_order
-from hatchet.query_matcher import QueryMatcher, InvalidQueryFilter, InvalidQueryPath
+from hatchet.query import QueryMatcher, InvalidQueryFilter, InvalidQueryPath
 
 
 def test_construct_high_level_api():

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -9,7 +9,19 @@ import re
 
 from hatchet import GraphFrame
 from hatchet.node import traversal_order
-from hatchet.query import QueryMatcher, InvalidQueryFilter, InvalidQueryPath
+from hatchet.query import (
+    QueryMatcher,
+    InvalidQueryFilter,
+    InvalidQueryPath,
+    AbstractQuery,
+    NaryQuery,
+    AndQuery,
+    OrQuery,
+    XorQuery,
+    IntersectionQuery,
+    UnionQuery,
+    SymDifferenceQuery,
+)
 
 
 def test_construct_high_level_api():
@@ -329,65 +341,84 @@ def test_apply(mock_graph_literal):
     ]
     root = gf.graph.roots[0]
     match = [
-        [
-            root,
-            root.children[1],
-            root.children[1].children[0],
-            root.children[1].children[0].children[0],
-            root.children[1].children[0].children[0].children[1],
-        ],
-        [
-            root.children[1],
-            root.children[1].children[0],
-            root.children[1].children[0].children[0],
-            root.children[1].children[0].children[0].children[1],
-        ],
+        root,
+        root.children[1],
+        root.children[1].children[0],
+        root.children[1].children[0].children[0],
+        root.children[1].children[0].children[0].children[1],
+        # Old-style return value of apply
+        # [
+        #     root,
+        #     root.children[1],
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[1],
+        # ],
+        # [
+        #     root.children[1],
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[1],
+        # ],
     ]
     query = QueryMatcher(path)
 
-    assert query.apply(gf) == match
+    assert sorted(query.apply(gf)) == sorted(match)
 
     path = [{"time (inc)": ">= 30.0"}, ".", {"name": "bar"}, "*"]
     match = [
-        [
-            root.children[1].children[0],
-            root.children[1].children[0].children[0],
-            root.children[1].children[0].children[0].children[0],
-            root.children[1].children[0].children[0].children[0].children[0],
-        ],
-        [
-            root.children[1].children[0],
-            root.children[1].children[0].children[0],
-            root.children[1].children[0].children[0].children[0],
-            root.children[1].children[0].children[0].children[0].children[1],
-        ],
+        root.children[1].children[0],
+        root.children[1].children[0].children[0],
+        root.children[1].children[0].children[0].children[0],
+        root.children[1].children[0].children[0].children[0].children[0],
+        root.children[1].children[0].children[0].children[0].children[1],
+        # Old-style return value of apply
+        # [
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[0].children[0],
+        # ],
+        # [
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[0].children[1],
+        # ],
     ]
     query = QueryMatcher(path)
-    assert query.apply(gf) == match
+    assert sorted(query.apply(gf)) == sorted(match)
 
     path = [{"name": "foo"}, {"name": "bar"}, {"time": 5.0}]
-    match = [[root, root.children[0], root.children[0].children[0]]]
+    # match = [[root, root.children[0], root.children[0].children[0]]]
+    match = [root, root.children[0], root.children[0].children[0]]
     query = QueryMatcher(path)
-    assert query.apply(gf) == match
+    assert sorted(query.apply(gf)) == sorted(match)
 
     path = [{"name": "foo"}, {"name": "qux"}, ("+", {"time (inc)": "> 15.0"})]
     match = [
-        [
-            root,
-            root.children[1],
-            root.children[1].children[0],
-            root.children[1].children[0].children[0],
-            root.children[1].children[0].children[0].children[0],
-        ],
-        [
-            root,
-            root.children[1],
-            root.children[1].children[0],
-            root.children[1].children[0].children[0],
-        ],
+        root,
+        root.children[1],
+        root.children[1].children[0],
+        root.children[1].children[0].children[0],
+        root.children[1].children[0].children[0].children[0],
+        # Old-style return value of apply
+        # [
+        #     root,
+        #     root.children[1],
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[0],
+        # ],
+        # [
+        #     root,
+        #     root.children[1],
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        # ],
     ]
     query = QueryMatcher(path)
-    assert query.apply(gf) == match
+    assert sorted(query.apply(gf)) == sorted(match)
 
     path = [{"name": "this"}, ("*", {"name": "is"}), {"name": "nonsense"}]
 
@@ -461,6 +492,7 @@ def test_apply(mock_graph_literal):
         ],
         [gf.graph.roots[1].children[0], gf.graph.roots[1].children[0].children[1]],
     ]
+    match = list(set().union(*match))
     query = QueryMatcher(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
@@ -490,8 +522,9 @@ def test_apply_indices(calc_pi_hpct_db):
             main.children[1].children[0].children[0],
         ],
     ]
+    matches = list(set().union(*matches))
     query = QueryMatcher(path)
-    assert query.apply(gf) == matches
+    assert sorted(query.apply(gf)) == sorted(matches)
 
     gf.drop_index_levels()
     assert query.apply(gf) == matches
@@ -501,8 +534,9 @@ def test_high_level_depth(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
     query = QueryMatcher([("*", {"depth": 1})])
     roots = gf.graph.roots
-    matches = [[c] for r in roots for c in r.children]
-    assert query.apply(gf) == matches
+    # matches = [[c] for r in roots for c in r.children]
+    matches = [c for r in roots for c in r.children]
+    assert sorted(query.apply(gf)) == sorted(matches)
 
     query = QueryMatcher([("*", {"depth": "<= 2"})])
     matches = [
@@ -528,6 +562,7 @@ def test_high_level_depth(mock_graph_literal):
         [roots[1].children[0], roots[1].children[0].children[1]],
         [roots[1].children[0].children[1]],
     ]
+    matches = list(set().union(*matches))
     assert sorted(query.apply(gf)) == sorted(matches)
 
     with pytest.raises(InvalidQueryFilter):
@@ -547,10 +582,12 @@ def test_high_level_hatchet_nid(mock_graph_literal):
         [root.children[0], root.children[0].children[1]],
         [root.children[0].children[1]],
     ]
+    matches = list(set().union(*matches))
     assert sorted(query.apply(gf)) == sorted(matches)
 
     query = QueryMatcher([{"node_id": 0}])
-    assert query.apply(gf) == [[gf.graph.roots[0]]]
+    # assert query.apply(gf) == [[gf.graph.roots[0]]]
+    assert query.apply(gf) == [gf.graph.roots[0]]
 
     with pytest.raises(InvalidQueryFilter):
         query = QueryMatcher([{"node_id": "hello"}])
@@ -570,10 +607,12 @@ def test_high_level_depth_index_levels(calc_pi_hpct_db):
         [root.children[0], root.children[0].children[1]],
         [root.children[0].children[1]],
     ]
+    matches = list(set().union(*matches))
     assert sorted(query.apply(gf)) == sorted(matches)
 
     query = QueryMatcher([("*", {"depth": 0})])
-    matches = [[root]]
+    # matches = [[root]]
+    matches = [root]
     assert query.apply(gf) == matches
 
     with pytest.raises(InvalidQueryFilter):
@@ -593,10 +632,12 @@ def test_high_level_node_id_index_levels(calc_pi_hpct_db):
         [root.children[0], root.children[0].children[0]],
         [root.children[0].children[0]],
     ]
+    matches = list(set().union(*matches))
     assert sorted(query.apply(gf)) == sorted(matches)
 
     query = QueryMatcher([("*", {"node_id": 0})])
-    matches = [[root]]
+    # matches = [[root]]
+    matches = [root]
     assert query.apply(gf) == matches
 
     with pytest.raises(InvalidQueryFilter):
@@ -658,4 +699,190 @@ def test_high_level_multi_condition_one_attribute(mock_graph_literal):
         [roots[1], roots[1].children[0]],
         [roots[1].children[0]],
     ]
+    matches = list(set().union(*matches))
     assert sorted(query.apply(gf)) == sorted(matches)
+
+
+def test_query_matcher_is_abstract_query():
+    assert issubclass(QueryMatcher, AbstractQuery)
+
+
+def test_nary_query_is_abstract_query():
+    assert issubclass(NaryQuery, AbstractQuery)
+
+
+def test_and_query_is_nary_query():
+    assert issubclass(AndQuery, NaryQuery)
+
+
+def test_or_query_is_nary_query():
+    assert issubclass(OrQuery, NaryQuery)
+
+
+def test_xor_query_is_nary_query():
+    assert issubclass(XorQuery, NaryQuery)
+
+
+def test_nary_query_high_level_construction(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query1 = [("*", {"time (inc)": [">= 20", "<= 60"]})]
+    query2 = [("*", {"time (inc)": ">= 60"})]
+    q1_node = gf.graph.roots[0].children[1].children[0].children[0]
+    q2_node = gf.graph.roots[0]
+    compound_query = AndQuery(query1, query2)
+    assert compound_query.subqueries[0].query_pattern[0][0] == "*"
+    assert compound_query.subqueries[0].query_pattern[0][1](gf.dataframe.loc[q1_node])
+    assert not compound_query.subqueries[0].query_pattern[0][1](
+        gf.dataframe.loc[q2_node]
+    )
+    assert compound_query.subqueries[1].query_pattern[0][0] == "*"
+    assert compound_query.subqueries[1].query_pattern[0][1](gf.dataframe.loc[q2_node])
+    assert not compound_query.subqueries[1].query_pattern[0][1](
+        gf.dataframe.loc[q1_node]
+    )
+
+
+def test_nary_query_low_level_construction(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query1 = QueryMatcher().match(
+        "*", lambda x: x["time (inc)"] >= 20 and x["time (inc)"] <= 60
+    )
+    query2 = QueryMatcher().match("*", lambda x: x["time (inc)"] >= 60)
+    q1_node = gf.graph.roots[0].children[1].children[0].children[0]
+    q2_node = gf.graph.roots[0]
+    compound_query = AndQuery(query1, query2)
+    assert compound_query.subqueries[0].query_pattern[0][0] == "*"
+    assert compound_query.subqueries[0].query_pattern[0][1](gf.dataframe.loc[q1_node])
+    assert not compound_query.subqueries[0].query_pattern[0][1](
+        gf.dataframe.loc[q2_node]
+    )
+    assert compound_query.subqueries[1].query_pattern[0][0] == "*"
+    assert compound_query.subqueries[1].query_pattern[0][1](gf.dataframe.loc[q2_node])
+    assert not compound_query.subqueries[1].query_pattern[0][1](
+        gf.dataframe.loc[q1_node]
+    )
+
+
+def test_nary_query_mixed_level_construction(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query1 = [("*", {"time (inc)": [">= 20", "<= 60"]})]
+    query2 = QueryMatcher().match("*", lambda x: x["time (inc)"] >= 60)
+    q1_node = gf.graph.roots[0].children[1].children[0].children[0]
+    q2_node = gf.graph.roots[0]
+    compound_query = AndQuery(query1, query2)
+    assert compound_query.subqueries[0].query_pattern[0][0] == "*"
+    assert compound_query.subqueries[0].query_pattern[0][1](gf.dataframe.loc[q1_node])
+    assert not compound_query.subqueries[0].query_pattern[0][1](
+        gf.dataframe.loc[q2_node]
+    )
+    assert compound_query.subqueries[1].query_pattern[0][0] == "*"
+    assert compound_query.subqueries[1].query_pattern[0][1](gf.dataframe.loc[q2_node])
+    assert not compound_query.subqueries[1].query_pattern[0][1](
+        gf.dataframe.loc[q1_node]
+    )
+
+
+def test_and_query(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query1 = [("*", {"time (inc)": [">= 20", "<= 60"]})]
+    query2 = [("*", {"time (inc)": ">= 60"})]
+    compound_query = AndQuery(query1, query2)
+    roots = gf.graph.roots
+    matches = [
+        roots[0].children[1],
+        roots[0].children[1].children[0],
+    ]
+    assert sorted(compound_query.apply(gf)) == sorted(matches)
+
+
+def test_intersection_query(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query1 = [("*", {"time (inc)": [">= 20", "<= 60"]})]
+    query2 = [("*", {"time (inc)": ">= 60"})]
+    compound_query = IntersectionQuery(query1, query2)
+    roots = gf.graph.roots
+    matches = [
+        roots[0].children[1],
+        roots[0].children[1].children[0],
+    ]
+    assert sorted(compound_query.apply(gf)) == sorted(matches)
+
+
+def test_or_query(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query1 = [("*", {"time (inc)": 5.0})]
+    query2 = [("*", {"time (inc)": 10.0})]
+    compound_query = OrQuery(query1, query2)
+    roots = gf.graph.roots
+    matches = [
+        roots[0].children[0].children[0],
+        roots[0].children[0].children[1],
+        roots[0].children[1].children[0].children[0].children[0].children[0],
+        roots[0].children[1].children[0].children[0].children[0].children[1],
+        roots[0].children[1].children[0].children[0].children[1],
+        roots[0].children[2].children[0].children[0],
+        roots[0].children[2].children[0].children[1].children[0].children[0],
+        roots[1].children[0].children[0],
+        roots[1].children[0].children[1],
+    ]
+    assert sorted(compound_query.apply(gf)) == sorted(matches)
+
+
+def test_union_query(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query1 = [("*", {"time (inc)": 5.0})]
+    query2 = [("*", {"time (inc)": 10.0})]
+    compound_query = UnionQuery(query1, query2)
+    roots = gf.graph.roots
+    matches = [
+        roots[0].children[0].children[0],
+        roots[0].children[0].children[1],
+        roots[0].children[1].children[0].children[0].children[0].children[0],
+        roots[0].children[1].children[0].children[0].children[0].children[1],
+        roots[0].children[1].children[0].children[0].children[1],
+        roots[0].children[2].children[0].children[0],
+        roots[0].children[2].children[0].children[1].children[0].children[0],
+        roots[1].children[0].children[0],
+        roots[1].children[0].children[1],
+    ]
+    assert sorted(compound_query.apply(gf)) == sorted(matches)
+
+
+def test_xor_query(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query1 = [("*", {"time (inc)": [">= 5.0", "<= 10.0"]})]
+    query2 = [("*", {"time (inc)": 10.0})]
+    compound_query = XorQuery(query1, query2)
+    roots = gf.graph.roots
+    matches = [
+        roots[0].children[0].children[0],
+        # roots[0].children[0].children[1],
+        roots[0].children[1].children[0].children[0].children[0].children[0],
+        # roots[0].children[1].children[0].children[0].children[0].children[1],
+        # roots[0].children[1].children[0].children[0].children[1],
+        roots[0].children[2].children[0].children[0],
+        roots[0].children[2].children[0].children[1].children[0].children[0],
+        roots[1].children[0].children[0],
+        # roots[1].children[0].children[1],
+    ]
+    assert sorted(compound_query.apply(gf)) == sorted(matches)
+
+
+def test_sym_diff_query(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    query1 = [("*", {"time (inc)": [">= 5.0", "<= 10.0"]})]
+    query2 = [("*", {"time (inc)": 10.0})]
+    compound_query = SymDifferenceQuery(query1, query2)
+    roots = gf.graph.roots
+    matches = [
+        roots[0].children[0].children[0],
+        # roots[0].children[0].children[1],
+        roots[0].children[1].children[0].children[0].children[0].children[0],
+        # roots[0].children[1].children[0].children[0].children[0].children[1],
+        # roots[0].children[1].children[0].children[0].children[1],
+        roots[0].children[2].children[0].children[0],
+        roots[0].children[2].children[0].children[1].children[0].children[0],
+        roots[1].children[0].children[0],
+        # roots[1].children[0].children[1],
+    ]
+    assert sorted(compound_query.apply(gf)) == sorted(matches)


### PR DESCRIPTION
Resolves #332 

This PR is for a new query language feature that I came up with during a discussion with @cscully-allison.

The idea of this feature (which I'm calling Compound Queries) is to add new query classes to allow users to apply some operation to the results of one or more queries. For example, using this feature, a user could get the intersection of matched nodes returned by two different queries.

To achieve this, this PR does 6 things:
1. Changes the name of `query_matcher.py` to `query.py`, and updates Hatchet's internal imports accordingly (more of a QoL change; not specific to the feature)
2. Creates an `AbstractQuery` class to define the basic requirements for a query in Hatchet
3. Updates the existing `QueryMatcher` class so that it inherits from `AbstractQuery`
4. Adds a `NaryQuery` class (see below for details) as an initial abstract base class for compound queries
5. Adds `AndQuery`, `OrQuery`, `XorQuery`, `IntersectionQuery`, `UnionQuery`, and `SymDifferenceQuery` as provided implementations of compound queries for users
6. Changes the output of `QueryMatcher.apply` from a list of matched paths to a list of the nodes contained in the matched paths. This was done to enable the rest of the feature.

So, `query.py` (formerly `query_matcher.py`) now contains 9 main classes:
1. `AbstractQuery`: an interface that defines the basic requirements for a class to be a Query
2. `QueryMatcher`: the class that defines and performs single high-level and low-level Queries. Now inherits from `AbstractQuery`.
3. `NaryQuery`: an abstract base class that inherits from `AbstractQuery`. This class defines the requirements for a compound query that performs _N_ subqueries, collects the results, and performs some subclass-defined operation to merge the _N_ results into a single result.
4. `AndQuery`: a compound query that collects the intersection of subquery results. Inherits from `NaryQuery`.
5. `IntersectionQuery`: an alias for `AndQuery`
6. `OrQuery`: a compound query that collects the union of subquery results. Inherits from `NaryQuery`.
7. `UnionQuery`: an alias of `OrQuery`
8. `XorQuery`: a compound query that collects the symmetric difference of subquery results. Inherits from `NaryQuery`.
9. `SymDifferenceQuery`: an alias of `XorQuery`

Users can use the provided subclasses of `NaryQuery` out of the box. For example, if a user wanted to get all nodes with an inclusive time of 5 **or** 10, they could now use the following:
```python
import hatchet as ht

gf = # Create a GraphFrame here
query1 = [("*", {"time (inc)": 5.0})]
query2 = [("*", {"time (inc)": 10.0})]
compound_query = ht.query.OrQuery(query1, query2)
filtered_gf = gf.filter(compound_query)
```

All subclasses of `NaryQuery` can support any valid type of query (e.g., high-level, low-level, or compound) in their constructor. This allows users to chain compound queries together to perform more complex querying with just one call to `GraphFrame.filter`.

Additionally, thanks to the `AbstractQuery` class, users can create their own custom queries that can plug directly into Hatchet. So, this feature also allows users to extend the query language.