### PR TITLE
ignore nan values when calculating min/max in console

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -32,6 +32,7 @@
 from ..version import __version__
 
 import pandas as pd
+import numpy as np
 
 
 class ConsoleRenderer:
@@ -72,17 +73,23 @@ class ConsoleRenderer:
         # grab the min and max metric value, ignoring inf and nan values
         if "rank" in dataframe.index.names:
             metric_series = (dataframe.xs(self.rank, level=1))[self.metric]
-            inf_mask = (metric_series.values > float("-inf")) & (
-                metric_series.values < float("inf")
-            )
+            inf_mask = [
+                (x > float("-inf")) & (x < float("inf"))
+                if x is not np.isnan(x)
+                else False
+                for x in metric_series.values
+            ]
             filtered_series = pd.Series(
                 metric_series.values[inf_mask], metric_series.index[inf_mask]
             )
         else:
             metric_series = dataframe[self.metric]
-            inf_mask = (metric_series.values > float("-inf")) & (
-                metric_series.values < float("inf")
-            )
+            inf_mask = [
+                (x > float("-inf")) & (x < float("inf"))
+                if x is not np.isnan(x)
+                else False
+                for x in metric_series.values
+            ]
             filtered_series = pd.Series(
                 metric_series.values[inf_mask], metric_series.index[inf_mask]
             )

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -154,38 +154,42 @@ def test_tree(lulesh_caliper_json):
     """Sanity test a GraphFrame object with known data."""
     gf = GraphFrame.from_caliper_json(str(lulesh_caliper_json))
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="time",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "121489.000 main" in output
     assert "663.000 LagrangeElements" in output
     assert "21493.000 CalcTimeConstraintsForElems" in output
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time (inc)",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="time (inc)",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "662712.000 EvalEOSForElems" in output
     assert "2895319.000 LagrangeNodal" in output
 

--- a/hatchet/tests/cprofile.py
+++ b/hatchet/tests/cprofile.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 import re
+import pytest
 
 from hatchet import GraphFrame
 from hatchet.external.console import ConsoleRenderer
@@ -30,36 +31,40 @@ def test_graphframe(hatchet_cycle_pstats):
 def test_tree(hatchet_cycle_pstats):
     gf = GraphFrame.from_cprofile(str(hatchet_cycle_pstats))
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="time",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "g pstats_reader_test.py" in output
     assert "<method 'disable' ...Profiler' objects> ~" in output
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time (inc)",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="time (inc)",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "f pstats_reader_test.py" in output
     assert re.match("(.|\n)*recursive(.|\n)*recursive", output)

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -7,10 +7,9 @@
 
 from __future__ import division
 
-import pytest
-
 import numpy as np
 import pandas as pd
+import pytest
 
 from hatchet import GraphFrame, QueryMatcher
 from hatchet.graphframe import InvalidFilter, EmptyFilter
@@ -683,38 +682,42 @@ def test_filter_emtpy_graphframe(mock_graph_literal):
 def test_tree(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="time",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "0.000 foo" in output
     assert "10.000 waldo" in output
     assert "15.000 garply" in output
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time (inc)",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="time (inc)",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "50.000 waldo" in output
     assert "15.000 garply" in output
 
@@ -758,20 +761,23 @@ def test_sub_decorator(small_mock1, small_mock2, small_mock3):
         gf4.dataframe.loc[gf4.dataframe["_missing_node"] == 0].shape[0] == 5
     )  # "" or same in both
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf4.graph.roots,
-        gf4.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf4.graph.roots,
+            gf4.dataframe,
+            metric_column="time",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+
+    assert len(num_warnings) == 0
     assert "0.000 C" in output
     assert u"nan D ▶" in output
     assert u"10.000 H ◀" in output
@@ -786,20 +792,22 @@ def test_sub_decorator(small_mock1, small_mock2, small_mock3):
     assert gf5.dataframe.loc[gf5.dataframe["_missing_node"] == 1].shape[0] == 2  # "L"
     assert gf5.dataframe.loc[gf5.dataframe["_missing_node"] == 0].shape[0] == 4  # ""
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf5.graph.roots,
-        gf5.dataframe,
-        metric_column="time (inc)",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf5.graph.roots,
+            gf5.dataframe,
+            metric_column="time (inc)",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "0.000 A" in output
     assert u"5.000 C ◀" in output
     assert u"55.000 H ◀" in output
