### PR TITLE
Add a "Middle-Level" API based on Cypher

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -373,14 +373,9 @@ class GraphFrame:
                 filtered_rows = dataframe_copy.apply(filter_obj, axis=1)
                 filtered_df = dataframe_copy[filtered_rows]
 
-<<<<<<< HEAD
-        # elif isinstance(filter_obj, list) or isinstance(filter_obj, QueryMatcher):
-        elif isinstance(filter_obj, list) or issubclass(
+        elif isinstance(filter_obj, (list, str)) or issubclass(
             type(filter_obj), AbstractQuery
         ):
-=======
-        elif isinstance(filter_obj, (list, QueryMatcher, str)):
->>>>>>> 6249ad8... Adds the CypherQuery class to convert Cypher queries to Hatchet query language
             # use a callpath query to apply the filter
             query = filter_obj
             if isinstance(filter_obj, list):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -15,7 +15,7 @@ import multiprocess as mp
 from .node import Node
 from .graph import Graph
 from .frame import Frame
-from .query import AbstractQuery, QueryMatcher
+from .query import AbstractQuery, QueryMatcher, CypherQuery
 from .external.console import ConsoleRenderer
 from .util.dot import trees_to_dot
 from .util.deprecated import deprecated_params
@@ -373,14 +373,20 @@ class GraphFrame:
                 filtered_rows = dataframe_copy.apply(filter_obj, axis=1)
                 filtered_df = dataframe_copy[filtered_rows]
 
+<<<<<<< HEAD
         # elif isinstance(filter_obj, list) or isinstance(filter_obj, QueryMatcher):
         elif isinstance(filter_obj, list) or issubclass(
             type(filter_obj), AbstractQuery
         ):
+=======
+        elif isinstance(filter_obj, (list, QueryMatcher, str)):
+>>>>>>> 6249ad8... Adds the CypherQuery class to convert Cypher queries to Hatchet query language
             # use a callpath query to apply the filter
             query = filter_obj
             if isinstance(filter_obj, list):
                 query = QueryMatcher(filter_obj)
+            elif isinstance(filter_obj, str):
+                query = CypherQuery(filter_obj)
             query_matches = query.apply(self)
             # match_set = list(set().union(*query_matches))
             # filtered_df = dataframe_copy.loc[dataframe_copy["node"].isin(match_set)]

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -19,6 +19,8 @@ import sys
 import pandas as pd
 from pandas import DataFrame
 from pandas.core.indexes.multi import MultiIndex
+from textx import metamodel_from_str
+from textx.exceptions import TextXError
 
 # Flake8 to ignore this import, it does not recognize that eval("np.nan") needs
 # numpy package
@@ -639,6 +641,265 @@ class QueryMatcher(AbstractQuery):
         # Continue the Depth First Search.
         for child in sorted(node.children, key=traversal_order):
             self._apply_impl(gf, child, visited, matches)
+
+GRAMMAR = """
+FullQuery: path_expr=MatchExpr(cond_expr=WhereExpr)?;
+MatchExpr: 'MATCH' path=PathQuery;
+PathQuery: '(' nodes=NodeExpr ')'('-['(nodes=NodeExpr)?']->' '(' nodes=NodeExpr ')')*;
+NodeExpr: ((wcard=INT | wcard=STRING) ',' name=ID) | (wcard=INT | wcard=STRING) |  name=ID;
+WhereExpr: 'WHERE' ConditionExpr;
+ConditionExpr: conditions+=CompoundCond;
+CompoundCond: UnaryCond | BinaryCond;
+BinaryCond: AndCond | OrCond;
+AndCond: 'AND' subcond=UnaryCond;
+OrCond: 'OR' subcond=UnaryCond;
+UnaryCond: NotCond | SingleCond;
+NotCond: 'NOT' subcond=SingleCond;
+SingleCond: StringCond | NumberCond;
+StringCond: StringEq | StringStartsWith | StringEndsWith | StringContains | StringMatch;
+StringEq: name=ID '.' prop=STRING '=' val=STRING;
+StringStartsWith: name=ID '.' prop=STRING 'STARTS WITH' val=STRING;
+StringEndsWith: name=ID '.' prop=STRING 'ENDS WITH' val=STRING;
+StringContains: name=ID '.' prop=STRING 'CONTAINS' val=STRING;
+StringMatch: name=ID '.' prop=STRING '=~' val=STRING;
+NumberCond: NumEq | NumLt | NumGt | NumLte | NumGte | NumNan | NumNotNan;
+NumEq: name=ID '.' prop=STRING '=' val=NUMBER;
+NumLt: name=ID '.' prop=STRING '<' val=NUMBER;
+NumGt: name=ID '.' prop=STRING '>' val=NUMBER;
+NumLte: name=ID '.' prop=STRING '<=' val=NUMBER;
+NumGte: name=ID '.' prop=STRING '>=' val=NUMBER;
+NumNan: name=ID '.' prop=STRING 'IS NULL';
+NumNotNan: name=ID '.' prop=STRING 'IS NOT NULL';
+"""
+
+mm = metamodel_from_str(GRAMMAR)
+
+def cname(obj):
+    return obj.__class__.__name__
+
+def filter_check_types(type_check, df_row, filt_lambda):
+    try:
+        if eval(type_check):
+            return filt_lambda(df_row)
+        else:
+            raise InvalidQueryFilter("Type mismatch in filter")
+    except KeyError:
+        return False
+
+class CypherQuery(AbstractQuery):
+
+    def __init__(self, cypher_query):
+        model = None
+        try:
+            model = mm.model_from_str(cypher_query)
+        except TextXError as e:
+            # TODO Change to a "raise-from" expression when Python 2.7 support is dropped
+            raise InvalidQueryPath(
+                "Invalid \"Cypher\" Query Detected. Parser Error Message: {}".format(e.message)
+            )
+        self.wcards = []
+        self.wcard_pos = {}
+        self._parse_path(model.path_expr)
+        self.filters = [[] for _ in self.wcards]
+        self._parse_conditions(model.cond_expr)
+        self.lambda_filters = [None for _ in self.wcards]
+        self._build_lambdas()
+        self.query_matcher = self._build_query_matcher()
+
+    def apply(self, gf):
+        return self.query_matcher.apply(gf)
+
+    def _build_query_matcher(self):
+        query = QueryMatcher()
+        for i in range(0, len(self.wcards)):
+            wcard = self.wcards[i][0]
+            filt_str = self.lambda_filters[i]
+            if filt_str is None:
+                if i == 0:
+                    query.match(wildcard_spec=wcard)
+                else:
+                    query.rel(wildcard_spec=wcard)
+            else:
+                if i == 0:
+                    query.match(wildcard_spec=wcard, filter_func=eval(filt_str))
+                else:
+                    query.rel(wildcard_spec=wcard, filter_func=eval(filt_str))
+        return query
+
+    def _build_lambdas(self):
+        for i in range(0, len(self.wcards)):
+            n = self.wcards[i]
+            if n[1] != "":
+                bool_expr = ""
+                type_check = ""
+                for j, cond in enumerate(self.filters[i]):
+                    if cond[0] is not None:
+                        bool_expr += " {}".format(cond[0])
+                    bool_expr += " {}".format(cond[1])
+                    if j == 0:
+                        type_check += " {}".format(cond[2])
+                    else:
+                        type_check += " and {}".format(cond[2])
+                bool_expr = "lambda df_row: {}".format(bool_expr)
+                bool_expr = "lambda df_row: filter_check_types(\"{}\", df_row, {})".format(type_check, bool_expr)
+                self.lambda_filters[i] = bool_expr
+
+    def _parse_path(self, path_obj):
+        nodes = path_obj.path.nodes
+        idx = len(self.wcards)
+        for n in nodes:
+            new_node = [n.wcard, n.name]
+            if n.wcard is None or n.wcard == "" or n.wcard == 0:
+                new_node[0] = "."
+            self.wcards.append(new_node)
+            if n.name != "":
+                self.wcard_pos[n.name] = idx
+            idx += 1
+
+    def _parse_conditions(self, cond_expr):
+        conditions = cond_expr.conditions
+        for cond in conditions:
+            converted_condition = None
+            if self._is_unary_cond(cond):
+                converted_condition = self._parse_unary_cond(cond)
+            elif self._is_binary_cond(cond):
+                converted_condition = self._parse_binary_cond(cond)
+            else:
+                raise RuntimeError("Bad Condition")
+            self.filters[self.wcard_pos[converted_condition[1]]].append([
+                converted_condition[0], converted_condition[2], converted_condition[3]
+            ])
+        for i in range(0, len(self.filters)):
+            if len(self.filters[i]) > 0:
+                if self.filters[i][0][0] != "not":
+                    self.filters[i][0][0] = None
+
+    def _is_unary_cond(self, obj):
+        if cname(obj) == "NotCond" or self._is_str_cond(obj) or self._is_num_cond(obj):
+            return True
+        return False
+
+    def _is_binary_cond(self, obj):
+        if cname(obj) in ["AndCond", "OrCond"]:
+            return True
+        return False
+
+    def _parse_binary_cond(self, obj):
+        if cname(obj) == "AndCond":
+            return self._parse_and_cond(obj)
+        if cname(obj) == "OrCond":
+            return self._parse_or_cond(obj)
+        raise RuntimeError("Bad Binary Condition")
+
+    def _parse_or_cond(self, obj):
+        converted_subcond = self._parse_unary_cond(obj.subcond)
+        converted_subcond[0] = "or"
+        return converted_subcond
+
+    def _parse_and_cond(self, obj):
+        converted_subcond = self._parse_unary_cond(obj.subcond)
+        converted_subcond[0] = "and"
+        return converted_subcond
+
+    def _parse_unary_cond(self, obj):
+        if cname(obj) == "NotCond":
+            return self._parse_not_cond(obj)
+        return self._parse_single_cond(obj)
+
+    def _parse_not_cond(self, obj):
+        converted_subcond = self._parse_single_cond(obj.subcond)
+        converted_subcond[2] = "not {}".format(converted_subcond[2])
+        return converted_subcond
+
+    def _parse_single_cond(self, obj):
+        if self._is_str_cond(obj):
+            return self._parse_str(obj)
+        if self._is_num_cond(obj):
+            return self._parse_num(obj)
+        raise RuntimeError("Bad Single Condition")
+
+    def _is_str_cond(self, obj):
+        if cname(obj) in ["StringEq", "StringStartsWith",
+                          "StringEndsWith", "StringContains", "StringMatch"]:
+            return True
+        return False
+
+    def _is_num_cond(self, obj):
+        if cname(obj) in ["NumEq", "NumLt", "NumGt", "NumLte",
+                          "NumGte", "NumNan", "NumNotNan"]:
+            return True
+        return False
+
+    def _parse_str(self, obj):
+        if cname(obj) == "StringEq":
+            return self._parse_str_eq(obj)
+        if cname(obj) == "StringStartsWith":
+            return self._parse_str_starts_with(obj)
+        if cname(obj) == "StringEndsWith":
+            return self._parse_str_ends_with(obj)
+        if cname(obj) == "StringContains":
+            return self._parse_str_contains(obj)
+        if cname(obj) == "StringMatch":
+            return self._parse_str_match(obj)
+        raise RuntimeError("Bad String Op Class")
+
+    def _parse_str_eq(self, obj):
+        return [None, obj.name, "df_row[\"{}\"] == \"{}\"".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], str)".format(obj.prop)]
+
+    def _parse_str_starts_with(self, obj):
+        return [None, obj.name, "df_row[\"{}\"].startswith(\"{}\")".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], str)".format(obj.prop)]
+
+    def _parse_str_ends_with(self, obj):
+        return [None, obj.name, "df_row[\"{}\"].endswith(\"{}\")".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], str)".format(obj.prop)]
+
+    def _parse_str_contains(self, obj):
+        return [None, obj.name, "\"{}\" in df_row[\"{}\"]".format(obj.val, obj.prop), "isinstance(df_row[\'{}\'], str)".format(obj.prop)]
+
+    def _parse_str_match(self, obj):
+        return [
+            None,
+            obj.name,
+            "re.match(\"{}\", df_row[\"{}\"]) is not None".format(obj.val, obj.prop),
+            "isinstance(df_row[\'{}\'], str)".format(obj.prop)
+        ]
+
+    def _parse_num(self, obj):
+        if cname(obj) == "NumEq":
+            return self._parse_num_eq(obj)
+        if cname(obj) == "NumLt":
+            return self._parse_num_lt(obj)
+        if cname(obj) == "NumGt":
+            return self._parse_num_gt(obj)
+        if cname(obj) == "NumLte":
+            return self._parse_num_lte(obj)
+        if cname(obj) == "NumGte":
+            return self._parse_num_gte(obj)
+        if cname(obj) == "NumNan":
+            return self._parse_num_nan(obj)
+        if cname(obj) == "NumNotNan":
+            return self._parse_num_not_nan(obj)
+        raise RuntimeError("Bad Number Op Class")
+
+    def _parse_num_eq(self, obj):
+        return [None, obj.name, "df_row[\"{}\"] == {}".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
+
+    def _parse_num_lt(self, obj):
+        return [None, obj.name, "df_row[\"{}\"] < {}".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
+
+    def _parse_num_gt(self, obj):
+        return [None, obj.name, "df_row[\"{}\"] > {}".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
+
+    def _parse_num_lte(self, obj):
+        return [None, obj.name, "df_row[\"{}\"] <= {}".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
+
+    def _parse_num_gte(self, obj):
+        return [None, obj.name, "df_row[\"{}\"] >= {}".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
+
+    def _parse_num_nan(self, obj):
+        return [None, obj.name, "pd.isna(df_row[\"{}\"])".format(obj.prop), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
+
+    def _parse_num_not_nan(self, obj):
+        return [None, obj.name, "not pd.isna(df_row[\"{}\"])".format(obj.prop), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
 
 
 class AndQuery(NaryQuery):

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -12,6 +12,7 @@ except ImportError:
 
     ABC = ABCMeta("ABC", (object,), {"__slots__": ()})
 
+import sys
 from itertools import groupby
 from numbers import Real
 import re
@@ -645,7 +646,7 @@ class QueryMatcher(AbstractQuery):
             self._apply_impl(gf, child, visited, matches)
 
 
-GRAMMAR = """
+GRAMMAR = u"""
 FullQuery: path_expr=MatchExpr(cond_expr=WhereExpr)?;
 MatchExpr: 'MATCH' path=PathQuery;
 PathQuery: '(' nodes=NodeExpr ')'('-['(nodes=NodeExpr)?']->' '(' nodes=NodeExpr ')')*;
@@ -720,6 +721,9 @@ class CypherQuery(AbstractQuery):
         query = QueryMatcher()
         for i in range(0, len(self.wcards)):
             wcard = self.wcards[i][0]
+            # TODO Remove this when Python 2.7 support is dropped.
+            if sys.version_info[0] == 2 and not isinstance(wcard, Real):
+                wcard = wcard.encode("ascii", "ignore")
             filt_str = self.lambda_filters[i]
             if filt_str is None:
                 if i == 0:

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -12,7 +12,6 @@ except ImportError:
 
     ABC = ABCMeta("ABC", (object,), {"__slots__": ()})
 
-import sys
 from itertools import groupby
 from numbers import Real
 import re

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -881,24 +881,52 @@ class CypherQuery(AbstractQuery):
         raise RuntimeError("Bad Number Op Class")
 
     def _parse_num_eq(self, obj):
+        if obj.prop == "depth":
+            return [None, obj.name, "df_row.name._depth == {}".format(obj.val), "isinstance(df_row.name._depth, Real)"]
+        if obj.prop == "node_id":
+            return [None, obj.name, "df_row.name._hatchet_nid == {}".format(obj.val), "isinstance(df_row.name._hatchet_nid, Real)"]
         return [None, obj.name, "df_row[\"{}\"] == {}".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
 
     def _parse_num_lt(self, obj):
+        if obj.prop == "depth":
+            return [None, obj.name, "df_row.name._depth < {}".format(obj.val), "isinstance(df_row.name._depth, Real)"]
+        if obj.prop == "node_id":
+            return [None, obj.name, "df_row.name._hatchet_nid < {}".format(obj.val), "isinstance(df_row.name._hatchet_nid, Real)"]
         return [None, obj.name, "df_row[\"{}\"] < {}".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
 
     def _parse_num_gt(self, obj):
+        if obj.prop == "depth":
+            return [None, obj.name, "df_row.name._depth > {}".format(obj.val), "isinstance(df_row.name._depth, Real)"]
+        if obj.prop == "node_id":
+            return [None, obj.name, "df_row.name._hatchet_nid > {}".format(obj.val), "isinstance(df_row.name._hatchet_nid, Real)"]
         return [None, obj.name, "df_row[\"{}\"] > {}".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
 
     def _parse_num_lte(self, obj):
+        if obj.prop == "depth":
+            return [None, obj.name, "df_row.name._depth <= {}".format(obj.val), "isinstance(df_row.name._depth, Real)"]
+        if obj.prop == "node_id":
+            return [None, obj.name, "df_row.name._hatchet_nid <= {}".format(obj.val), "isinstance(df_row.name._hatchet_nid, Real)"]
         return [None, obj.name, "df_row[\"{}\"] <= {}".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
 
     def _parse_num_gte(self, obj):
+        if obj.prop == "depth":
+            return [None, obj.name, "df_row.name._depth >= {}".format(obj.val), "isinstance(df_row.name._depth, Real)"]
+        if obj.prop == "node_id":
+            return [None, obj.name, "df_row.name._hatchet_nid >= {}".format(obj.val), "isinstance(df_row.name._hatchet_nid, Real)"]
         return [None, obj.name, "df_row[\"{}\"] >= {}".format(obj.prop, obj.val), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
 
     def _parse_num_nan(self, obj):
+        if obj.prop == "depth":
+            return [None, obj.name, "pd.isna(df_row.name._depth)", "isinstance(df_row.name._depth, Real)"]
+        if obj.prop == "node_id":
+            return [None, obj.name, "pd.isna(df_row.name._hatchet_nid)", "isinstance(df_row.name._hatchet_nid, Real)"]
         return [None, obj.name, "pd.isna(df_row[\"{}\"])".format(obj.prop), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
 
     def _parse_num_not_nan(self, obj):
+        if obj.prop == "depth":
+            return [None, obj.name, "not pd.isna(df_row.name._depth)", "isinstance(df_row.name._depth, Real)"]
+        if obj.prop == "node_id":
+            return [None, obj.name, "not pd.isna(df_row.name._hatchet_nid)", "isinstance(df_row.name._hatchet_nid, Real)"]
         return [None, obj.name, "not pd.isna(df_row[\"{}\"])".format(obj.prop), "isinstance(df_row[\'{}\'], Real)".format(obj.prop)]
 
 

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -1088,6 +1088,19 @@ def test_apply_cypher(mock_graph_literal):
     query = CypherQuery(path)
     assert sorted(query.apply(gf)) == sorted(match)
 
+    path = u"""MATCH (p)-[]->(q)
+    WHERE p."time (inc)" > 100 OR p."time (inc)" <= 30 AND q."time (inc)" = 20
+    """
+    roots = gf.graph.roots
+    match = [
+        roots[0],
+        roots[0].children[0],
+        roots[1],
+        roots[1].children[0],
+    ]
+    query = CypherQuery(path)
+    assert sorted(query.apply(gf)) == sorted(match)
+
     # path = [{"name": "this"}, ("*", {"name": "is"}), {"name": "nonsense"}]
     path = u"""MATCH (p)-["*", q]->(r)
     WHERE p."name" = "this" AND q."name" = "is" AND r."name" = "nonsense"

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -895,11 +895,11 @@ def test_construct_cypher_api():
     mock_node_time_true = {"time (inc)": 0.1}
     mock_node_time_false = {"time (inc)": 0.001}
     # path1 = [{"name": "MPI_[_a-zA-Z]*"}, "*", {"name": "ibv[_a-zA-Z]*"}]
-    path1 = """MATCH (p)-["*"]->(q)
+    path1 = u"""MATCH (p)-["*"]->(q)
     WHERE p."name" STARTS WITH "MPI_" AND q."name" STARTS WITH "ibv"
     """
     # path2 = [{"name": "MPI_[_a-zA-Z]*"}, 2, {"name": "ibv[_a-zA-Z]*"}]
-    path2 = """MATCH (p)-[2]->(q)
+    path2 = u"""MATCH (p)-[2]->(q)
     WHERE p."name" STARTS WITH "MPI_" AND q."name" STARTS WITH "ibv"
     """
     # path3 = [
@@ -907,7 +907,7 @@ def test_construct_cypher_api():
     #     ("+", {"time (inc)": ">= 0.1"}),
     #     {"name": "ibv[_a-zA-Z]*"},
     # ]
-    path3 = """MATCH (p)-["+", a]->(q)
+    path3 = u"""MATCH (p)-["+", a]->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" >= 0.1 AND q."name" STARTS WITH "ibv"
     """
     # path4 = [
@@ -915,7 +915,7 @@ def test_construct_cypher_api():
     #     (3, {"time (inc)": 0.1}),
     #     {"name": "ibv[_a-zA-Z]*"},
     # ]
-    path4 = """MATCH (p)-[3, a]->(q)
+    path4 = u"""MATCH (p)-[3, a]->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" = 0.1 AND q."name" STARTS WITH "ibv"
     """
     query1 = CypherQuery(path1)
@@ -978,7 +978,7 @@ def test_construct_cypher_api():
     #     ({"bad": "wildcard"}, {"time (inc)": 0.1}),
     #     {"name": "ibv[_a-zA-Z]*"},
     # ]
-    invalid_path = """MATCH (p)-[{"bad": "wildcard"}, a]->(q)
+    invalid_path = u"""MATCH (p)-[{"bad": "wildcard"}, a]->(q)
     WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" = 0.1 AND
     q."name" STARTS WITH "ibv"
     """
@@ -994,7 +994,7 @@ def test_apply_cypher(mock_graph_literal):
     #     ("*", {"name": "[^b][a-z]+"}),
     #     {"name": "gr[a-z]+"},
     # ]
-    path = """MATCH (p)-[]->(2, q)-["*", r]->(s)
+    path = u"""MATCH (p)-[]->(2, q)-["*", r]->(s)
     WHERE p."time (inc)" >= 30.0 AND NOT q."name" STARTS WITH "b"
     AND r."name" =~ "[^b][a-z]+" AND s."name" STARTS WITH "gr"
     """
@@ -1025,7 +1025,7 @@ def test_apply_cypher(mock_graph_literal):
     assert sorted(query.apply(gf)) == sorted(match)
 
     # path = [{"time (inc)": ">= 30.0"}, ".", {"name": "bar"}, "*"]
-    path = """MATCH (p)-["."]->(q)-[]->("*")
+    path = u"""MATCH (p)-["."]->(q)-[]->("*")
     WHERE p."time (inc)" >= 30.0 AND q."name" = "bar"
     """
     match = [
@@ -1052,7 +1052,7 @@ def test_apply_cypher(mock_graph_literal):
     assert sorted(query.apply(gf)) == sorted(match)
 
     # path = [{"name": "foo"}, {"name": "bar"}, {"time": 5.0}]
-    path = """MATCH (p)-[]->(q)-[]->(r)
+    path = u"""MATCH (p)-[]->(q)-[]->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND r."time" = 5.0
     """
     # match = [[root, root.children[0], root.children[0].children[0]]]
@@ -1061,7 +1061,7 @@ def test_apply_cypher(mock_graph_literal):
     assert sorted(query.apply(gf)) == sorted(match)
 
     # path = [{"name": "foo"}, {"name": "qux"}, ("+", {"time (inc)": "> 15.0"})]
-    path = """MATCH (p)-[]->(q)-[]->("+", r)
+    path = u"""MATCH (p)-[]->(q)-[]->("+", r)
     WHERE p."name" = "foo" AND q."name" = "qux" AND r."time (inc)" > 15.0
     """
     match = [
@@ -1089,7 +1089,7 @@ def test_apply_cypher(mock_graph_literal):
     assert sorted(query.apply(gf)) == sorted(match)
 
     # path = [{"name": "this"}, ("*", {"name": "is"}), {"name": "nonsense"}]
-    path = """MATCH (p)-["*", q]->(r)
+    path = u"""MATCH (p)-["*", q]->(r)
     WHERE p."name" = "this" AND q."name" = "is" AND r."name" = "nonsense"
     """
 
@@ -1097,7 +1097,7 @@ def test_apply_cypher(mock_graph_literal):
     assert query.apply(gf) == []
 
     # path = [{"name": 5}, "*", {"name": "whatever"}]
-    path = """MATCH (p)-["*"]->(q)
+    path = u"""MATCH (p)-["*"]->(q)
     WHERE p."name" = 5 AND q."name" = "whatever"
     """
     with pytest.raises(InvalidQueryFilter):
@@ -1105,7 +1105,7 @@ def test_apply_cypher(mock_graph_literal):
         query.apply(gf)
 
     # path = [{"time": "badstring"}, "*", {"name": "whatever"}]
-    path = """MATCH (p)-["*"]->(q)
+    path = u"""MATCH (p)-["*"]->(q)
     WHERE p."time" = "badstring" AND q."name" = "whatever"
     """
     query = CypherQuery(path)
@@ -1124,7 +1124,7 @@ def test_apply_cypher(mock_graph_literal):
     ] = DummyType()
     gf = GraphFrame.from_literal(bad_field_test_dict)
     # path = [{"name": "foo"}, {"name": "bar"}, {"list": DummyType()}]
-    path = """MATCH (p)-[]->(q)-[]->(r)
+    path = u"""MATCH (p)-[]->(q)-[]->(r)
     WHERE p."name" = "foo" AND q."name" = "bar" AND p."list" = DummyType()
     """
     with pytest.raises(InvalidQueryPath):
@@ -1132,7 +1132,7 @@ def test_apply_cypher(mock_graph_literal):
         query.apply(gf)
 
     # path = ["*", {"name": "bar"}, {"name": "grault"}, "*"]
-    path = """MATCH ("*")-[]->(p)-[]->(q)-[]->("*")
+    path = u"""MATCH ("*")-[]->(p)-[]->(q)-[]->("*")
     WHERE p."name" = "bar" AND q."name" = "grault"
     """
     match = [
@@ -1180,7 +1180,7 @@ def test_apply_cypher(mock_graph_literal):
     assert sorted(query.apply(gf)) == sorted(match)
 
     # path = ["*", {"name": "bar"}, {"name": "grault"}, "+"]
-    path = """MATCH ("*")-[]->(p)-[]->(q)-[]->("+")
+    path = u"""MATCH ("*")-[]->(p)-[]->(q)-[]->("+")
     WHERE p."name" = "bar" AND q."name" = "grault"
     """
     query = CypherQuery(path)

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -21,6 +21,7 @@ from hatchet.query import (
     IntersectionQuery,
     UnionQuery,
     SymDifferenceQuery,
+    CypherQuery
 )
 
 
@@ -886,3 +887,299 @@ def test_sym_diff_query(mock_graph_literal):
         # roots[1].children[0].children[1],
     ]
     assert sorted(compound_query.apply(gf)) == sorted(matches)
+
+def test_construct_cypher_api():
+    mock_node_mpi = {"name": "MPI_Bcast"}
+    mock_node_ibv = {"name": "ibv_reg_mr"}
+    mock_node_time_true = {"time (inc)": 0.1}
+    mock_node_time_false = {"time (inc)": 0.001}
+    # path1 = [{"name": "MPI_[_a-zA-Z]*"}, "*", {"name": "ibv[_a-zA-Z]*"}]
+    path1 = """MATCH (p)-["*"]->(q)
+    WHERE p."name" STARTS WITH "MPI_" AND q."name" STARTS WITH "ibv"
+    """
+    # path2 = [{"name": "MPI_[_a-zA-Z]*"}, 2, {"name": "ibv[_a-zA-Z]*"}]
+    path2 = """MATCH (p)-[2]->(q)
+    WHERE p."name" STARTS WITH "MPI_" AND q."name" STARTS WITH "ibv"
+    """
+    # path3 = [
+    #     {"name": "MPI_[_a-zA-Z]*"},
+    #     ("+", {"time (inc)": ">= 0.1"}),
+    #     {"name": "ibv[_a-zA-Z]*"},
+    # ]
+    path3 = """MATCH (p)-["+", a]->(q)
+    WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" >= 0.1 AND q."name" STARTS WITH "ibv"
+    """
+    # path4 = [
+    #     {"name": "MPI_[_a-zA-Z]*"},
+    #     (3, {"time (inc)": 0.1}),
+    #     {"name": "ibv[_a-zA-Z]*"},
+    # ]
+    path4 = """MATCH (p)-[3, a]->(q)
+    WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" = 0.1 AND q."name" STARTS WITH "ibv"
+    """
+    query1 = CypherQuery(path1)
+    query2 = CypherQuery(path2)
+    query3 = CypherQuery(path3)
+    query4 = CypherQuery(path4)
+
+    assert query1.query_matcher.query_pattern[0][0] == "."
+    assert query1.query_matcher.query_pattern[0][1](mock_node_mpi)
+    assert not query1.query_matcher.query_pattern[0][1](mock_node_ibv)
+    assert not query1.query_matcher.query_pattern[0][1](mock_node_time_true)
+    assert query1.query_matcher.query_pattern[1][0] == "*"
+    assert query1.query_matcher.query_pattern[1][1](mock_node_mpi)
+    assert query1.query_matcher.query_pattern[1][1](mock_node_ibv)
+    assert query1.query_matcher.query_pattern[1][1](mock_node_time_true)
+    assert query1.query_matcher.query_pattern[1][1](mock_node_time_false)
+    assert query1.query_matcher.query_pattern[2][0] == "."
+
+    assert query2.query_matcher.query_pattern[0][0] == "."
+    assert query2.query_matcher.query_pattern[1][0] == "."
+    assert query2.query_matcher.query_pattern[1][1](mock_node_mpi)
+    assert query2.query_matcher.query_pattern[1][1](mock_node_ibv)
+    assert query2.query_matcher.query_pattern[1][1](mock_node_time_true)
+    assert query2.query_matcher.query_pattern[1][1](mock_node_time_false)
+    assert query2.query_matcher.query_pattern[2][0] == "."
+    assert query2.query_matcher.query_pattern[2][1](mock_node_mpi)
+    assert query2.query_matcher.query_pattern[2][1](mock_node_ibv)
+    assert query2.query_matcher.query_pattern[2][1](mock_node_time_true)
+    assert query2.query_matcher.query_pattern[2][1](mock_node_time_false)
+    assert query2.query_matcher.query_pattern[3][0] == "."
+
+    assert query3.query_matcher.query_pattern[0][0] == "."
+    assert query3.query_matcher.query_pattern[1][0] == "+"
+    assert not query3.query_matcher.query_pattern[1][1](mock_node_mpi)
+    assert not query3.query_matcher.query_pattern[1][1](mock_node_ibv)
+    assert query3.query_matcher.query_pattern[1][1](mock_node_time_true)
+    assert not query3.query_matcher.query_pattern[1][1](mock_node_time_false)
+    assert query3.query_matcher.query_pattern[2][0] == "."
+
+    assert query4.query_matcher.query_pattern[0][0] == "."
+    assert query4.query_matcher.query_pattern[1][0] == "."
+    assert not query4.query_matcher.query_pattern[1][1](mock_node_mpi)
+    assert not query4.query_matcher.query_pattern[1][1](mock_node_ibv)
+    assert query4.query_matcher.query_pattern[1][1](mock_node_time_true)
+    assert not query4.query_matcher.query_pattern[1][1](mock_node_time_false)
+    assert query4.query_matcher.query_pattern[2][0] == "."
+    assert not query4.query_matcher.query_pattern[2][1](mock_node_mpi)
+    assert not query4.query_matcher.query_pattern[2][1](mock_node_ibv)
+    assert query4.query_matcher.query_pattern[2][1](mock_node_time_true)
+    assert not query4.query_matcher.query_pattern[2][1](mock_node_time_false)
+    assert query4.query_matcher.query_pattern[3][0] == "."
+    assert not query4.query_matcher.query_pattern[3][1](mock_node_mpi)
+    assert not query4.query_matcher.query_pattern[3][1](mock_node_ibv)
+    assert query4.query_matcher.query_pattern[3][1](mock_node_time_true)
+    assert not query4.query_matcher.query_pattern[3][1](mock_node_time_false)
+    assert query4.query_matcher.query_pattern[4][0] == "."
+
+    # invalid_path = [
+    #     {"name": "MPI_[_a-zA-Z]*"},
+    #     ({"bad": "wildcard"}, {"time (inc)": 0.1}),
+    #     {"name": "ibv[_a-zA-Z]*"},
+    # ]
+    invalid_path = """MATCH (p)-[{"bad": "wildcard"}, a]->(q)
+    WHERE p."name" STARTS WITH "MPI" AND a."time (inc)" = 0.1 AND
+    q."name" STARTS WITH "ibv"
+    """
+    with pytest.raises(InvalidQueryPath):
+        _ = CypherQuery(invalid_path)
+
+def test_apply_cypher(mock_graph_literal):
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    # path = [
+    #     {"time (inc)": ">= 30.0"},
+    #     (2, {"name": "[^b][a-z]+"}),
+    #     ("*", {"name": "[^b][a-z]+"}),
+    #     {"name": "gr[a-z]+"},
+    # ]
+    path = """MATCH (p)-[]->(2, q)-["*", r]->(s)
+    WHERE p."time (inc)" >= 30.0 AND NOT q."name" STARTS WITH "b"
+    AND r."name" =~ "[^b][a-z]+" AND s."name" STARTS WITH "gr"
+    """
+    root = gf.graph.roots[0]
+    match = [
+        root,
+        root.children[1],
+        root.children[1].children[0],
+        root.children[1].children[0].children[0],
+        root.children[1].children[0].children[0].children[1],
+        # Old-style return value of apply
+        # [
+        #     root,
+        #     root.children[1],
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[1],
+        # ],
+        # [
+        #     root.children[1],
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[1],
+        # ],
+    ]
+    query = CypherQuery(path)
+
+    assert sorted(query.apply(gf)) == sorted(match)
+
+    # path = [{"time (inc)": ">= 30.0"}, ".", {"name": "bar"}, "*"]
+    path = """MATCH (p)-["."]->(q)-[]->("*")
+    WHERE p."time (inc)" >= 30.0 AND q."name" = "bar"
+    """
+    match = [
+        root.children[1].children[0],
+        root.children[1].children[0].children[0],
+        root.children[1].children[0].children[0].children[0],
+        root.children[1].children[0].children[0].children[0].children[0],
+        root.children[1].children[0].children[0].children[0].children[1],
+        # Old-style return value of apply
+        # [
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[0].children[0],
+        # ],
+        # [
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[0].children[1],
+        # ],
+    ]
+    query = CypherQuery(path)
+    assert sorted(query.apply(gf)) == sorted(match)
+
+    # path = [{"name": "foo"}, {"name": "bar"}, {"time": 5.0}]
+    path = """MATCH (p)-[]->(q)-[]->(r)
+    WHERE p."name" = "foo" AND q."name" = "bar" AND r."time" = 5.0
+    """
+    # match = [[root, root.children[0], root.children[0].children[0]]]
+    match = [root, root.children[0], root.children[0].children[0]]
+    query = CypherQuery(path)
+    assert sorted(query.apply(gf)) == sorted(match)
+
+    # path = [{"name": "foo"}, {"name": "qux"}, ("+", {"time (inc)": "> 15.0"})]
+    path = """MATCH (p)-[]->(q)-[]->("+", r)
+    WHERE p."name" = "foo" AND q."name" = "qux" AND r."time (inc)" > 15.0
+    """
+    match = [
+        root,
+        root.children[1],
+        root.children[1].children[0],
+        root.children[1].children[0].children[0],
+        root.children[1].children[0].children[0].children[0],
+        # Old-style return value of apply
+        # [
+        #     root,
+        #     root.children[1],
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        #     root.children[1].children[0].children[0].children[0],
+        # ],
+        # [
+        #     root,
+        #     root.children[1],
+        #     root.children[1].children[0],
+        #     root.children[1].children[0].children[0],
+        # ],
+    ]
+    query = CypherQuery(path)
+    assert sorted(query.apply(gf)) == sorted(match)
+
+    # path = [{"name": "this"}, ("*", {"name": "is"}), {"name": "nonsense"}]
+    path = """MATCH (p)-["*", q]->(r)
+    WHERE p."name" = "this" AND q."name" = "is" AND r."name" = "nonsense"
+    """
+
+    query = CypherQuery(path)
+    assert query.apply(gf) == []
+
+    # path = [{"name": 5}, "*", {"name": "whatever"}]
+    path = """MATCH (p)-["*"]->(q)
+    WHERE p."name" = 5 AND q."name" = "whatever"
+    """
+    with pytest.raises(InvalidQueryFilter):
+        query = CypherQuery(path)
+        query.apply(gf)
+
+    # path = [{"time": "badstring"}, "*", {"name": "whatever"}]
+    path = """MATCH (p)-["*"]->(q)
+    WHERE p."time" = "badstring" AND q."name" = "whatever"
+    """
+    query = CypherQuery(path)
+    with pytest.raises(InvalidQueryFilter):
+        query.apply(gf)
+
+    class DummyType:
+        def __init__(self):
+            self.x = 5.0
+            self.y = -1
+            self.z = "hello"
+
+    bad_field_test_dict = list(mock_graph_literal)
+    bad_field_test_dict[0]["children"][0]["children"][0]["metrics"][
+        "list"
+    ] = DummyType()
+    gf = GraphFrame.from_literal(bad_field_test_dict)
+    # path = [{"name": "foo"}, {"name": "bar"}, {"list": DummyType()}]
+    path = """MATCH (p)-[]->(q)-[]->(r)
+    WHERE p."name" = "foo" AND q."name" = "bar" AND p."list" = DummyType()
+    """
+    with pytest.raises(InvalidQueryPath):
+        query = CypherQuery(path)
+        query.apply(gf)
+
+    # path = ["*", {"name": "bar"}, {"name": "grault"}, "*"]
+    path = """MATCH ("*")-[]->(p)-[]->(q)-[]->("*")
+    WHERE p."name" = "bar" AND q."name" = "grault"
+    """
+    match = [
+        [root, root.children[0], root.children[0].children[1]],
+        [root.children[0], root.children[0].children[1]],
+        [
+            root,
+            root.children[1],
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+        [
+            root.children[1],
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+        [
+            root.children[1].children[0],
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+        [
+            root.children[1].children[0].children[0],
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+        [
+            root.children[1].children[0].children[0].children[0],
+            root.children[1].children[0].children[0].children[0].children[1],
+        ],
+        [
+            gf.graph.roots[1],
+            gf.graph.roots[1].children[0],
+            gf.graph.roots[1].children[0].children[1],
+        ],
+        [gf.graph.roots[1].children[0], gf.graph.roots[1].children[0].children[1]],
+    ]
+    match = list(set().union(*match))
+    query = CypherQuery(path)
+    assert sorted(query.apply(gf)) == sorted(match)
+
+    # path = ["*", {"name": "bar"}, {"name": "grault"}, "+"]
+    path = """MATCH ("*")-[]->(p)-[]->(q)-[]->("+")
+    WHERE p."name" = "bar" AND q."name" = "grault"
+    """
+    query = CypherQuery(path)
+    assert query.apply(gf) == []

--- a/hatchet/tests/query.py
+++ b/hatchet/tests/query.py
@@ -21,7 +21,7 @@ from hatchet.query import (
     IntersectionQuery,
     UnionQuery,
     SymDifferenceQuery,
-    CypherQuery
+    CypherQuery,
 )
 
 
@@ -888,6 +888,7 @@ def test_sym_diff_query(mock_graph_literal):
     ]
     assert sorted(compound_query.apply(gf)) == sorted(matches)
 
+
 def test_construct_cypher_api():
     mock_node_mpi = {"name": "MPI_Bcast"}
     mock_node_ibv = {"name": "ibv_reg_mr"}
@@ -983,6 +984,7 @@ def test_construct_cypher_api():
     """
     with pytest.raises(InvalidQueryPath):
         _ = CypherQuery(invalid_path)
+
 
 def test_apply_cypher(mock_graph_literal):
     gf = GraphFrame.from_literal(mock_graph_literal)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ numpy
 PyYAML
 cython
 multiprocess
+textX

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "hatchet.tests",
         "hatchet.cython_modules.libs",
     ],
-    install_requires=["pydot", "PyYAML", "matplotlib", "numpy", "pandas"],
+    install_requires=["pydot", "PyYAML", "matplotlib", "numpy", "pandas", "textX"],
     ext_modules=[
         Extension(
             "hatchet.cython_modules.libs.reader_modules",


### PR DESCRIPTION
Resolves #363 

This PR adds a new API "level" to the Hatchet Query Langauge. This API uses a slightly modified subset of the [Cypher query language](https://www.opencypher.org/).

As with a normal Cypher query, you can think of a middle-level API query as consisting of two parts:
1. Path Specification
2. Condition Specification

## Path Specification

In the path specification, the user specifies the wildcards and order of abstract nodes. This part of the query must start with the "MATCH" keyword. The rest of the specification consists of a series of abstract nodes and edges in the following general form:
```diff
- MATCH (...)-[...]->(...)-[...]->(...)
+ MATCH (...)->(...)->(...)
```
_In the above example, the text in red is the old version of the path specification, and the text in green is the new version._

In the above example, every instance of "..." represents a possible abstract node. However, only the "..." between parentheses must be replaced with actual content. The "..." between square braces can be left empty if desired.

The path specification must contain at least one "node" (content in parentheses) and zero or more "edges" (the `-[]->` syntax). The path specification must also end with a "node".

Each placeholder above (i.e., "...") must contain one of the following:
1. Only a wildcard (same syntax for wildcards as in the high- and low-level APIs) (e.g., `"."`, `"*"`, `"+"`, `1`, `4`, etc)
2. A "variable name" (to be used in the condition section) (e.g., `p`)
3. Both a wildcard and a variable name, separated by a comma (e.g., `"*", p`)

## Condition Specification

The condition specification section is used to specify all the conditions that define what real nodes can be matched to abstract nodes in the Path Specification section. This is similar to the filters of the high- and low-level APIs, but, in the middle-level API, all the conditions are specified in a single statement using boolean operators (e.g., and, or, etc.). Internally, the `CypherQuery` class will convert all these conditions into the individual filters used in the high- and low-level APIs.

The condition specification section starts with the "WHERE" keyword followed by the conditions. Each individual condition has the following form:
```
<VAR NAME>."<ATTRIBUTE NAME>" <OPERATOR> [VAL]
```
In the above specification, content in angle braces (`<>`) represents required user-provided content, and content in square braces represents optional content. This notation is consistent with Cypher with one major exception: the `ATTRIBUTE NAME` field **must** be in quotes. This is due to the fact that node attributes in Hatchet (e.g., "time", "time (inc)", etc.) are not guaranteed to follow variable naming requirements, which is guaranteed in Cypher.

There are two sets of "operators" in the middle-level API: string operators and number operators. The tables below describes the available operators for each type.
**Type-Less Operators:**
| Operator                | Example                    | Description                                                             |
| :----                        | :----                             | :----                                                                         |
| Is None | `p."time" IS NONE` | Checks if attribute value is None |
| Is Not None | `p."time" IS NOT NONE` | Checks if attribute value is not None |

**String Operators:**
| Operator                | Example                    | Description                                                             |
| :----                        | :----                             | :----                                                                         |
| Equivalence          | `p."name" = "main"`    | Checks if attribute value matches right-hand side |
| Starts With            | `p."name" STARTS WITH "MPI"` | Checks if attribute value starts with right-hand side |
| Ends With             | `p."name" ENDS WITH "impl"`     | Checks if attribute value ends with right-hand side  |
| Contains               | `p."name" CONTAINS "RAJA"`    | Checks if attribute value contains right-hand side as a substring |
| Regex Match        | `p."name" =~ "<([\w]+).*>(.*?)<\/\1>"` | Checks if attribute value satisfies the regex expression |

**Number Operators:**
| Operator                | Example                    | Description                                                             |
| :----                        | :----                             | :----                                                                         |
| Equivalence          | `p."time" = 5`              | Checks if attribute value is equal to right-hand side |
| Less-Than             | `p."time (inc)" < 20`   | Checks if attribute value is less than right-hand side |
| Greater-Than        | `p."time (inc)" > 60`   | Checks if attribute value is greater than right-hand side |
| Less-Than or Equal | `p."time (inc)" <= 20`   | Checks if attribute value is less than or equal to right-hand side |
| Greater-Than or Equal | `p."time (inc)" >= 60`   | Checks if attribute value is greater than or equal to right-hand side |
| Is NaN | `p."time" IS NAN` | Checks if attribute value is NaN |
| Is Not NaN | `p."time" IS NOT NAN` | Checks if attribute value is not NaN |
| Is Infinity | `p."time" IS INF` | Checks if attribute value is Infinity |
| Is Not Infinity | `p."time" IS NOT INF` | Checks if attribute value is not Infinity |

**"Other" Operators:**
| Operator                | Example                    | Description                                                             |
| :----                        | :----                             | :----                                                                         |
| Is None                  | `p."attr" IS NONE`        | Checks if attribute value is `None`                          |
| Is Not None                  | `p."attr" IS NOT NONE`        | Checks if attribute value is not `None`                          |

To combine individual conditions, use the three provided binary and unary operators:
1. `AND`
2. `OR`
3. `NOT`

**NOTE: currently, all syntax is _case sensitive_! In the future, I'll probably be modifying it so the keywords (e.g., "MATCH", "WHERE", "ENDS WITH", etc.) are not case sensitive, but for now, make sure keywords are in all caps!**

## Putting Everything Together

Both parts of the middle-level API query should be combined into a string (I recommend a multi-line string). Once this string is created, the user can use it just like a high-level query. So, to filter a `GraphFrame` using a middle-level API query, simply pass this string to the `GraphFrame.filter` function. For example:
```python
path = """MATCH (p)-[]->(2, q)-["*", r]->(s)
WHERE p."time (inc)" >= 30.0 AND NOT q."name" STARTS WITH "b"
AND r."name" =~ "[^b][a-z]+" AND s."name" STARTS WITH "gr"
"""
filtered_gf = gf.filter(path)
```

Internally, the `GraphFrame.filter` function will pass the middle-level API query to the new `CypherQuery` class, which uses the textX library to parse the input and construct a Hatchet query from it.