### PR TITLE
Removed header from tree() output to prevent errenous letter counting in test_output_with_cycle_graphs

### DIFF
--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -962,7 +962,7 @@ def test_tree_deprecated_parameters(mock_graph_literal):
         gf.tree(metric="time", metric_column="time")
 
 
-@pytest.mark.xfail(reason="Temporarily allow this to fail.")
+# @pytest.mark.xfail(reason="Temporarily allow this to fail.")
 def test_output_with_cycle_graphs():
     r"""Test three output modes on a graph with cycles,
         multiple parents and children.
@@ -1018,10 +1018,13 @@ def test_output_with_cycle_graphs():
     for edge in dot_edges:
         assert edge in dotout
 
+    # removing header to prevent it being counted
+    treeout = "\n".join(treeout.split("\n")[6:])
+
     # check that a certain number of occurences
     # of same node are in tree indicating multiple
     # edges
-    assert treeout.count("a") == 4
+    assert treeout.count("a") == 2
     assert treeout.count("d") == 2
     assert treeout.count("e") == 1
     assert treeout.count("f") == 1

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -962,7 +962,6 @@ def test_tree_deprecated_parameters(mock_graph_literal):
         gf.tree(metric="time", metric_column="time")
 
 
-# @pytest.mark.xfail(reason="Temporarily allow this to fail.")
 def test_output_with_cycle_graphs():
     r"""Test three output modes on a graph with cycles,
         multiple parents and children.


### PR DESCRIPTION
### Description of Fix

The header on the tree output of a graphframe contains hatchet version information. This version string can sometimes contain the character 'a'. Since string.count() was used to scan the tree for the proper number of nodes of a particular name (in this case "a"), it would pick up the "a" in the header. To mitigate this problem I have removed the 7 header lines from the output before counting instances of nodes.

![An example with three "a" characters in the tree() string when only 2 were expected.](https://user-images.githubusercontent.com/10066043/113777254-b0062c00-96df-11eb-9f7f-8e361d189c51.png)

I strongly suspect that an earlier instance of this test having 4 "a"'s came from a version which contained 2 "a"'s.
