### PR TITLE
Add more Pandas-based Checkpointing and Save/Load Functions

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -33,7 +33,9 @@ jobs:
         python -m pip install --upgrade pip flake8 pytest
         pip install -r requirements.txt
         # Optional Dependency for HDF Checkpointing
-        pip install tables
+        python -m pip install tables
+        # All Possible Optional Dependencies for Excel Checkpointing
+        python -m pip install XlsxWriter openpyxl pyxlsb xlrd xlwt
         python setup.py install
         python setup.py build_ext --inplace
         python -m pip list

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -35,7 +35,8 @@ jobs:
         # Optional Dependency for HDF Checkpointing
         python -m pip install tables
         # All Possible Optional Dependencies for Excel Checkpointing
-        python -m pip install XlsxWriter openpyxl pyxlsb xlrd xlwt
+        # python -m pip install XlsxWriter openpyxl pyxlsb xlrd xlwt
+        python -m pip install xlrd xlwt
         python setup.py install
         python setup.py build_ext --inplace
         python -m pip list

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -360,17 +360,24 @@ class GraphFrame:
         )
 
     @staticmethod
-    def from_hdf(filename, key=None):
+    def from_hdf(filename, key=None, **kwargs):
         # import this lazily to avoid circular dependencies
         from .readers.hdf5_reader import HDF5Reader
 
-        return HDF5Reader(filename).read(**kwargs)
+        return HDF5Reader(filename).read(key=key, **kwargs)
 
-    def to_hdf(self, filename, key="hatchet_graphframe", **kwargs):
+    def to_hdf(
+        self,
+        filename,
+        key="hatchet_graphframe",
+        **kwargs
+    ):
         # import this lazily to avoid circular dependencies
         from .writers.hdf5_writer import HDF5Writer
 
-        HDF5Writer(filename).write(self, key=key, **kwargs)
+        HDF5Writer(filename).write(
+            self, key=key, **kwargs
+        )
 
     @staticmethod
     def from_pickle(filename, **kwargs):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -366,18 +366,11 @@ class GraphFrame:
 
         return HDF5Reader(filename).read(key=key, **kwargs)
 
-    def to_hdf(
-        self,
-        filename,
-        key="hatchet_graphframe",
-        **kwargs
-    ):
+    def to_hdf(self, filename, key="hatchet_graphframe", **kwargs):
         # import this lazily to avoid circular dependencies
         from .writers.hdf5_writer import HDF5Writer
 
-        HDF5Writer(filename).write(
-            self, key=key, **kwargs
-        )
+        HDF5Writer(filename).write(self, key=key, **kwargs)
 
     @staticmethod
     def from_pickle(filename, **kwargs):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -298,7 +298,7 @@ class GraphFrame:
                     fformat = _custom_format_extensions[extension]
         if fformat is not None:
             try:
-                gf = _load_func_dict[fformat](filename **kwargs)
+                gf = _load_func_dict[fformat](filename, **kwargs)
                 print("Successfully loaded from {}".format(fformat))
                 return gf
             except ImportError:
@@ -307,40 +307,42 @@ class GraphFrame:
                         fformat
                     )
                 )
-        raise ValueError("File format was not provided and could not be automatically determined.")
-#
-#         format_priority = ["hdf", "pickle", "csv", "excel"]
-#         fformat = fileformat
-#         if fformat is None:
-#             for ext in _custom_format_extensions.keys():
-#                 if filename.endswith(ext):
-#                     fformat = _custom_format_extensions[ext]
-#                     break
-#         if fformat is not None and fformat in format_priority:
-#             format_priority.remove(fformat)
-#             try:
-#                 gf = _load_func_dict[fformat](filename, **kwargs)
-#                 print("Successfully loaded to {}".format(fformat))
-#                 return gf
-#             except ImportError:
-#                 print(
-#                     "Could not load from {} format. Trying alternatives.".format(
-#                         fformat
-#                     )
-#                 )
-#         for form in format_priority:
-#             print("Trying {}".format(form))
-#             try:
-#                 gf = _load_func_dict[form](filename, **kwargs)
-#                 print("Sucessfully loaded from {}".format(form))
-#                 return gf
-#             except ImportError:
-#                 print("Could not load from {} format.".format(form))
-#         raise IOError(
-#             "Could not parse {} with the available formats. Make sure you have the necessary dependencies installed.".format(
-#                 filename
-#             )
-#         )
+        raise ValueError(
+            "File format was not provided and could not be automatically determined."
+        )
+        #
+        # format_priority = ["hdf", "pickle", "csv", "excel"]
+        # fformat = fileformat
+        # if fformat is None:
+        #     for ext in _custom_format_extensions.keys():
+        #         if filename.endswith(ext):
+        #             fformat = _custom_format_extensions[ext]
+        #             break
+        # if fformat is not None and fformat in format_priority:
+        #     format_priority.remove(fformat)
+        #     try:
+        #         gf = _load_func_dict[fformat](filename, **kwargs)
+        #         print("Successfully loaded to {}".format(fformat))
+        #         return gf
+        #     except ImportError:
+        #         print(
+        #             "Could not load from {} format. Trying alternatives.".format(
+        #                 fformat
+        #             )
+        #         )
+        # for form in format_priority:
+        #     print("Trying {}".format(form))
+        #     try:
+        #         gf = _load_func_dict[form](filename, **kwargs)
+        #         print("Sucessfully loaded from {}".format(form))
+        #         return gf
+        #     except ImportError:
+        #         print("Could not load from {} format.".format(form))
+        # raise IOError(
+        #     "Could not parse {} with the available formats. Make sure you have the necessary dependencies installed.".format(
+        #         filename
+        #     )
+        # )
 
     def save(self, filename, fileformat=None, **kwargs):
         fformat = fileformat
