### PR TITLE
Temporary CI fix for #368

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,8 @@ script:
   - which cali-query
   - if [[ "$(echo ${TRAVIS_PYTHON_VERSION} | sed 's/\.//g')" -ge "36" ]]; then
       pip install --upgrade scikit-build;
-      pip install --upgrade --no-cache-dir --no-deps -v --pre timemory --install-option=--disable-{c,gotcha,tools};
+      # pip install --upgrade --no-cache-dir --no-deps -v --pre timemory --install-option=--disable-{c,gotcha,tools};
+      pip install --upgrade --no-cache-dir --no-deps -v timemory==3.2.0.dev4 --install-option=--disable-{c,gotcha,tools};
     fi
   - PYTHONPATH=. coverage run $(which pytest)
 


### PR DESCRIPTION
As suggested by @jrmadsen, this PR changes the line that installs Timemory in `.travis.yml` so that it forces the installation of Timemory 3.2.0.dev4. This is the newest version of Timemory that does not cause the issues described in #368.

This PR is meant to be a stop-gap fix until #368 is resolved. Once that issue is resolved, the old line in `.travis.yml` (which is now just commented out) should be restored.