### PR TITLE
single front-end from_caliper API to load JSON-split or cali files

### DIFF
--- a/docs/basic_tutorial.rst
+++ b/docs/basic_tutorial.rst
@@ -66,7 +66,7 @@ follows:
 
   >>> import hatchet as ht
   >>> caliper_file = 'lulesh-annotation-profile-1core.json'
-  >>> gf = ht.GraphFrame.from_caliper_json(caliper_file)
+  >>> gf = ht.GraphFrame.from_caliper(caliper_file)
   >>>
 
 At this point, your input file (profile) has been loaded into Hatchet's data
@@ -322,8 +322,8 @@ two trees are initialized with a value of nan, and are colored in blue.
 
   >>> caliper_file_1core = 'lulesh-annotation-profile-1core.json'
   >>> caliper_file_64cores = 'lulesh-annotation-profile-64cores.json'
-  >>> gf = ht.GraphFrame.from_caliper_json(caliper_file_1core)
-  >>> gf2 = ht.GraphFrame.from_caliper_json(caliper_file_64cores)
+  >>> gf = ht.GraphFrame.from_caliper(caliper_file_1core)
+  >>> gf2 = ht.GraphFrame.from_caliper(caliper_file_64cores)
   >>> gf.drop_index_levels()
   >>> gf2.drop_index_levels()
   >>> gf3 = gf/gf2

--- a/docs/examples/read/caliper_cali_to_json.py
+++ b/docs/examples/read/caliper_cali_to_json.py
@@ -24,9 +24,9 @@ if __name__ == "__main__":
         [cali_query, "-q", query, cali_file], stdout=subprocess.PIPE
     )
 
-    # Use hatchet's ``from_caliper_json`` API with the resulting json-split.
+    # Use hatchet's ``from_caliper`` API with the resulting json-split.
     # The result is stored into Hatchet's GraphFrame.
-    gf = ht.GraphFrame.from_caliper_json(cali_json.stdout)
+    gf = ht.GraphFrame.from_caliper(cali_json.stdout)
 
     # Printout the DataFrame component of the GraphFrame.
     print(gf.dataframe)

--- a/docs/examples/read/caliper_json.py
+++ b/docs/examples/read/caliper_json.py
@@ -7,9 +7,9 @@ if __name__ == "__main__":
     # Path to caliper json-split file.
     json_file = "../../../hatchet/tests/data/caliper-cpi-json/cpi-callpath-profile.json"
 
-    # Use hatchet's ``from_caliper_json`` API with the resulting json-split.
+    # Use hatchet's ``from_caliper`` API with the resulting json-split.
     # The result is stored into Hatchet's GraphFrame.
-    gf = ht.GraphFrame.from_caliper_json(json_file)
+    gf = ht.GraphFrame.from_caliper(json_file)
 
     # Printout the DataFrame component of the GraphFrame.
     print(gf.dataframe)

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -68,7 +68,7 @@ HPCToolkit database directory that they want to analyze, they can use the
       gf = ht.GraphFrame.from_hpctoolkit(dirname)
 
 Similarly if the input file is a split-JSON output by Caliper, they can use
-the ``from_caliper_json`` method:
+the ``from_caliper`` method:
 
 .. code-block:: python
 
@@ -76,7 +76,7 @@ the ``from_caliper_json`` method:
 
   if __name__ == "__main__":
       filename = ("hatchet/tests/data/caliper-lulesh-json/lulesh-sample-annotation-profile.json")
-      gf = ht.GraphFrame.from_caliper_json(filename)
+      gf = ht.GraphFrame.from_caliper(filename)
 
 Examples of reading in other file formats can be found in
 :doc:`Analysis Examples <analysis_examples>`.

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -101,11 +101,12 @@ class GraphFrame:
 
     @staticmethod
     def from_caliper(filename_or_stream, query=None):
-        """Read in a Caliper file.
+        """Read in a Caliper .cali or .json file.
 
         Args:
             filename_or_stream (str or file-like): name of a Caliper output
