### PR TITLE
match nodes containing int/float/nan/inf metric values

### DIFF
--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -981,3 +981,86 @@ def test_output_with_cycle_graphs():
     assert treeout.count("d") == 2
     assert treeout.count("e") == 1
     assert treeout.count("f") == 1
+
+
+def test_filter_squash_query_nan_and_inf_metric(small_mock1, small_mock2):
+    """Use call path query language on a metric column containing both
+    int/float, NaN and inf."""
+    gf1 = GraphFrame.from_literal(small_mock1)
+    gf2 = GraphFrame.from_literal(small_mock2)
+
+    gf3 = gf1 / gf2
+
+    query_nan = [{"time": "== np.nan"}]
+    filt_nan_gf3 = gf3.filter(query_nan, squash=True)
+
+    assert len(filt_nan_gf3.graph.roots) == 2
+    assert all(pd.isnull(time) for time in filt_nan_gf3.dataframe["time (inc)"])
+    assert all(pd.isnull(time) for time in filt_nan_gf3.dataframe["time"])
+    assert filt_nan_gf3.dataframe.shape[0] == 2
+    assert sorted(filt_nan_gf3.dataframe["name"].values) == ["D", "G"]
+
+    query_inf = [{"time": "== np.inf"}]
+    filt_inf_gf3 = gf3.filter(query_inf, squash=True)
+
+    assert len(filt_inf_gf3.graph.roots) == 1
+    assert all(np.isinf(inc_time) for inc_time in filt_inf_gf3.dataframe["time (inc)"])
+    assert all(np.isinf(exc_time) for exc_time in filt_inf_gf3.dataframe["time"])
+    assert filt_inf_gf3.dataframe.shape[0] == 1
+    assert filt_inf_gf3.dataframe["name"].values[0] == "B"
+
+
+def test_filter_squash_query_metric_with_nan_and_inf(small_mock1, small_mock2):
+    """Use call path query language to match nodes with NaN and inf metric values."""
+    gf1 = GraphFrame.from_literal(small_mock1)
+    gf2 = GraphFrame.from_literal(small_mock2)
+
+    gf3 = gf1 / gf2
+
+    query = [{"time": ">= 1"}]
+    filter_gf3 = gf3.filter(query, squash=True)
+
+    assert len(filter_gf3.graph.roots) == 3
+    assert filter_gf3.dataframe["time"].sum() == np.inf
+    assert filter_gf3.dataframe["time (inc)"].sum() == np.inf
+    assert filter_gf3.dataframe.shape[0] == 5
+
+
+def test_filter_nan_and_inf(small_mock1, small_mock2):
+    """Use lambda to filter for nodes with NaN and inf values."""
+    gf1 = GraphFrame.from_literal(small_mock1)
+    gf2 = GraphFrame.from_literal(small_mock2)
+
+    gf3 = gf1 / gf2
+
+    filt_nan_gf3 = gf3.filter(lambda x: pd.isnull(x["time"]), squash=True)
+
+    assert len(filt_nan_gf3.graph.roots) == 2
+    assert all(pd.isnull(inc_time) for inc_time in filt_nan_gf3.dataframe["time (inc)"])
+    assert all(pd.isnull(exc_time) for exc_time in filt_nan_gf3.dataframe["time"])
+    assert filt_nan_gf3.dataframe.shape[0] == 2
+    assert sorted(filt_nan_gf3.dataframe["name"].values) == ["D", "G"]
+
+    filt_inf_gf3 = gf3.filter(lambda x: np.isinf(x["time"]), squash=True)
+
+    assert len(filt_inf_gf3.graph.roots) == 1
+    assert all(np.isinf(inc_time) for inc_time in filt_inf_gf3.dataframe["time (inc)"])
+    assert all(np.isinf(exc_time) for exc_time in filt_inf_gf3.dataframe["time"])
+    assert filt_inf_gf3.dataframe.shape[0] == 1
+    assert filt_inf_gf3.dataframe["name"].values == "B"
+
+
+def test_filter_with_nan_and_inf(small_mock1, small_mock2):
+    """Use lambda to filter for metric containing int/float, NaN, and inf values."""
+    gf1 = GraphFrame.from_literal(small_mock1)
+    gf2 = GraphFrame.from_literal(small_mock2)
+
+    gf3 = gf1 / gf2
+
+    filter_gf3 = gf3.filter(lambda x: x["time"] > 5, squash=True)
+
+    assert len(filter_gf3.graph.roots) == 2
+    assert filter_gf3.dataframe["time"].sum() == np.inf
+    assert filter_gf3.dataframe["time (inc)"].sum() == np.inf
+    assert filter_gf3.dataframe.shape[0] == 2
+    assert sorted(filter_gf3.dataframe["name"].values) == ["B", "H"]


### PR DESCRIPTION
fix query matcher code v1.3.0 to handle matching nodes:
- with metric values containing a combination of ints, floats, NaN, and inf
  values (e.g., match nodes with time > 5, where time values may be an int,
  float, NaN, or inf)
- with metric value of NaN (e.g., match nodes with time == NaN)
- with metric value of inf (e.g., match nodes with time == inf)

add tests for using the query language and standard filter functions to
match nodes with NaN and inf metric values

This fix targets 1.3.0 release.