### PR TITLE
bugfix: graphframe groupby-aggregate

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -1170,15 +1170,21 @@ class GraphFrame:
         # traverse groupby_obj, determine old node to super node mapping
         # only create super nodes for each unique value in groupby column
         nid = 0
+        name_to_node = {}
         for k, v in groupby_obj.groups.items():
             if isinstance(k, tuple):
                 node_name = k[0]
             else:
                 node_name = k
 
-            super_node = Node(Frame({"name": node_name, "type": node_type}), None, nid)
-            node_dicts.append({"node": super_node, "name": node_name})
-            nid += 1
+            super_node = name_to_node.get(node_name)
+            if not super_node:
+                super_node = Node(
+                    Frame({"name": node_name, "type": node_type}), None, nid
+                )
+                node_dicts.append({"node": super_node, "name": node_name})
+                name_to_node[node_name] = super_node
+                nid += 1
 
             # if many old nodes map to the same super node
             for i in v:

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -1056,7 +1056,7 @@ class GraphFrame:
 
         return self
 
-    def groupby_aggregate(self, groupby_function, agg_function):
+    def groupby_aggregate(self, groupby_column, agg_function):
         """Groupby-aggregate dataframe and reindex the Graph.
 
         Reindex the graph to match the groupby-aggregated dataframe.
@@ -1065,12 +1065,18 @@ class GraphFrame:
 
         Arguments:
             self (graphframe): self's graphframe
-            groupby_function: groupby function on dataframe
+            groupby_column (str): column to be used for groupby
             agg_function: aggregate function on dataframe
 
         Return:
             (GraphFrame): new graphframe with reindexed graph and groupby-aggregated dataframe
         """
+        if groupby_column not in self.dataframe.columns:
+            raise ValueError("Specified groupby column does not exist.")
+
+        if groupby_column in self.inc_metrics or groupby_column in self.exc_metrics:
+            raise ValueError("Groupby column must be non-numeric.")
+
         # create new nodes for each unique node in the old dataframe
         # length is equal to number of nodes in original graph
         old_to_new = {}
@@ -1123,47 +1129,91 @@ class GraphFrame:
                 for child in node.children:
                     reindex(child, super_node, visited)
 
+        index_names = list(self.dataframe.index.names)
+
+        # determine if groupby_column has missing data, if it does insert str
+        # None so that super nodes are still created
+        contains_null_values = self.dataframe[groupby_column].isnull().values.any()
+        if contains_null_values:
+            self.dataframe.fillna(value={groupby_column: "None"}, inplace=True)
+
+        if "rank" in index_names and "thread" in index_names:
+            groupby_column = [groupby_column, "rank", "thread"]
+        elif "rank" in index_names:
+            groupby_column = [groupby_column, "rank"]
+        elif "thread" in index_names:
+            groupby_column = [groupby_column, "thread"]
+
         # groupby-aggregate dataframe based on user-supplied functions
-        groupby_obj = self.dataframe.groupby(groupby_function)
+        groupby_obj = self.dataframe.groupby(groupby_column)
         agg_df = groupby_obj.agg(agg_function)
 
+        # rename the groupby_column to name, node is first level in the case of
+        # a multi-index
+        if isinstance(self.dataframe.index, pd.MultiIndex):
+            agg_df.index.rename("name", level=0, inplace=True)
+        else:
+            agg_df.index.rename("name", inplace=True)
+        agg_df.reset_index(inplace=True)
+
+        # set the node type for the new hierarchy by using the existing node
+        # types or using the specified groupby column
+        if groupby_column == "name":
+            node_type = self.graph.roots[0].frame["type"]
+        else:
+            node_type = (
+                groupby_column[0]
+                if isinstance(groupby_column, list)
+                else groupby_column
+            )
+
         # traverse groupby_obj, determine old node to super node mapping
+        # only create super nodes for each unique value in groupby column
         nid = 0
         for k, v in groupby_obj.groups.items():
-            node_name = k
-            node_type = agg_df.index.name
+            if isinstance(k, tuple):
+                node_name = k[0]
+            else:
+                node_name = k
+
             super_node = Node(Frame({"name": node_name, "type": node_type}), None, nid)
-            n = {"node": super_node, "nid": nid, "name": node_name}
-            node_dicts.append(n)
+            node_dicts.append({"node": super_node, "name": node_name})
             nid += 1
 
             # if many old nodes map to the same super node
             for i in v:
-                old_to_new[i] = super_node
+                if isinstance(v, pd.MultiIndex):
+                    old_to_new[i[0]] = super_node
+                else:
+                    old_to_new[i] = super_node
 
         # reindex graph by traversing old graph
         visited = set()
         for root in self.graph.roots:
             reindex(root, None, visited)
 
