### PR TITLE
flamegraph: use Frame string object for sample names

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -743,8 +743,35 @@ class GraphFrame:
             for hnode in root.traverse():
                 callpath = hnode.path()
                 for i in range(0, len(callpath) - 1):
-                    folded_stack = folded_stack + callpath[i].attrs[name] + "; "
-                folded_stack = folded_stack + callpath[-1].attrs[name] + " "
+                    if (
+                        "rank" in self.dataframe.index.names
+                        and "thread" in self.dataframe.index.names
+                    ):
+                        df_index = (callpath[i], rank, thread)
+                    elif "rank" in self.dataframe.index.names:
+                        df_index = (callpath[i], rank)
+                    elif "thread" in self.dataframe.index.names:
+                        df_index = (callpath[i], thread)
+                    else:
+                        df_index = callpath[i]
+                    folded_stack = (
+                        folded_stack + str(self.dataframe.loc[df_index, "name"]) + "; "
+                    )
+
+                if (
+                    "rank" in self.dataframe.index.names
+                    and "thread" in self.dataframe.index.names
+                ):
+                    df_index = (callpath[-1], rank, thread)
+                elif "rank" in self.dataframe.index.names:
+                    df_index = (callpath[-1], rank)
+                elif "thread" in self.dataframe.index.names:
+                    df_index = (callpath[-1], thread)
+                else:
+                    df_index = callpath[-1]
+                folded_stack = (
+                    folded_stack + str(self.dataframe.loc[df_index, "name"]) + " "
+                )
 
                 # set dataframe index based on if rank and thread are part of the index
                 if (

--- a/hatchet/node.py
+++ b/hatchet/node.py
@@ -37,37 +37,30 @@ class Node:
         assert isinstance(node, Node)
         self.children.append(node)
 
-    def paths(self, attrs=None):
+    def paths(self):
         """List of tuples, one for each path from this node to any root.
 
-        Arguments:
-            attrs (str or list, optional): attribute(s) to extract from Frames
-
-        Paths are tuples of Frame objects, or, if attrs is provided, they
-        are paths containing the requested attributes.
+        Paths are tuples of node objects.
         """
-        node_value = (self.frame,) if attrs is None else (self.frame.values(attrs),)
+        node_value = (self,)
         if not self.parents:
             return [node_value]
         else:
             paths = []
             for parent in self.parents:
-                parent_paths = parent.paths(attrs)
+                parent_paths = parent.paths()
                 paths.extend([path + node_value for path in parent_paths])
             return paths
 
     def path(self, attrs=None):
         """Path to this node from root. Raises if there are multiple paths.
 
-        Arguments:
-            attrs (str or list, optional): attribute(s) to extract from Frames
-
         This is useful for trees (where each node only has one path), as
         it just gets the only element from ``self.paths``.  This will
         fail with a MultiplePathError if there is more than one path to
         this node.
         """
-        paths = self.paths(attrs)
+        paths = self.paths()
         if len(paths) > 1:
             raise MultiplePathError("Node has more than one path: " % paths)
         return paths[0]

--- a/hatchet/tests/node.py
+++ b/hatchet/tests/node.py
@@ -67,16 +67,12 @@ def test_path():
     node = Node.from_lists(["a", ["b", d]])
 
     assert d.path() == (
-        Frame(name="a"),
-        Frame(name="b"),
-        Frame(name="d", type="function"),
+        Node(Frame(name="a")),
+        Node(Frame(name="b")),
+        Node(Frame(name="d", type="function")),
     )
-    assert d.parents[0].path() == (Frame(name="a"), Frame(name="b"))
-    assert node.path() == (Frame(name="a"),)
-
-    assert d.path(attrs="name") == ("a", "b", "d")
-    assert d.parents[0].path(attrs="name") == ("a", "b")
-    assert node.path(attrs="name") == ("a",)
+    assert d.parents[0].path() == (Node(Frame(name="a")), Node(Frame(name="b")))
+    assert node.path() == (Node(Frame(name="a")),)
 
 
 def test_paths():
@@ -86,11 +82,9 @@ def test_paths():
         d.path()
 
     assert d.paths() == [
-        (Frame(name="a"), Frame(name="b"), Frame(name="d")),
-        (Frame(name="a"), Frame(name="c"), Frame(name="d")),
+        (Node(Frame(name="a")), Node(Frame(name="b")), Node(Frame(name="d"))),
+        (Node(Frame(name="a")), Node(Frame(name="c")), Node(Frame(name="d"))),
     ]
-
-    assert d.paths(attrs="name") == [("a", "b", "d"), ("a", "c", "d")]
 
 
 def test_traverse_paths():


### PR DESCRIPTION
Some frames will not contain a name attribute (i.e. statement, loop nodes), so
this cannot be used in the flamegraph representation. This generalizes
to_flamegraph() to print all types of nodes.