### PR TITLE
console output: check for both nans and infs

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -32,6 +32,7 @@
 from ..version import __version__
 
 import pandas as pd
+import numpy as np
 
 
 class ConsoleRenderer:
@@ -72,19 +73,17 @@ class ConsoleRenderer:
         # grab the min and max metric value, ignoring inf and nan values
         if "rank" in dataframe.index.names:
             metric_series = (dataframe.xs(self.rank, level=1))[self.metric]
-            inf_mask = (metric_series.values > float("-inf")) & (
-                metric_series.values < float("inf")
-            )
+            isfinite_mask = np.isfinite(metric_series.values)
+
             filtered_series = pd.Series(
-                metric_series.values[inf_mask], metric_series.index[inf_mask]
+                metric_series.values[isfinite_mask], metric_series.index[isfinite_mask]
             )
+
         else:
             metric_series = dataframe[self.metric]
-            inf_mask = (metric_series.values > float("-inf")) & (
-                metric_series.values < float("inf")
-            )
+            isfinite_mask = np.isfinite(metric_series.values)
             filtered_series = pd.Series(
-                metric_series.values[inf_mask], metric_series.index[inf_mask]
+                metric_series.values[isfinite_mask], metric_series.index[isfinite_mask]
             )
 
         self.max_metric = filtered_series.max()


### PR DESCRIPTION
More performant solution to #344, fixes #335 

Fixes RuntimeWarning comparing np.nan > float(-inf) and np.nan < float(inf)