+        # create a dataframe with all nodes in the call graph
         # append super nodes to groupby-aggregate dataframe
-        df_index = list(agg_df.index.names)
-        agg_df.reset_index(inplace=True)
         df_nodes = pd.DataFrame.from_dict(data=node_dicts)
-        tmp_df = pd.concat([agg_df, df_nodes], axis=1)
-        # add node to dataframe index if it doesn't exist
-        if "node" not in df_index:
-            df_index.append("node")
-        # reset index
-        tmp_df.set_index(df_index, inplace=True)
 
-        # update _hatchet_nid in reindexed graph and groupby-aggregate dataframe
+        tmp_df = agg_df.merge(df_nodes, on="name")
+
+        indices = ["node"]
+        if "rank" in index_names and "thread" in index_names:
+            indices.append(["rank", "thread"])
+        elif "rank" in index_names:
+            indices.append("rank")
+        elif "thread" in index_names:
+            indices.append("thread")
+
+        tmp_df.set_index(indices, inplace=True)
+        tmp_df.sort_index(inplace=True)
+
         graph = Graph(new_roots)
         graph.enumerate_traverse()
 
         # put it all together
         new_gf = GraphFrame(graph, tmp_df, self.exc_metrics, self.inc_metrics)
-        new_gf.drop_index_levels()
         return new_gf
 
     def add(self, other):

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -262,3 +262,62 @@ def test_inclusive_time_calculation(lulesh_caliper_json):
     assert all(
         gf.dataframe["time (inc)"].values == gf.dataframe["orig_inc_time"].values
     )
+
+
+def test_groupby_aggregate_by_name(calc_pi_caliper_json):
+    gf = GraphFrame.from_caliper_json(str(calc_pi_caliper_json))
+
+    functions = gf.dataframe["name"].unique()
+
+    groupby_column = "name"
+    agg_func = {"time": np.sum}
+    grouped_gf = gf.groupby_aggregate(groupby_column, agg_func)
+
+    assert all(m in grouped_gf.dataframe.name.values for m in functions)
+    assert len(grouped_gf.graph) == len(functions)
+
+
+@pytest.mark.xfail(reason="Hatchet cannot perform groupby-aggregate on missing data.")
+def test_groupby_aggregate_by_module(calc_pi_caliper_json):
+    """
+    Resulting groupby-aggregate dataframe will have missing ranks (i.e.,
+    missing rows) if the specified column contains values that vary across
+    ranks for a given node. For example for a node N, the file values for ranks
+    0-2 are [None, "foo.c", None]. The None values were added to the resulting
+    dataframe since the profile contained no data for this node and rank.
+    """
+    gf = GraphFrame.from_caliper_json(str(calc_pi_caliper_json))
+
+    modules = gf.dataframe["module"].unique()
+
+    groupby_column = "module"
+    agg_func = {"time": np.sum}
+    grouped_gf = gf.groupby_aggregate(groupby_column, agg_func)
+
+    # one of the modules is None (type: NoneType), so we need to check if the
+    # string None is in the list of modules
+    assert all(str(m) in grouped_gf.dataframe.name.values for m in modules)
+    assert len(grouped_gf.graph) == len(modules)
+
+
+@pytest.mark.xfail(reason="Hatchet cannot perform groupby-aggregate on missing data.")
+def test_groupby_aggregate_by_file(calc_pi_caliper_json):
+    """
+    Resulting groupby-aggregate dataframe will have missing ranks (i.e.,
+    missing rows) if the specified column contains values that vary across
+    ranks for a given node. For example for a node N, the file values for ranks
+    0-2 are [None, "foo.c", None]. The None values were added to the resulting
+    dataframe since the profile contained no data for this node and rank.
+    """
+    gf = GraphFrame.from_caliper_json(str(calc_pi_caliper_json))
+
+    filenames = gf.dataframe["file"].unique()
+
+    groupby_column = "file"
+    agg_func = {"time": np.max}
+    grouped_gf = gf.groupby_aggregate(groupby_column, agg_func)
+
+    # one of the modules is None (type: NoneType), so we need to check if the
+    # string None is in the list of modules
+    assert all(str(m) in grouped_gf.dataframe.name.unique() for m in filenames)
+    assert len(grouped_gf.graph) == len(filenames)

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -265,7 +265,7 @@ def test_inclusive_time_calculation(lulesh_caliper_json):
 
 
 def test_groupby_aggregate_by_name(calc_pi_caliper_json):
-    gf = GraphFrame.from_caliper_json(str(calc_pi_caliper_json))
+    gf = GraphFrame.from_caliper(str(calc_pi_caliper_json))
 
     functions = gf.dataframe["name"].unique()
 