-                file in `.cali` or JSON-split, or an open file object to read one
+                file in `.cali` or JSON-split format, or an open file object
+                to read one
             query (str): cali-query in CalQL format
         """
         # import this lazily to avoid circular dependencies

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -57,9 +57,8 @@ class GraphFrame:
 
         Likely, you do not want to use this function.
 
-        See ``from_hpctoolkit``, ``from_caliper``, ``from_caliper_json``,
-        ``from_gprof_dot``, and other reader methods for easier ways to
-        create a ``GraphFrame``.
+        See ``from_hpctoolkit``, ``from_caliper``, ``from_gprof_dot``, and
+        other reader methods for easier ways to create a ``GraphFrame``.
 
         Arguments:
              graph (Graph): Graph of nodes in this GraphFrame.
@@ -101,30 +100,18 @@ class GraphFrame:
         return HPCToolkitReader(dirname).read()
 
     @staticmethod
-    def from_caliper(filename, query):
-        """Read in a Caliper `cali` file.
+    def from_caliper(filename_or_stream, query=None):
+        """Read in a Caliper file.
 
         Args:
-            filename (str): name of a Caliper output file in `.cali` format
+            filename_or_stream (str or file-like): name of a Caliper output
+                file in `.cali` or JSON-split, or an open file object to read one
             query (str): cali-query in CalQL format
         """
         # import this lazily to avoid circular dependencies
         from .readers.caliper_reader import CaliperReader
 
-        return CaliperReader(filename, query).read()
-
-    @staticmethod
-    def from_caliper_json(filename_or_stream):
-        """Read in a Caliper `cali-query` JSON-split file or an open file object.
-
-        Args:
-            filename_or_stream (str or file-like): name of a Caliper JSON-split
-                output file, or an open file object to read one
-        """
-        # import this lazily to avoid circular dependencies
-        from .readers.caliper_reader import CaliperReader
-
-        return CaliperReader(filename_or_stream).read()
+        return CaliperReader(filename_or_stream, query).read()
 
     @staticmethod
     def from_caliperreader(filename_or_caliperreader):

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -49,7 +49,7 @@ annotations = [
 
 def test_graphframe(lulesh_caliper_json):
     """Sanity test a GraphFrame object with known data."""
-    gf = GraphFrame.from_caliper_json(str(lulesh_caliper_json))
+    gf = GraphFrame.from_caliper(str(lulesh_caliper_json))
 
     assert len(gf.dataframe.groupby("name")) == 24
 
@@ -80,7 +80,7 @@ def test_read_lulesh_json(lulesh_caliper_json):
 
 def test_calc_pi_json(calc_pi_caliper_json):
     """Sanity test a GraphFrame object with known data."""
-    gf = GraphFrame.from_caliper_json(str(calc_pi_caliper_json))
+    gf = GraphFrame.from_caliper(str(calc_pi_caliper_json))
 
     assert len(gf.dataframe.groupby("name")) == 100
 
@@ -115,15 +115,15 @@ def test_lulesh_json_stream(lulesh_caliper_cali):
         [cali_query, "-q", query, lulesh_caliper_cali], stdout=subprocess.PIPE
     )
 
-    gf = GraphFrame.from_caliper_json(cali_json.stdout)
+    gf = GraphFrame.from_caliper(cali_json.stdout)
 
     assert len(gf.dataframe.groupby("name")) == 18
 
 
 def test_filter_squash_unify_caliper_data(lulesh_caliper_json):
     """Sanity test a GraphFrame object with known data."""
-    gf1 = GraphFrame.from_caliper_json(str(lulesh_caliper_json))
-    gf2 = GraphFrame.from_caliper_json(str(lulesh_caliper_json))
+    gf1 = GraphFrame.from_caliper(str(lulesh_caliper_json))
+    gf2 = GraphFrame.from_caliper(str(lulesh_caliper_json))
 
     assert gf1.graph is not gf2.graph
 
@@ -158,7 +158,7 @@ def test_filter_squash_unify_caliper_data(lulesh_caliper_json):
 
 def test_tree(lulesh_caliper_json):
     """Sanity test a GraphFrame object with known data."""
-    gf = GraphFrame.from_caliper_json(str(lulesh_caliper_json))
+    gf = GraphFrame.from_caliper(str(lulesh_caliper_json))
 
     output = ConsoleRenderer(unicode=True, color=False).render(
         gf.graph.roots,
@@ -200,7 +200,7 @@ def test_tree(lulesh_caliper_json):
 
 def test_graphframe_to_literal(lulesh_caliper_json):
     """Sanity test a GraphFrame object with known data."""
-    gf = GraphFrame.from_caliper_json(str(lulesh_caliper_json))
+    gf = GraphFrame.from_caliper(str(lulesh_caliper_json))
     graph_literal = gf.to_literal()
 
     gf2 = GraphFrame.from_literal(graph_literal)


### PR DESCRIPTION
- deprecates from_caliper_json()
- augments existing from_caliper() to accept an
  optional query parameter as well as a cali or json file