### PR TITLE
Compound Query Operators

### DIFF
--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -15,6 +15,7 @@ except ImportError:
 from itertools import groupby
 from numbers import Real
 import re
+import sys
 import pandas as pd
 from pandas import DataFrame
 from pandas.core.indexes.multi import MultiIndex
@@ -645,8 +646,10 @@ class AndQuery(NaryQuery):
     of the subqueries"""
 
     def __init__(self, *args):
-        # TODO Remove Arguments when Python 2.7 support is dropped
-        super(AndQuery, self).__init__(args)
+        if sys.version_info[0] == 2:
+            super(AndQuery, self).__init__(args)
+        else:
+            super().__init__(args)
         if len(self.subqueries) < 2:
             raise BadNumberNaryQueryArgs("AndQuery requires 2 or more subqueries")
 
@@ -664,8 +667,10 @@ class OrQuery(NaryQuery):
     of the subqueries"""
 
     def __init__(self, *args):
-        # TODO Remove Arguments when Python 2.7 support is dropped
-        super(OrQuery, self).__init__(args)
+        if sys.version_info[0] == 2:
+            super(OrQuery, self).__init__(args)
+        else:
+            super().__init__(args)
         if len(self.subqueries) < 2:
             raise BadNumberNaryQueryArgs("OrQuery requires 2 or more subqueries")
 
@@ -683,8 +688,10 @@ class XorQuery(NaryQuery):
     (i.e., set-based XOR) of the results of the subqueries"""
 
     def __init__(self, *args):
-        # TODO Remove Arguments when Python 2.7 support is dropped
-        super(XorQuery, self).__init__(args)
+        if sys.version_info[0] == 2:
+            super(XorQuery, self).__init__(args)
+        else:
+            super().__init__(args)
         if len(self.subqueries) < 2:
             raise BadNumberNaryQueryArgs("XorQuery requires 2 or more subqueries")
 
@@ -704,8 +711,10 @@ class NotQuery(NaryQuery):
     are not returned from the subquery."""
 
     def __init__(self, *args):
-        # TODO Remove Arguments when Python 2.7 support is dropped
-        super(NotQuery, self).__init__(args)
+        if sys.version_info[0] == 2:
+            super(NotQuery, self).__init__(args)
+        else:
+            super().__init__(args)
         if len(self.subqueries) != 1:
             raise BadNumberNaryQueryArgs("NotQuery requires exactly 1 subquery")
 

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -27,11 +27,23 @@ from .node import Node, traversal_order
 
 
 class AbstractQuery(ABC):
-    """Interface defining a Hatchet Query"""
+    """Abstract Base Class defining a Hatchet Query"""
 
     @abstractmethod
     def apply(self, gf):
         pass
+
+    def __and__(self, *others):
+        return AndQuery(self, *others)
+
+    def __or__(self, *others):
+        return OrQuery(self, *others)
+
+    def __xor__(self, *others):
+        return XorQuery(self, *others)
+
+    def __invert__(self):
+        return NotQuery(self)
 
 
 class NaryQuery(AbstractQuery):

--- a/hatchet/query.py
+++ b/hatchet/query.py
@@ -33,14 +33,14 @@ class AbstractQuery(ABC):
     def apply(self, gf):
         pass
 
-    def __and__(self, *others):
-        return AndQuery(self, *others)
+    def __and__(self, other):
+        return AndQuery(self, other)
 
-    def __or__(self, *others):
-        return OrQuery(self, *others)
+    def __or__(self, other):
+        return OrQuery(self, other)
 
-    def __xor__(self, *others):
-        return XorQuery(self, *others)
+    def __xor__(self, other):
+        return XorQuery(self, other)
 
     def __invert__(self):
         return NotQuery(self)


### PR DESCRIPTION
Resolves #338 

This PR adds the following operators to the `AbstractQuery` class introduced in #333:
1. `&`: constructs an `AndQuery`
2. `|`: constructs an `OrQuery`
3. `^`: constructs a `XorQuery`
4. `~`: constructs a `NotQuery`

Because of the use of `NotQuery`, this PR is dependent on #348 and should not be merged before that PR.