### PR TITLE
fix to query on metric that contains nan/inf/float/int values

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -463,7 +463,11 @@ class GraphFrame:
         agg_dict = {}
         for col in df.columns.tolist():
             if col in self.exc_metrics + self.inc_metrics:
-                agg_dict[col] = np.sum
+                # use min_count=1 (default is 0) here, so sum of an all-NA
+                # series is NaN, not 0
+                # when min_count=1, sum([NaN, NaN)] = NaN
+                # when min_count=0, sum([NaN, NaN)] = 0
+                agg_dict[col] = lambda x: x.sum(min_count=1)
             else:
                 agg_dict[col] = lambda x: x.iloc[0]
 
@@ -490,7 +494,9 @@ class GraphFrame:
 
         return out_columns
 
-    def subtree_sum(self, columns, out_columns=None, function=np.sum):
+    def subtree_sum(
+        self, columns, out_columns=None, function=lambda x: x.sum(min_count=1)
+    ):
         """Compute sum of elements in subtrees.  Valid only for trees.
 
         For each row in the graph, ``out_columns`` will contain the
@@ -507,8 +513,7 @@ class GraphFrame:
             out_columns (list of str): names of columns to store results
                 (default: in place)
             function (callable): associative operator used to sum
-                elements (default: sum)
-
+                elements, sum of an all-NA series is NaN (default: sum(min_count=1))
         """
         out_columns = self._init_sum_columns(columns, out_columns)
 
@@ -520,7 +525,9 @@ class GraphFrame:
                         self.dataframe.loc[[node] + node.children, col]
                     )
 
-    def subgraph_sum(self, columns, out_columns=None, function=np.sum):
+    def subgraph_sum(
+        self, columns, out_columns=None, function=lambda x: x.sum(min_count=1)
+    ):
         """Compute sum of elements in subgraphs.
 
         For each row in the graph, ``out_columns`` will contain the
@@ -537,7 +544,7 @@ class GraphFrame:
             out_columns (list of str): names of columns to store results
                 (default: in place)
             function (callable): associative operator used to sum
-                elements (default: sum)
+                elements, sum of an all-NA series is NaN (default: sum(min_count=1))
         """
         if self.graph.is_tree():
             self.subtree_sum(columns, out_columns, function)


### PR DESCRIPTION
Will fix #341, not sure if changes need to be made to other places within `query_matcher.py`.

Note: Flake8 is failing, saying that numpy is imported, but is not used (since it's in a string, flake8 doesn't see it). But when running the notebook without this import, the python complains that np is not found.

- [x] add unit tests for querying on nan values
- [x] extend to handle queries on a inf metric value 