@@ -286,7 +286,7 @@ def test_groupby_aggregate_by_module(calc_pi_caliper_json):
     0-2 are [None, "foo.c", None]. The None values were added to the resulting
     dataframe since the profile contained no data for this node and rank.
     """
-    gf = GraphFrame.from_caliper_json(str(calc_pi_caliper_json))
+    gf = GraphFrame.from_caliper(str(calc_pi_caliper_json))
 
     modules = gf.dataframe["module"].unique()
 
@@ -309,7 +309,7 @@ def test_groupby_aggregate_by_file(calc_pi_caliper_json):
     0-2 are [None, "foo.c", None]. The None values were added to the resulting
     dataframe since the profile contained no data for this node and rank.
     """
-    gf = GraphFrame.from_caliper_json(str(calc_pi_caliper_json))
+    gf = GraphFrame.from_caliper(str(calc_pi_caliper_json))
 
     filenames = gf.dataframe["file"].unique()
 

--- a/hatchet/tests/callgrind.py
+++ b/hatchet/tests/callgrind.py
@@ -44,3 +44,16 @@ def test_read_calc_pi_database(calc_pi_callgrind_dot):
         root_names.append(root.frame.attrs["name"])
 
     assert all(rt in root_names for rt in roots)
+
+
+def test_groupby_aggregate_by_module(calc_pi_callgrind_dot):
+    gf = GraphFrame.from_gprof_dot(str(calc_pi_callgrind_dot))
+
+    modules = gf.dataframe["module"].unique()
+
+    groupby_column = "module"
+    agg_func = {"time": np.mean}
+    grouped_gf = gf.groupby_aggregate(groupby_column, agg_func)
+
+    assert all(m in grouped_gf.dataframe.name.values for m in modules)
+    assert len(grouped_gf.graph) == len(modules)

--- a/hatchet/tests/callgrind.py
+++ b/hatchet/tests/callgrind.py
@@ -44,16 +44,3 @@ def test_read_calc_pi_database(calc_pi_callgrind_dot):
         root_names.append(root.frame.attrs["name"])
 
     assert all(rt in root_names for rt in roots)
-
-
-def test_groupby_aggregate_by_module(calc_pi_callgrind_dot):
-    gf = GraphFrame.from_gprof_dot(str(calc_pi_callgrind_dot))
-
-    modules = gf.dataframe["module"].unique()
-
-    groupby_column = "module"
-    agg_func = {"time": np.mean}
-    grouped_gf = gf.groupby_aggregate(groupby_column, agg_func)
-
-    assert all(m in grouped_gf.dataframe.name.values for m in modules)
-    assert len(grouped_gf.graph) == len(modules)

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -846,96 +846,18 @@ def test_div_decorator(small_mock1, small_mock2):
     assert u"10.000 H ◀" in output
 
 
-def test_groupby_aggregate_simple(mock_dag_literal_module):
-    r"""Test reindex on a simple graph:
+def test_groupby_aggregate_by_name(mock_graph_literal):
+    """Transform a CCT into a call graph by grouping on name column."""
+    gf = GraphFrame.from_literal(mock_graph_literal)
 
-          a                              main
-         / \                             /  \
-        b   e       groupby module     foo  bar
-        |   |       -------------->     |    |
-        c   f                         graz  baz
+    call_graph_nodes = gf.dataframe["name"].unique()
 
-        Node   Module
-         a     main
-         b     foo
-         c     graz
-         e     bar
-         f     baz
-
-    """
-    modules = ["main", "foo", "graz", "bar", "baz"]
-
-    gf = GraphFrame.from_literal(mock_dag_literal_module)
-
-    groupby_func = ["module"]
-    agg_func = {"time (inc)": np.max, "time": np.max}
-    out_gf = gf.groupby_aggregate(groupby_func, agg_func)
-
-    assert all(m in out_gf.dataframe.name.values for m in modules)
-    assert len(out_gf.graph) == len(modules)
-
-
-def test_groupby_aggregate_complex(mock_dag_literal_module_complex):
-    r"""Test reindex on a complex graph:
-
-          a                              main
-         / \                             /  \
-        b   e       groupby module     foo  bar
-        |           -------------->     |
-        c                             graz
-        |
-        d
-
-        Node   Module
-         a     main
-         b     foo
-         c     graz
-         d     graz
-         e     bar
-
-    """
-    modules = ["main", "foo", "graz", "bar"]
-
-    gf = GraphFrame.from_literal(mock_dag_literal_module_complex)
-
-    groupby_func = ["module"]
+    groupby_column = "name"
     agg_func = {"time (inc)": np.sum, "time": np.sum}
-    out_gf = gf.groupby_aggregate(groupby_func, agg_func)
+    grouped_gf = gf.groupby_aggregate(groupby_column, agg_func)
 
