### PR TITLE
do not modify list of inc_metrics when exc_metrics is empty

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -593,6 +593,10 @@ class GraphFrame:
         """Update inclusive columns (typically after operations that rewire the
         graph.
         """
+        # we should update inc metric only if exc metric exist
+        if not self.exc_metrics:
+            return
+
         self.inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
         self.subgraph_sum(self.exc_metrics, self.inc_metrics)
 

--- a/hatchet/tests/conftest.py
+++ b/hatchet/tests/conftest.py
@@ -836,3 +836,41 @@ def timemory_json_data():
         trace_func(trace_arr, tol)
 
     return timemory.get(hierarchy=True)
+
+
+@pytest.fixture
+def mock_graph_inc_metric_only():
+    ldict = [
+        {
+            "frame": {"name": "A", "type": "function"},
+            "metrics": {"time (inc)": 130.0},
+            "children": [
+                {
+                    "frame": {"name": "B", "type": "function"},
+                    "metrics": {"time (inc)": 20.0},
+                    "children": [
+                        {
+                            "frame": {"name": "C", "type": "function"},
+                            "metrics": {"time (inc)": 5.0},
+                        }
+                    ],
+                },
+                {
+                    "frame": {"name": "E", "type": "function"},
+                    "metrics": {"time (inc)": 55.0},
+                    "children": [
+                        {
+                            "frame": {"name": "F", "type": "function"},
+                            "metrics": {"time (inc)": 1.0},
+                        }
+                    ],
+                },
+                {
+                    "frame": {"name": "H", "type": "function"},
+                    "metrics": {"time (inc)": 55.0},
+                },
+            ],
+        }
+    ]
+
+    return ldict

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1137,3 +1137,18 @@ def test_filter_with_nan_and_inf(small_mock1, small_mock2):
     assert filter_gf3.dataframe["time (inc)"].sum() == np.inf
     assert filter_gf3.dataframe.shape[0] == 2
     assert sorted(filter_gf3.dataframe["name"].values) == ["B", "H"]
+
+
+def test_inc_metric_only(mock_graph_inc_metric_only):
+    """Test graph with only an inclusive metric and no associated exclusive
+    metric. A filter-squash should not change the inclusive metric values, and
+    the list of exclusive metrics and inclusive metrics should stay the same.
+    """
+    gf = GraphFrame.from_literal(mock_graph_inc_metric_only)
+    filt_gf = gf.filter(lambda x: x["time (inc)"] > 50, squash=True, num_procs=1)
+
+    assert len(filt_gf.graph) == 3
+    assert all(filt_gf.dataframe["name"].values == ["A", "E", "H"])
+    assert all(filt_gf.dataframe["time (inc)"].values == [130, 55, 55])
+    assert gf.inc_metrics == filt_gf.inc_metrics
+    assert gf.exc_metrics == filt_gf.exc_metrics


### PR DESCRIPTION
List of inclusive metrics was being emptied in `update_inclusive_columns()`, when there were no exclusive
metrics defined on the graphframe. If a user tries to print an invalid metric on the tree, the warning says to run `show_metric_columns()`, which reports an empty list (though there is still a valid incl metric on the dataframe). For now, we will not update the list of incl columns if no excl columns exist. A longer term solution will be to compute excl from incl, so that the incl can be updated appropriately.