### PR TITLE
Adding GitHub citation entry

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.1.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: Bhatele
+    given-names: Abhinav
+    orcid: https://orcid.org/0000-0003-3069-3701
+  - family-names: Gamblin
+    given-names: Todd
+    orcid: https://orcid.org/0000-0002-7857-2805
+  - family-names: Stephanie
+    given-names: Brink
+    orcid: https://orcid.org/0000-0002-1458-8453
+title: "Hatchet: Pruning the Overgrowth in Parallel Profiles"
+version: develop
+doi: 10.1145/3295500.3356219
+date-released: 2019-11-17


### PR DESCRIPTION
Hi Hatchet team! 

GitHub has [recently added](https://twitter.com/natfriedman/status/1420122675813441540) this standard file, CITATION.cff, that will render a sidebar link to easily copy paste bibtex information to cite the work. I thought this would be great for hatchet to have (since there is an obvious citation) so I've added a basic entry here. It's a bit strange that an exact version is required for the entry (it will not render without it) so the workaround that I've seen people using is to indicate the develop or main branch, as I've done here. The one ORCID I wasn't sure about is Stephanie's, because she seems to have two entries (and there isn't a good way to know if one is here):

- https://orcid.org/0000-0002-1458-8453
- https://orcid.org/0000-0002-5316-8283

I hope this might be useful for hatchet!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>