-    assert all(m in out_gf.dataframe.name.values for m in modules)
-    assert len(out_gf.graph) == len(modules)
-
-
-def test_groupby_aggregate_more_complex(mock_dag_literal_module_more_complex):
-    r"""Test reindex on a more complex graph:
-
-          a                              main
-         / \                             /  \
-        b   e       groupby module     foo--bar
-        |   |       -------------->     |
-        c   f                         graz
-        |
-        d
-
-        Node   Module
-         a     main
-         b     foo
-         c     graz
-         d     graz
-         e     bar
-         f     foo
-
-    """
-    modules = ["main", "foo", "graz", "bar"]
-
-    gf = GraphFrame.from_literal(mock_dag_literal_module_more_complex)
-
-    groupby_func = ["module"]
-    agg_func = {"time (inc)": np.sum, "time": np.sum}
-    out_gf = gf.groupby_aggregate(groupby_func, agg_func)
-
-    assert all(m in out_gf.dataframe.name.values for m in modules)
-    assert len(out_gf.graph) == len(modules)
+    assert all(m in grouped_gf.dataframe.name.values for m in call_graph_nodes)
+    assert len(grouped_gf.graph) == len(call_graph_nodes)
 
 
 def test_depth(mock_graph_literal):

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -7,6 +7,8 @@ import numpy as np
 import pandas as pd
 import os
 
+import pytest
+
 from hatchet import GraphFrame
 from hatchet.readers.hpctoolkit_reader import HPCToolkitReader
 from hatchet.external.console import ConsoleRenderer
@@ -228,3 +230,57 @@ def test_inclusive_time_calculation(data_dir, calc_pi_hpct_db):
     assert all(
         gf.dataframe["time (inc)"].values == gf.dataframe["orig_inc_time"].values
     )
+
+
+def test_graphframe_groupby_aggregate_by_name(calc_pi_hpct_db):
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+
+    functions = gf.dataframe["name"].unique()
+
+    groupby_column = "name"
+    agg_func = {"time": np.mean}
+    grouped_gf = gf.groupby_aggregate(groupby_column, agg_func)
+
+    assert all(m in grouped_gf.dataframe.name.values for m in functions)
+    assert len(grouped_gf.graph) == len(functions)
+
+
+@pytest.mark.xfail(reason="Hatchet cannot perform groupby-aggregate on missing data.")
+def test_graphframe_groupby_aggregate_by_module(calc_pi_hpct_db):
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+
+    modules = gf.dataframe["module"].unique()
+
+    groupby_column = "module"
+    agg_func = {"time": np.mean}
+    grouped_gf = gf.groupby_aggregate(groupby_column, agg_func)
+
+    assert all(m in grouped_gf.dataframe.name.values for m in modules)
+    assert len(grouped_gf.graph) == len(modules)
+
+
+@pytest.mark.xfail(reason="Hatchet cannot perform groupby-aggregate on missing data.")
+def test_graphframe_groupby_aggregate_by_file(calc_pi_hpct_db):
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+
+    filenames = gf.dataframe["file"].unique()
+
+    groupby_column = "file"
+    agg_func = {"time": np.mean}
+    grouped_gf = gf.groupby_aggregate(groupby_column, agg_func)
+
+    assert all(m in grouped_gf.dataframe.name.values for m in filenames)
+    assert len(grouped_gf.graph) == len(filenames)
+
+
+def test_graphframe_groupby_aggregate_by_type(calc_pi_hpct_db):
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+
+    types = gf.dataframe["type"].unique()
+
+    groupby_column = "type"
+    agg_func = {"time": np.mean}
+    grouped_gf = gf.groupby_aggregate(groupby_column, agg_func)
+
+    assert all(m in grouped_gf.dataframe.name.values for m in types)
+    assert len(grouped_gf.graph) == len(types)


### PR DESCRIPTION
- node dict stores supernode and groupby column, cannot assume "name" since
  this is a valid groupby function, causing duplicate columns
- merge groupby-agg dataframe and node dict instead of using concat
- node is the only index-level in resulting graphframe

- [x] What should the index of the result dataframe be?
- [x] What if user wants to groupby_function multiple columns? -- throw error on list longer than 1, change parameter to label or list of cols
- [x] Need to validate that groupby_function is on a non-numeric column -- check if exists in exc or inc cols
- [x] Add test for empty or None in groupby-function -- follow how pandas handles this

Assumptions:
- If the groupby column contains missing values, we still want to create a supernode for all the nodes. By default, pandas groupby will ignore missing data. For hatchet, this means that we would not create a supernode for these nodes, and the resulting dataframe would have missing data. Would this be a surprise to our users?