@@ -354,7 +356,7 @@ class GraphFrame:
                     fformat = _custom_format_extensions[extension]
         if fformat is not None:
             try:
-                _save_func_dict[fformat](self, filename **kwargs)
+                _save_func_dict[fformat](self, filename, **kwargs)
                 print("Successfully saved to {}".format(fformat))
                 return
             except ImportError:
@@ -363,7 +365,9 @@ class GraphFrame:
                         fformat
                     )
                 )
-        raise ValueError("File format was not provided and could not be automatically determined.")
+        raise ValueError(
+            "File format was not provided and could not be automatically determined."
+        )
         # format_priority = ["hdf", "pickle", "csv", "excel"]
         # fformat = fileformat
         # if fformat is None:

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -271,6 +271,17 @@ class GraphFrame:
 
         HDF5Writer(filename).write(self, key=key, **kwargs)
 
+    @staticmethod
+    def from_pickle(filename, **kwargs):
+        from .readers.pickle_reader import PickleReader
+
+        return PickleReader(filename).read(**kwargs)
+
+    def to_pickle(filename, **kwargs):
+        from .writers.pickle_writer import PickleWriter
+
+        PickleWriter(filename).write(**kwargs)
+
     def copy(self):
         """Return a shallow copy of the graphframe.
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -281,21 +281,15 @@ class GraphFrame:
         format_priority = ["hdf", "pickle", "csv", "excel"]
         fformat = fileformat
         if fformat is None:
-            # TODO
-            # for ext in self._format_extensions.keys():
             for ext in _format_extensions.keys():
                 if filename.endswith(ext):
-                    # TODO
-                    # fformat = self._format_extensions[ext]
                     fformat = _format_extensions[ext]
                     break
         if fformat is not None and fformat in format_priority:
             format_priority.remove(fformat)
             try:
-                # TODO
-                # gf = self._load_func_dict[fformat](filename, **kwargs)
                 gf = _load_func_dict[fformat](filename, **kwargs)
-                print("Successfully saved to {}".format(fformat))
+                print("Successfully loaded to {}".format(fformat))
                 return gf
             except ImportError:
                 print(
@@ -306,8 +300,6 @@ class GraphFrame:
         for form in format_priority:
             print("Trying {}".format(form))
             try:
-                # TODO
-                # gf = self._load_func_dict[form](filename, **kwargs)
                 gf = _load_func_dict[form](filename, **kwargs)
                 print("Sucessfully loaded from {}".format(form))
                 return gf

--- a/hatchet/readers/csv_reader.py
+++ b/hatchet/readers/csv_reader.py
@@ -3,13 +3,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-from .pandas_writer import PandasWriter
+import pandas as pd
+from .pandas_reader import PandasReader
 
 
-class PickleWriter(PandasWriter):
+class CSVReader(PandasReader):
     def __init__(self, filename):
         # TODO Remove Arguments when Python 2.7 support is dropped
-        super(PickleWriter, self).__init__(filename)
+        super(CSVReader, self).__init__(filename)
 
-    def _write_to_file_type(self, df, **kwargs):
-        df.to_pickle(self.fname, **kwargs)
+    def _read_from_file_type(self, **kwargs):
+        return pd.read_csv(self.fname, **kwargs)

--- a/hatchet/readers/csv_reader.py
+++ b/hatchet/readers/csv_reader.py
@@ -9,13 +9,18 @@ import pandas as pd
 from .pandas_reader import PandasReader
 
 import pickle
+import sys
 
 
 def _unpickle_series_elems(pd_series):
     # unpickled_elems = [pickle.loads(e.encode("utf-8")) for e in pd_series]
     unpickled_elems = []
     for e in pd_series:
-        e_bytes = literal_eval(e)
+        e_bytes = e
+        print(sys.version_info)
+        print(sys.version_info >= (3,))
+        if sys.version_info >= (3,):
+            e_bytes = literal_eval(e)
         unpickled_elems.append(pickle.loads(e_bytes))
     return pd.Series(unpickled_elems)
 

--- a/hatchet/readers/csv_reader.py
+++ b/hatchet/readers/csv_reader.py
@@ -2,9 +2,42 @@
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
+from __future__ import unicode_literals
 
+from ast import literal_eval
 import pandas as pd
 from .pandas_reader import PandasReader
+
+import pickle
+
+
+def _unpickle_series_elems(pd_series):
+    # unpickled_elems = [pickle.loads(e.encode("utf-8")) for e in pd_series]
+    unpickled_elems = []
+    for e in pd_series:
+        e_bytes = literal_eval(e)
+        unpickled_elems.append(pickle.loads(e_bytes))
+    return pd.Series(unpickled_elems)
+
+
+def _corrrect_children_and_parent_col_types(df):
+    new_children_col = []
+    for c in df["children"]:
+        if not isinstance(c, list):
+            new_val = literal_eval(c)
+            new_children_col.append(new_val)
+        else:
+            new_children_col.append(c)
+    df["children"] = pd.Series(new_children_col)
+    new_parent_col = []
+    for p in df["parents"]:
+        if not isinstance(p, list):
+            new_val = literal_eval(p)
+            new_parent_col.append(new_val)
+        else:
+            new_parent_col.append(p)
+    df["parents"] = pd.Series(new_parent_col)
+    return df
 
 
 class CSVReader(PandasReader):
@@ -13,4 +46,19 @@ class CSVReader(PandasReader):
         super(CSVReader, self).__init__(filename)
 
     def _read_from_file_type(self, **kwargs):
-        return pd.read_csv(self.fname, **kwargs)
+        index_col = None
+        if "index_col" in kwargs:
+            index_col = kwargs["index_col"]
+            del kwargs["index_col"]
+        csv_df = pd.read_csv(self.fname, index_col=0, **kwargs)
+        csv_df["node"] = _unpickle_series_elems(csv_df["node"])
+        csv_df = _corrrect_children_and_parent_col_types(csv_df)
+        if index_col is not None:
+            return csv_df.reset_index(drop=True).set_index(index_col)
+        multindex_cols = ["node", "rank", "thread"]
+        while len(multindex_cols) > 0:
+            if set(multindex_cols).issubset(csv_df.columns):
+                return csv_df.reset_index(drop=True).set_index(multindex_cols)
+            multindex_cols.pop()
+        # TODO Replace with a custom error
+        raise RuntimeError("Could not generate a valid Index or MultiIndex")

--- a/hatchet/readers/csv_reader.py
+++ b/hatchet/readers/csv_reader.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2017-2021 Lawrence Livermore National Security, LLC and other
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 from ast import literal_eval
 import pandas as pd
-from .pandas_reader import PandasReader
+from .dataframe_reader import DataframeReader
 
 import pickle
 import sys
@@ -45,17 +45,19 @@ def _corrrect_children_and_parent_col_types(df):
     return df
 
 
-class CSVReader(PandasReader):
+class CSVReader(DataframeReader):
     def __init__(self, filename):
-        # TODO Remove Arguments when Python 2.7 support is dropped
-        super(CSVReader, self).__init__(filename)
+        if sys.version_info[0] == 2:
+            super(CSVReader, self).__init__(filename)
+        else:
+            super().__init__(filename)
 
-    def _read_from_file_type(self, **kwargs):
+    def _read_dataframe_from_file(self, **kwargs):
         index_col = None
         if "index_col" in kwargs:
             index_col = kwargs["index_col"]
             del kwargs["index_col"]
-        csv_df = pd.read_csv(self.fname, index_col=0, **kwargs)
+        csv_df = pd.read_csv(self.filename, index_col=0, **kwargs)
         csv_df["node"] = _unpickle_series_elems(csv_df["node"])
         csv_df = _corrrect_children_and_parent_col_types(csv_df)
         if index_col is not None:

--- a/hatchet/readers/excel_reader.py
+++ b/hatchet/readers/excel_reader.py
@@ -3,13 +3,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-from .pandas_writer import PandasWriter
+import pandas as pd
+from .pandas_reader import PandasReader
 
 
-class PickleWriter(PandasWriter):
+class ExcelReader(PandasReader):
     def __init__(self, filename):
         # TODO Remove Arguments when Python 2.7 support is dropped
-        super(PickleWriter, self).__init__(filename)
+        super(ExcelReader, self).__init__(filename)
 
-    def _write_to_file_type(self, df, **kwargs):
-        df.to_pickle(self.fname, **kwargs)
+    def _read_from_file_type(self, **kwargs):
+        return pd.read_excel(self.fname, **kwargs)

--- a/hatchet/readers/excel_reader.py
+++ b/hatchet/readers/excel_reader.py
@@ -8,12 +8,15 @@ import pandas as pd
 from .pandas_reader import PandasReader
 
 import pickle
+import sys
 
 
 def _unpickle_series_elems(pd_series):
     unpickled_elems = []
     for e in pd_series:
-        e_bytes = literal_eval(e)
+        e_bytes = e
+        if sys.version_info >= (3,):
+            e_bytes = literal_eval(e)
         unpickled_elems.append(pickle.loads(e_bytes))
     return pd.Series(unpickled_elems)
 

--- a/hatchet/readers/excel_reader.py
+++ b/hatchet/readers/excel_reader.py
@@ -3,8 +3,39 @@
 #
 # SPDX-License-Identifier: MIT
 
+from ast import literal_eval
 import pandas as pd
 from .pandas_reader import PandasReader
+
+import pickle
+
+
+def _unpickle_series_elems(pd_series):
+    unpickled_elems = []
+    for e in pd_series:
+        e_bytes = literal_eval(e)
+        unpickled_elems.append(pickle.loads(e_bytes))
+    return pd.Series(unpickled_elems)
+
+
+def _corrrect_children_and_parent_col_types(df):
+    new_children_col = []
+    for c in df["children"]:
+        if not isinstance(c, list):
+            new_val = literal_eval(c)
+            new_children_col.append(new_val)
+        else:
+            new_children_col.append(c)
+    df["children"] = pd.Series(new_children_col)
+    new_parent_col = []
+    for p in df["parents"]:
+        if not isinstance(p, list):
+            new_val = literal_eval(p)
+            new_parent_col.append(new_val)
+        else:
+            new_parent_col.append(p)
+    df["parents"] = pd.Series(new_parent_col)
+    return df
 
 
 class ExcelReader(PandasReader):
@@ -13,4 +44,19 @@ class ExcelReader(PandasReader):
         super(ExcelReader, self).__init__(filename)
 
     def _read_from_file_type(self, **kwargs):
-        return pd.read_excel(self.fname, **kwargs)
+        index_col = None
+        if "index_col" in kwargs:
+            index_col = kwargs["index_col"]
+            del kwargs["index_col"]
+        csv_df = pd.read_excel(self.fname, index_col=0, **kwargs)
+        csv_df["node"] = _unpickle_series_elems(csv_df["node"])
+        csv_df = _corrrect_children_and_parent_col_types(csv_df)
+        if index_col is not None:
+            return csv_df.reset_index(drop=True).set_index(index_col)
+        multindex_cols = ["node", "rank", "thread"]
+        while len(multindex_cols) > 0:
+            if set(multindex_cols).issubset(csv_df.columns):
+                return csv_df.reset_index(drop=True).set_index(multindex_cols)
+            multindex_cols.pop()
+        # TODO Replace with a custom error
+        raise RuntimeError("Could not generate a valid Index or MultiIndex")

--- a/hatchet/readers/excel_reader.py
+++ b/hatchet/readers/excel_reader.py
@@ -1,11 +1,11 @@
-# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2017-2021 Lawrence Livermore National Security, LLC and other
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
 
 from ast import literal_eval
 import pandas as pd
-from .pandas_reader import PandasReader
+from .dataframe_reader import DataframeReader
 
 import pickle
 import sys
@@ -41,17 +41,19 @@ def _corrrect_children_and_parent_col_types(df):
     return df
 
 
-class ExcelReader(PandasReader):
+class ExcelReader(DataframeReader):
     def __init__(self, filename):
-        # TODO Remove Arguments when Python 2.7 support is dropped
-        super(ExcelReader, self).__init__(filename)
+        if sys.version_info[0] == 2:
+            super(ExcelReader, self).__init__(filename)
+        else:
+            super().__init__(filename)
 
-    def _read_from_file_type(self, **kwargs):
+    def _read_dataframe_from_file(self, **kwargs):
         index_col = None
         if "index_col" in kwargs:
             index_col = kwargs["index_col"]
             del kwargs["index_col"]
-        csv_df = pd.read_excel(self.fname, index_col=0, **kwargs)
+        csv_df = pd.read_excel(self.filename, index_col=0, **kwargs)
         csv_df["node"] = _unpickle_series_elems(csv_df["node"])
         csv_df = _corrrect_children_and_parent_col_types(csv_df)
         if index_col is not None:

--- a/hatchet/readers/hdf5_reader.py
+++ b/hatchet/readers/hdf5_reader.py
@@ -11,7 +11,6 @@ from .dataframe_reader import DataframeReader
 
 class HDF5Reader(DataframeReader):
     def __init__(self, filename):
-        # TODO Remove Arguments when Python 2.7 support is dropped
         if sys.version_info[0] == 2:
             super(HDF5Reader, self).__init__(filename)
         else:

--- a/hatchet/readers/json_reader.py
+++ b/hatchet/readers/json_reader.py
@@ -1,0 +1,42 @@
+# Copyright 2017-2021 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import pandas as pd
+
+import sys
+
+from ..frame import Frame
+from ..node import Node
+from .dataframe_reader import DataframeReader
+
+def unjsonify_series_nodes(pd_series):
+    unjsonified_list = []
+    for json_node in pd_series:
+        frame = Frame(attrs=json_node["frame"])
+        node = Node(
+            frame,
+            hnid=json_node["hatchet_nid"],
+            depth=json_node["depth"]
+        )
+        unjsonified_list.append(node)
+    return pd.Series(unjsonified_list)
+
+class JsonReader(DataframeReader):
+    def __init__(self, filename):
+        if sys.version_info[0] == 2:
+            super(JsonReader, self).__init__(filename)
+        else:
+            super().__init__(filename)
+
+    def _read_dataframe_from_file(self, **kwargs):
+        json_df = pd.read_json(self.filename, **kwargs)
+        json_df["node"] = unjsonify_series_nodes(json_df["node"])
+        multindex_cols = ["node", "rank", "thread"]
+        while len(multindex_cols) > 0:
+            if set(multindex_cols).issubset(json_df.columns):
+                return json_df.reset_index(drop=True).set_index(multindex_cols)
+            multindex_cols.pop()
+        # TODO Replace with a custom error
+        raise RuntimeError("Could not generate a valid Index or MultiIndex")

--- a/hatchet/readers/json_reader.py
+++ b/hatchet/readers/json_reader.py
@@ -11,17 +11,15 @@ from ..frame import Frame
 from ..node import Node
 from .dataframe_reader import DataframeReader
 
+
 def unjsonify_series_nodes(pd_series):
     unjsonified_list = []
     for json_node in pd_series:
         frame = Frame(attrs=json_node["frame"])
-        node = Node(
-            frame,
-            hnid=json_node["hatchet_nid"],
-            depth=json_node["depth"]
-        )
+        node = Node(frame, hnid=json_node["hatchet_nid"], depth=json_node["depth"])
         unjsonified_list.append(node)
     return pd.Series(unjsonified_list)
+
 
 class JsonReader(DataframeReader):
     def __init__(self, filename):

--- a/hatchet/readers/pickle_reader.py
+++ b/hatchet/readers/pickle_reader.py
@@ -10,7 +10,7 @@ from .pandas_reader import PandasReader
 class PickleReader(PandasReader):
     def __init__(self, filename):
         # TODO Remove Arguments when Python 2.7 support is dropped
-        super(HDF5Reader, self).__init__(filename)
+        super(PickleReader, self).__init__(filename)
 
     def _read_from_file_type(self, **kwargs):
         return pd.read_pickle(self.fname, **kwargs)

--- a/hatchet/readers/pickle_reader.py
+++ b/hatchet/readers/pickle_reader.py
@@ -1,0 +1,16 @@
+# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import pandas as pd
+from .pandas_reader import PandasReader
+
+
+class PickleReader(PandasReader):
+    def __init__(self, filename):
+        # TODO Remove Arguments when Python 2.7 support is dropped
+        super(HDF5Reader, self).__init__(filename)
+
+    def _read_from_file_type(self, **kwargs):
+        return pd.read_pickle(self.fname, **kwargs)

--- a/hatchet/readers/pickle_reader.py
+++ b/hatchet/readers/pickle_reader.py
@@ -1,16 +1,20 @@
-# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2017-2021 Lawrence Livermore National Security, LLC and other
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
 
 import pandas as pd
-from .pandas_reader import PandasReader
+from .dataframe_reader import DataframeReader
+
+import sys
 
 
-class PickleReader(PandasReader):
+class PickleReader(DataframeReader):
     def __init__(self, filename):
-        # TODO Remove Arguments when Python 2.7 support is dropped
-        super(PickleReader, self).__init__(filename)
+        if sys.version_info[0] == 2:
+            super(PickleReader, self).__init__(filename)
+        else:
+            super().__init__(filename)
 
-    def _read_from_file_type(self, **kwargs):
-        return pd.read_pickle(self.fname, **kwargs)
+    def _read_dataframe_from_file(self, **kwargs):
+        return pd.read_pickle(self.filename, **kwargs)

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1202,11 +1202,11 @@ def test_csv_load_store(mock_graph_literal):
 
 
 def test_excel_load_store(mock_graph_literal):
-    if os.path.exists("test_gframe.xlsx"):
-        os.remove("test_gframe.xlsx")
+    if os.path.exists("test_gframe.xls"):
+        os.remove("test_gframe.xls")
     gf_orig = GraphFrame.from_literal(mock_graph_literal)
-    gf_orig.to_excel("test_gframe.xlsx")
-    gf_loaded = GraphFrame.from_excel("test_gframe.xlsx")
+    gf_orig.to_excel("test_gframe.xls")
+    gf_loaded = GraphFrame.from_excel("test_gframe.xls")
 
     # Excel will convert integers represented as floats back into integers.
     # To ensure "equals" evaluates correctly, I manually cast the "time" and "time (inc)"
@@ -1221,8 +1221,8 @@ def test_excel_load_store(mock_graph_literal):
     assert gf_orig.dataframe.equals(gf_loaded.dataframe)
     assert gf_orig.graph == gf_loaded.graph
 
-    if os.path.exists("test_gframe.xlsx"):
-        os.remove("test_gframe.xlsx")
+    if os.path.exists("test_gframe.xls"):
+        os.remove("test_gframe.xls")
 
 
 def test_save_func_w_extension(mock_graph_literal):

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1171,3 +1171,120 @@ def test_hdf_load_store(mock_graph_literal):
 
     if os.path.exists("test_gframe.hdf"):
         os.remove("test_gframe.hdf")
+
+
+def test_pickle_load_store(mock_graph_literal):
+    if os.path.exists("test_gframe.pkl"):
+        os.remove("test_gframe.pkl")
+    gf_orig = GraphFrame.from_literal(mock_graph_literal)
+    gf_orig.to_pickle("test_gframe.pkl")
+    gf_loaded = GraphFrame.from_pickle("test_gframe.pkl")
+
+    assert gf_orig.dataframe.equals(gf_loaded.dataframe)
+    assert gf_orig.graph == gf_loaded.graph
+
+    if os.path.exists("test_gframe.pkl"):
+        os.remove("test_gframe.pkl")
+
+
+def test_csv_load_store(mock_graph_literal):
+    if os.path.exists("test_gframe.csv"):
+        os.remove("test_gframe.csv")
+    gf_orig = GraphFrame.from_literal(mock_graph_literal)
+    gf_orig.to_csv("test_gframe.csv")
+    gf_loaded = GraphFrame.from_csv("test_gframe.csv")
+
+    assert gf_orig.dataframe.equals(gf_loaded.dataframe)
+    assert gf_orig.graph == gf_loaded.graph
+
+    if os.path.exists("test_gframe.csv"):
+        os.remove("test_gframe.csv")
+
+
+def test_excel_load_store(mock_graph_literal):
+    if os.path.exists("test_gframe.xlsx"):
+        os.remove("test_gframe.xlsx")
+    gf_orig = GraphFrame.from_literal(mock_graph_literal)
+    gf_orig.to_excel("test_gframe.xlsx")
+    gf_loaded = GraphFrame.from_excel("test_gframe.xlsx")
+
+    assert gf_orig.dataframe.equals(gf_loaded.dataframe)
+    assert gf_orig.graph == gf_loaded.graph
+
+    if os.path.exists("test_gframe.xlsx"):
+        os.remove("test_gframe.xlsx")
+
+
+def test_save_func_w_extension(mock_graph_literal):
+    fname = "test_gframe.hdf"
+    if os.path.exists(fname):
+        os.remove(fname)
+    gf_orig = GraphFrame.from_literal(mock_graph_literal)
+    gf_orig.save(fname)
+    gf_loaded = GraphFrame.from_hdf(fname)
+
+    assert gf_orig.dataframe.equals(gf_loaded.dataframe)
+    assert gf_orig.graph == gf_loaded.graph
+
+    if os.path.exists(fname):
+        os.remove(fname)
+
+
+def test_save_func_w_manual_format(mock_graph_literal):
+    fname = "test_gframe"
+    if os.path.exists(fname):
+        os.remove(fname)
+    gf_orig = GraphFrame.from_literal(mock_graph_literal)
+    gf_orig.save(fname, fileformat="hdf")
+    gf_loaded = GraphFrame.from_hdf(fname)
+
+    assert gf_orig.dataframe.equals(gf_loaded.dataframe)
+    assert gf_orig.graph == gf_loaded.graph
+
+    if os.path.exists(fname):
+        os.remove(fname)
+
+
+def test_load_func_w_extension(mock_graph_literal):
+    fname = "test_gframe.pkl"
+    if os.path.exists(fname):
+        os.remove(fname)
+    gf_orig = GraphFrame.from_literal(mock_graph_literal)
+    gf_orig.to_pickle(fname)
+    gf_loaded = GraphFrame.load(fname)
+
+    assert gf_orig.dataframe.equals(gf_loaded.dataframe)
+    assert gf_orig.graph == gf_loaded.graph
+
+    if os.path.exists(fname):
+        os.remove(fname)
+
+
+def test_load_func_w_manual_format(mock_graph_literal):
+    fname = "test_gframe"
+    if os.path.exists(fname):
+        os.remove(fname)
+    gf_orig = GraphFrame.from_literal(mock_graph_literal)
+    gf_orig.to_hdf(fname)
+    gf_loaded = GraphFrame.load(fname, fileformat="hdf")
+
+    assert gf_orig.dataframe.equals(gf_loaded.dataframe)
+    assert gf_orig.graph == gf_loaded.graph
+
+    if os.path.exists(fname):
+        os.remove(fname)
+
+
+def test_save_load_func_w_guessing_format(mock_graph_literal):
+    fname = "test_gframe"
+    if os.path.exists(fname):
+        os.remove(fname)
+    gf_orig = GraphFrame.from_literal(mock_graph_literal)
+    gf_orig.save(fname)
+    gf_loaded = GraphFrame.load(fname)
+
+    assert gf_orig.dataframe.equals(gf_loaded.dataframe)
+    assert gf_orig.graph == gf_loaded.graph
+
+    if os.path.exists(fname):
+        os.remove(fname)

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1208,6 +1208,16 @@ def test_excel_load_store(mock_graph_literal):
     gf_orig.to_excel("test_gframe.xlsx")
     gf_loaded = GraphFrame.from_excel("test_gframe.xlsx")
 
+    # Excel will convert integers represented as floats back into integers.
+    # To ensure "equals" evaluates correctly, I manually cast the "time" and "time (inc)"
+    # columns back to float
+    gf_loaded.dataframe["time"] = gf_loaded.dataframe["time"].astype(
+        gf_orig.dataframe.dtypes["time"]
+    )
+    gf_loaded.dataframe["time (inc)"] = gf_loaded.dataframe["time (inc)"].astype(
+        gf_orig.dataframe.dtypes["time (inc)"]
+    )
+
     assert gf_orig.dataframe.equals(gf_loaded.dataframe)
     assert gf_orig.graph == gf_loaded.graph
 

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1205,8 +1205,8 @@ def test_json_load_store(mock_graph_literal):
     if os.path.exists("test_gframe.json"):
         os.remove("test_gframe.json")
     gf_orig = GraphFrame.from_literal(mock_graph_literal)
-    gf_orig.to_csv("test_gframe.json")
-    gf_loaded = GraphFrame.from_csv("test_gframe.json")
+    gf_orig.to_json("test_gframe.json")
+    gf_loaded = GraphFrame.from_json("test_gframe.json")
 
     assert gf_orig.dataframe.equals(gf_loaded.dataframe)
     assert gf_orig.graph == gf_loaded.graph

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1201,6 +1201,20 @@ def test_csv_load_store(mock_graph_literal):
         os.remove("test_gframe.csv")
 
 
+def test_json_load_store(mock_graph_literal):
+    if os.path.exists("test_gframe.json"):
+        os.remove("test_gframe.json")
+    gf_orig = GraphFrame.from_literal(mock_graph_literal)
+    gf_orig.to_csv("test_gframe.json")
+    gf_loaded = GraphFrame.from_csv("test_gframe.json")
+
+    assert gf_orig.dataframe.equals(gf_loaded.dataframe)
+    assert gf_orig.graph == gf_loaded.graph
+
+    if os.path.exists("test_gframe.json"):
+        os.remove("test_gframe.json")
+
+
 def test_excel_load_store(mock_graph_literal):
     if os.path.exists("test_gframe.xls"):
         os.remove("test_gframe.xls")
@@ -1285,8 +1299,8 @@ def test_load_func_w_manual_format(mock_graph_literal):
         os.remove(fname)
 
 
-def test_save_load_func_w_guessing_format(mock_graph_literal):
-    fname = "test_gframe"
+def test_save_load_mime(mock_graph_literal):
+    fname = "test_gframe.csv"
     if os.path.exists(fname):
         os.remove(fname)
     gf_orig = GraphFrame.from_literal(mock_graph_literal)

--- a/hatchet/writers/csv_writer.py
+++ b/hatchet/writers/csv_writer.py
@@ -5,6 +5,14 @@
 
 from .pandas_writer import PandasWriter
 
+import pandas as pd
+import pickle
+
+
+def pickle_series_elems(pd_series):
+    pickled_elems = [pickle.dumps(e) for e in pd_series]
+    return pd.Series(pickled_elems)
+
 
 class CSVWriter(PandasWriter):
     def __init__(self, filename):
@@ -12,4 +20,8 @@ class CSVWriter(PandasWriter):
         super(CSVWriter, self).__init__(filename)
 
     def _write_to_file_type(self, df, **kwargs):
+        df.reset_index(inplace=True)
+        df["node"] = pickle_series_elems(df["node"])
+        df["children"] = df["children"].apply(str, convert_dtype=True)
+        df["parents"] = df["parents"].apply(str, convert_dtype=True)
         df.to_csv(self.fname, **kwargs)

--- a/hatchet/writers/csv_writer.py
+++ b/hatchet/writers/csv_writer.py
@@ -6,10 +6,10 @@
 from .pandas_writer import PandasWriter
 
 
-class PickleWriter(PandasWriter):
+class CSVWriter(PandasWriter):
     def __init__(self, filename):
         # TODO Remove Arguments when Python 2.7 support is dropped
-        super(PickleWriter, self).__init__(filename)
+        super(CSVWriter, self).__init__(filename)
 
     def _write_to_file_type(self, df, **kwargs):
-        df.to_pickle(self.fname, **kwargs)
+        df.to_csv(self.fname, **kwargs)

--- a/hatchet/writers/csv_writer.py
+++ b/hatchet/writers/csv_writer.py
@@ -1,12 +1,14 @@
-# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2017-2021 Lawrence Livermore National Security, LLC and other
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
 
-from .pandas_writer import PandasWriter
+from .dataframe_writer import DataframeWriter
 
 import pandas as pd
 import pickle
+
+import sys
 
 
 def pickle_series_elems(pd_series):
@@ -14,14 +16,16 @@ def pickle_series_elems(pd_series):
     return pd.Series(pickled_elems)
 
 
-class CSVWriter(PandasWriter):
+class CSVWriter(DataframeWriter):
     def __init__(self, filename):
-        # TODO Remove Arguments when Python 2.7 support is dropped
-        super(CSVWriter, self).__init__(filename)
+        if sys.version_info[0] == 2:
+            super(CSVWriter, self).__init__(filename)
+        else:
+            super().__init__(filename)
 
-    def _write_to_file_type(self, df, **kwargs):
+    def _write_dataframe_to_file(self, df, **kwargs):
         df.reset_index(inplace=True)
         df["node"] = pickle_series_elems(df["node"])
         df["children"] = df["children"].apply(str, convert_dtype=True)
         df["parents"] = df["parents"].apply(str, convert_dtype=True)
-        df.to_csv(self.fname, **kwargs)
+        df.to_csv(self.filename, **kwargs)

--- a/hatchet/writers/excel_writer.py
+++ b/hatchet/writers/excel_writer.py
@@ -1,12 +1,14 @@
-# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2017-2021 Lawrence Livermore National Security, LLC and other
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
 
-from .pandas_writer import PandasWriter
+from .dataframe_writer import DataframeWriter
 
 import pandas as pd
 import pickle
+
+import sys
 
 
 def pickle_series_elems(pd_series):
@@ -14,12 +16,14 @@ def pickle_series_elems(pd_series):
     return pd.Series(pickled_elems)
 
 
-class ExcelWriter(PandasWriter):
+class ExcelWriter(DataframeWriter):
     def __init__(self, filename):
-        # TODO Remove Arguments when Python 2.7 support is dropped
-        super(ExcelWriter, self).__init__(filename)
+        if sys.version_info[0] == 2:
+            super(ExcelWriter, self).__init__(filename)
+        else:
+            super().__init__(filename)
 
-    def _write_to_file_type(self, df, **kwargs):
+    def _write_dataframe_to_file(self, df, **kwargs):
         df.reset_index(inplace=True)
         df["node"] = pickle_series_elems(df["node"])
-        df.to_excel(self.fname, **kwargs)
+        df.to_excel(self.filename, **kwargs)

--- a/hatchet/writers/excel_writer.py
+++ b/hatchet/writers/excel_writer.py
@@ -6,10 +6,10 @@
 from .pandas_writer import PandasWriter
 
 
-class PickleWriter(PandasWriter):
+class ExcelWriter(PandasWriter):
     def __init__(self, filename):
         # TODO Remove Arguments when Python 2.7 support is dropped
-        super(PickleWriter, self).__init__(filename)
+        super(ExcelWriter, self).__init__(filename)
 
     def _write_to_file_type(self, df, **kwargs):
-        df.to_pickle(self.fname, **kwargs)
+        df.to_excel(self.fname, **kwargs)

--- a/hatchet/writers/excel_writer.py
+++ b/hatchet/writers/excel_writer.py
@@ -5,6 +5,14 @@
 
 from .pandas_writer import PandasWriter
 
+import pandas as pd
+import pickle
+
+
+def pickle_series_elems(pd_series):
+    pickled_elems = [pickle.dumps(e) for e in pd_series]
+    return pd.Series(pickled_elems)
+
 
 class ExcelWriter(PandasWriter):
     def __init__(self, filename):
@@ -12,4 +20,6 @@ class ExcelWriter(PandasWriter):
         super(ExcelWriter, self).__init__(filename)
 
     def _write_to_file_type(self, df, **kwargs):
+        df.reset_index(inplace=True)
+        df["node"] = pickle_series_elems(df["node"])
         df.to_excel(self.fname, **kwargs)

--- a/hatchet/writers/hdf5_writer.py
+++ b/hatchet/writers/hdf5_writer.py
@@ -17,10 +17,6 @@ class HDF5Writer(DataframeWriter):
             super().__init__(filename)
 
     def _write_dataframe_to_file(self, df, **kwargs):
-        if "key" not in kwargs:
-            raise KeyError("Writing to HDF5 requires a user-supplied key")
-        key = kwargs["key"]
-        del kwargs["key"]
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=Warning)
-            df.to_hdf(self.filename, key, **kwargs)
+            df.to_hdf(self.filename, **kwargs)

--- a/hatchet/writers/json_writer.py
+++ b/hatchet/writers/json_writer.py
@@ -9,16 +9,18 @@ import sys
 
 from .dataframe_writer import DataframeWriter
 
+
 def jsonify_series_nodes(pd_series):
     jsonified_list = []
     for node in pd_series:
         jsonified_node = {
             "depth": node._depth,
             "hatchet_nid": node._hatchet_nid,
-            "frame": self.frame.attrs,
+            "frame": node.frame.attrs,
         }
         jsonified_list.append(jsonified_node)
     return pd.Series(jsonified_list)
+
 
 class JsonWriter(DataframeWriter):
     def __init__(self, filename):

--- a/hatchet/writers/json_writer.py
+++ b/hatchet/writers/json_writer.py
@@ -1,0 +1,33 @@
+# Copyright 2017-2021 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import pandas as pd
+
+import sys
+
+from .dataframe_writer import DataframeWriter
+
+def jsonify_series_nodes(pd_series):
+    jsonified_list = []
+    for node in pd_series:
+        jsonified_node = {
+            "depth": node._depth,
+            "hatchet_nid": node._hatchet_nid,
+            "frame": self.frame.attrs,
+        }
+        jsonified_list.append(jsonified_node)
+    return pd.Series(jsonified_list)
+
+class JsonWriter(DataframeWriter):
+    def __init__(self, filename):
+        if sys.version_info[0] == 2:
+            super(JsonWriter, self).__init__(filename)
+        else:
+            super().__init__(filename)
+
+    def _write_dataframe_to_file(self, df, **kwargs):
+        df.reset_index(inplace=True)
+        df["node"] = jsonify_series_nodes(df["node"])
+        df.to_json(self.filename, **kwargs)

--- a/hatchet/writers/pickle_writer.py
+++ b/hatchet/writers/pickle_writer.py
@@ -1,0 +1,17 @@
+# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import warnings
+
+from .pandas_writer import PandasWriter
+
+
+class PickleWriter(PandasWriter):
+    def __init__(self, filename):
+        # TODO Remove Arguments when Python 2.7 support is dropped
+        super(HDF5Writer, self).__init__(filename)
+
+    def _write_to_file_type(self, df, **kwargs):
+        df.to_pickle(self.fname, **kwargs)

--- a/hatchet/writers/pickle_writer.py
+++ b/hatchet/writers/pickle_writer.py
@@ -1,15 +1,19 @@
-# Copyright 2017-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2017-2021 Lawrence Livermore National Security, LLC and other
 # Hatchet Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
 
-from .pandas_writer import PandasWriter
+from .dataframe_writer import DataframeWriter
+
+import sys
 
 
-class PickleWriter(PandasWriter):
+class PickleWriter(DataframeWriter):
     def __init__(self, filename):
-        # TODO Remove Arguments when Python 2.7 support is dropped
-        super(PickleWriter, self).__init__(filename)
+        if sys.version_info[0] == 2:
+            super(PickleWriter, self).__init__(filename)
+        else:
+            super().__init__(filename)
 
-    def _write_to_file_type(self, df, **kwargs):
-        df.to_pickle(self.fname, **kwargs)
+    def _write_dataframe_to_file(self, df, **kwargs):
+        df.to_pickle(self.filename, **kwargs)


### PR DESCRIPTION
Follow up to #272 

This PR adds the following new functions for checkpointing GraphFrames (i.e., saving to/reading from files):
1. `to_pickle` and `from_pickle` ([Pickle Format](https://docs.python.org/3/library/pickle.html#:~:text=%E2%80%9CPickling%E2%80%9D%20is%20the%20process%20whereby,back%20into%20an%20object%20hierarchy.))
2. `to_csv` and `from_csv`
3. `to_excel` and `from_excel`

These functions utilize similar read/write functions from Pandas. In many cases, these Pandas functions require additional dependencies. Those dependencies will **not** be required in Hatchet. If the dependency for a particular function is not installed, Pandas will raise an `ImportError`.

This PR also adds new `save` and `load` functions to the `GraphFrame` class. These functions can be used to simplify the use of checkpointing. Both of these functions only require one argument: the filename. If the filename contains a recognized extension, that format will be used. Otherwise, the optional `fileformat` parameter can be provided to specify the desired format. If the necessary dependencies are not installed, the `ImportError` raised by Pandas will be caught. In that case, all remaining formats will be attempted. If no supported format succeeds, an `IOError` will be raised.

All the new functions added in this PR accepts keyword arguments (i.e., `**kwargs`). These arguments will be passed to the Pandas function that is eventually invoked to read/write the file. Documentation (i.e., docstrings) will be added that will link to the associated functions' documentation.

Other file formats (e.g., Parquet and Feather) will be added in future PRs.