### PR TITLE
minor fix to setting PYTHONPATH in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
-if [ "$PYTHONPATH" != *"$PWD"* ]; then
-	PYTHONPATH=$PWD:$PYTHONPATH
-fi
+case "$PYTHONPATH" in
+    *"$PWD"*)
+        ;;
+
+    *)
+        PYTHONPATH=$PWD:$PYTHONPATH
+        ;;
+esac
 
 python setup.py build_ext --inplace


### PR DESCRIPTION
Check PYTHONPATH for PWD substring before appending. Previously, PYTHONPATH
would contain duplicates of the same path for multiple launches of the install
script.