@@ -819,20 +827,22 @@ def test_div_decorator(small_mock1, small_mock2):
     assert gf3.dataframe.loc[gf3.dataframe["_missing_node"] == 1].shape[0] == 1  # "L"
     assert gf3.dataframe.loc[gf3.dataframe["_missing_node"] == 0].shape[0] == 5  # ""
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf3.graph.roots,
-        gf3.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf3.graph.roots,
+            gf3.dataframe,
+            metric_column="time",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "1.000 C" in output
     assert "inf B" in output
     assert u"nan D ▶" in output

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -3,9 +3,11 @@
 #
 # SPDX-License-Identifier: MIT
 
+import os
+
 import numpy as np
 import pandas as pd
-import os
+import pytest
 
 from hatchet import GraphFrame
 from hatchet.readers.hpctoolkit_reader import HPCToolkitReader
@@ -101,40 +103,44 @@ def test_graphframe(data_dir, calc_pi_hpct_db):
 def test_tree(calc_pi_hpct_db):
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="time",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "0.000 <program root> <unknown file>" in output
     assert (
         "0.000 198:MPIR_Init_thread /tmp/dpkg-mkdeb.gouoc49UG7/src/mvapich/src/build/../src/mpi/init/initthread.c"
         in output
     )
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time (inc)",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="time (inc)",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "17989.000 interp.c:0 interp.c" in output
     assert (
         "999238.000 230:psm_dofinalize /tmp/dpkg-mkdeb.gouoc49UG7/src/mvapich/src/build/../src/mpid/ch3/channels/psm/src/psm_exit.c"

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -6,6 +6,7 @@
 import json
 
 import numpy as np
+import pytest
 
 from hatchet import GraphFrame
 from hatchet.external.console import ConsoleRenderer
@@ -77,37 +78,41 @@ def test_tree(hatchet_pyinstrument_json):
     """Sanity test a GraphFrame object with known data."""
     gf = GraphFrame.from_pyinstrument(str(hatchet_pyinstrument_json))
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="time",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "0.000 <module> examples.py" in output
     assert "0.025 read hatchet/readers/caliper_reader.py" in output
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="time (inc)",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="time (inc)",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
     assert "0.478 <module> examples.py" in output
     assert "0.063 from_caliper_json hatchet/graphframe.py" in output
 

--- a/hatchet/tests/timemory_test.py
+++ b/hatchet/tests/timemory_test.py
@@ -5,11 +5,10 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
+import pytest
 
 from hatchet import GraphFrame
 from hatchet.external.console import ConsoleRenderer
-
-import pytest
 
 timemory_avail = True
 try:
@@ -45,37 +44,41 @@ def test_tree(timemory_json_data):
 
     print(gf.tree("sum"))
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="sum",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="sum",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
 
     print(output)
 
-    output = ConsoleRenderer(unicode=True, color=False).render(
-        gf.graph.roots,
-        gf.dataframe,
-        metric_column="sum.inc",
-        precision=3,
-        name_column="name",
-        expand_name=False,
-        context_column="file",
-        rank=0,
-        thread=0,
-        depth=10000,
-        highlight_name=False,
-        invert_colormap=False,
-    )
+    with pytest.warns(None) as num_warnings:
+        output = ConsoleRenderer(unicode=True, color=False).render(
+            gf.graph.roots,
+            gf.dataframe,
+            metric_column="sum.inc",
+            precision=3,
+            name_column="name",
+            expand_name=False,
+            context_column="file",
+            rank=0,
+            thread=0,
+            depth=10000,
+            highlight_name=False,
+            invert_colormap=False,
+        )
+    assert len(num_warnings) == 0
 
     print(output)
 


### PR DESCRIPTION
- fixes RuntimeWarning comparing np.nan > float(-inf) and np.nan < float(inf)
- pytest check for warnings when running ConsoleRenderer

Fixes #335 