### PR TITLE
Add module encoding to the literal tree visualization

### DIFF
--- a/hatchet/external/roundtrip/roundtrip.py
+++ b/hatchet/external/roundtrip/roundtrip.py
@@ -97,24 +97,6 @@ class Roundtrip(Magics):
 
     def runVis(self, name, javascriptFile, path):
         name = "roundtripTreeVis" + str(self.id_number)
-<<<<<<< HEAD
-        header = (
-            """
-                  <div id=\""""
-            + name
-            + """\"></div>
-                  <script>
-                  elementTop.appendChild(document.getElementById('"""
-            + str(name)
-            + """'));
-                  element = document.getElementById('"""
-            + str(name)
-            + """');"""
-            + """var jsNodeSelected;"""
-        )
-        footer = """</script>"""
-        display(HTML(header + javascriptFile + footer))
-=======
 
         javascriptExport = """
             <div id=\"{0}\">
@@ -130,7 +112,6 @@ class Roundtrip(Magics):
         )
 
         display(HTML(javascriptExport))
->>>>>>> Fixed up the layout to be dunamic to the size of the tree. We will need to reduce trees now.
 
     @line_magic
     def fetchData(self, dest):

--- a/hatchet/external/roundtrip/roundtrip.py
+++ b/hatchet/external/roundtrip/roundtrip.py
@@ -107,6 +107,7 @@ class Roundtrip(Magics):
                   element = document.getElementById('"""
             + str(name)
             + """');"""
+            + """var jsNodeSelected;"""
         )
         footer = """</script>"""
         display(HTML(header + javascriptFile + footer))

--- a/hatchet/external/roundtrip/roundtrip.py
+++ b/hatchet/external/roundtrip/roundtrip.py
@@ -97,21 +97,22 @@ class Roundtrip(Magics):
 
     def runVis(self, name, javascriptFile, path):
         name = "roundtripTreeVis" + str(self.id_number)
-
-        javascriptExport = """
-            <div id=\"{0}\">
-            </div>
-            <script type=module>
-                import Test from './{1}test.js'
-                elementTop.appendChild(document.getElementById('{2}'));
-                var element = document.getElementById('{2}');
-                {3}
-            </script>
-        """.format(
-            name, path, str(name), javascriptFile
+        header = (
+            """
+                  <div id=\""""
+            + name
+            + """\"></div>
+                  <script>
+                  elementTop.appendChild(document.getElementById('"""
+            + str(name)
+            + """'));
+                  element = document.getElementById('"""
+            + str(name)
+            + """');"""
+            + """var jsNodeSelected;"""
         )
-
-        display(HTML(javascriptExport))
+        footer = """</script>"""
+        display(HTML(header + javascriptFile + footer))
 
     @line_magic
     def fetchData(self, dest):

--- a/hatchet/external/roundtrip/roundtrip.py
+++ b/hatchet/external/roundtrip/roundtrip.py
@@ -122,7 +122,7 @@ class Roundtrip(Magics):
             <script type=module>
                 import Test from './{1}test.js'
                 elementTop.appendChild(document.getElementById('{2}'));
-                element = document.getElementById('{2}');
+                var element = document.getElementById('{2}');
                 {3}
             </script>
         """.format(name, path, str(name), javascriptFile)

--- a/hatchet/external/roundtrip/roundtrip.py
+++ b/hatchet/external/roundtrip/roundtrip.py
@@ -31,6 +31,7 @@ class Roundtrip(Magics):
         "json": "text/json",
         "css": "text/css",
     }
+    
     codeMap = {}
 
     @line_magic
@@ -62,7 +63,7 @@ class Roundtrip(Magics):
         displayObj = display(HTML(argList), display_id=True)
 
         args[1] = self.shell.user_ns[args[1]]
-        displayObj.update(Javascript('argList.push("' + str(args[1]) + '")'))
+        displayObj.update( Javascript( 'argList.push("{}")'.format(str(args[1])) ) )
 
         # Check that users provided a tree literal
         if not isinstance(args[1], list):
@@ -88,13 +89,15 @@ class Roundtrip(Magics):
         preRun = """
         // Grab current context
         elementTop = element.get(0);"""
+
         displayObj.update(Javascript(preRun))
 
-        self.runVis(name, javascriptFile)
+        self.runVis(name, javascriptFile, path)
         self.id_number += 1
 
-    def runVis(self, name, javascriptFile):
+    def runVis(self, name, javascriptFile, path):
         name = "roundtripTreeVis" + str(self.id_number)
+<<<<<<< HEAD
         header = (
             """
                   <div id=\""""
@@ -111,6 +114,21 @@ class Roundtrip(Magics):
         )
         footer = """</script>"""
         display(HTML(header + javascriptFile + footer))
+=======
+
+        javascriptExport = """
+            <div id=\"{0}\">
+            </div>
+            <script type=module>
+                import Test from './{1}test.js'
+                elementTop.appendChild(document.getElementById('{2}'));
+                element = document.getElementById('{2}');
+                {3}
+            </script>
+        """.format(name, path, str(name), javascriptFile)
+    
+        display(HTML(javascriptExport))
+>>>>>>> Fixed up the layout to be dunamic to the size of the tree. We will need to reduce trees now.
 
     @line_magic
     def fetchData(self, dest):

--- a/hatchet/external/roundtrip/roundtrip.py
+++ b/hatchet/external/roundtrip/roundtrip.py
@@ -31,7 +31,7 @@ class Roundtrip(Magics):
         "json": "text/json",
         "css": "text/css",
     }
-    
+
     codeMap = {}
 
     @line_magic
@@ -63,7 +63,7 @@ class Roundtrip(Magics):
         displayObj = display(HTML(argList), display_id=True)
 
         args[1] = self.shell.user_ns[args[1]]
-        displayObj.update( Javascript( 'argList.push("{}")'.format(str(args[1])) ) )
+        displayObj.update(Javascript('argList.push("{}")'.format(str(args[1]))))
 
         # Check that users provided a tree literal
         if not isinstance(args[1], list):
@@ -125,8 +125,10 @@ class Roundtrip(Magics):
                 var element = document.getElementById('{2}');
                 {3}
             </script>
-        """.format(name, path, str(name), javascriptFile)
-    
+        """.format(
+            name, path, str(name), javascriptFile
+        )
+
         display(HTML(javascriptExport))
 >>>>>>> Fixed up the layout to be dunamic to the size of the tree. We will need to reduce trees now.
 

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -14,7 +14,8 @@
                 METRICCHANGE: "METRICCHANGE",
                 TREECHANGE: "TREECHANGE",
                 COLORCLICK: "COLORCLICK",
-                LEGENDCLICK: "LEGENDCLICK"
+                LEGENDCLICK: "LEGENDCLICK",
+                PAN: "PAN"
             },
             layout: {
                 margin: {top: 20, right: 20, bottom: 80, left: 20},
@@ -195,6 +196,8 @@
                             break;
                         case(globals.signals.LEGENDCLICK):
                             _model.updateLegends();
+                            break;
+                        case(globals.signals.PAN):
                             break;
                         default:
                             console.log('Unknown event type', evt.type);
@@ -429,7 +432,6 @@
                             //call update selected
                             this.updateSelected(brushedNodes);
                         }
-
                     }
                     else{
                         this.updateSelected([]);
@@ -469,7 +471,6 @@
                     _state["activeTree"] = activeTree;
                     _observers.notify();
                 }
-
             }
         }
 
@@ -811,13 +812,13 @@
                 var spreadFactor = width / (maxHeight + 1);
                 var legendOffset = 30;
 
+
                 model.updateNodes(treeIndex,
                     function(n){
                         // Normalize for fixed-depth.
                         n.forEach(function (d) {
-                            d.x = d.x + legendOffset ;
-                            d.y = d.depth * spreadFactor;
-                            d.treeIndex = treeIndex;
+                            d.x = d.x;
+                            d.y = (d.depth * spreadFactor);
                         });
                     }
                 );
@@ -836,6 +837,7 @@
                         });
                     }
                 );
+
 
                 newg.style("display", "inline-block");
             } //end for-loop "add tree"
@@ -859,14 +861,13 @@
                         var nodes = model.getNodesFromMap(treeIndex);
                         var links = model.getLinksFromMap(treeIndex);
                         var chart = svg.selectAll('.group-' + treeIndex);
-
-
+                        var tree = chart.selectAll('.chart');
 
 
                         //ENTER 
                         // Update the nodes…
                         var i = 0;
-                        var node = chart.selectAll("g.node")
+                        var node = tree.selectAll("g.node")
                                 .data(nodes, function (d) {
                                     return d.id || (d.id = ++i);
                                 });
@@ -877,7 +878,6 @@
                                 .attr("transform", function (d) {
                                     return "translate(" + lastClicked.y + "," + lastClicked.x + ")";
                                 })
-                                // .on("click", click)
                                 .on("click", function(d){
                                     _observers.notify({
                                         type: globals.signals.CLICK,
@@ -890,7 +890,6 @@
                                         node: d,
                                         tree: treeIndex
                                     })
-                                    // doubleclick(d, treeData, g);
                                 });
             
                         nodeEnter.append("circle")
@@ -923,7 +922,7 @@
         
 
                         // links
-                        var link = chart.selectAll("path.link")
+                        var link = tree.selectAll("path.link")
                         .data(links, function (d) {
                             return d.id;
                         });
@@ -938,8 +937,6 @@
                                 .attr('fill', 'none')
                                 .attr('stroke', '#ccc')
                                 .attr('stroke-width', '2px');
-        
-
 
         
                         //UPDATES
@@ -970,7 +967,6 @@
                             }
                         });
 
-
                         //legend updates
                         chart.selectAll(".legend rect")
                                 .transition()
@@ -999,7 +995,7 @@
                         nodeUpdate.transition()
                                 .duration(globals.duration)
                                 .attr("transform", function (d) {
-                                    return "translate(" + d.y + "," + d.x + ")";
+                                    return `translate(${d.y}, ${d.x})`;
                                 });
 
                         nodeUpdate.select('circle.circleNode')

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -242,10 +242,6 @@
                             _model.updateLegends();
                             break;
                         case(globals.signals.ZOOM):
-<<<<<<< HEAD
-=======
-                            // add debounce
->>>>>>> Panning and zooming works and updates for brushing.
                             _model.updateNodeLocations(evt.index, evt.transformation);
                             break;
                         default:
@@ -520,7 +516,6 @@
                     _observers.notify();
                 },
                 updateNodeLocations: function(index, transformation){
-<<<<<<< HEAD
                     _data["treemaps"][index].descendants().forEach(function(d, i) {
                         // This function gets the absolute location for each point based on the relative
                         // locations of the points based on transformations
@@ -530,11 +525,6 @@
                         // Adapted from: https://stackoverflow.com/questions/18554224/getting-screen-positions-of-d3-nodes-after-transform
                         d.yMainG = transformation.e + d.y0*transformation.d + d.x0*transformation.c - globals.layout.margin.left;
                         d.xMainG = transformation.f + d.y0*transformation.b + d.x0*transformation.a - globals.layout.margin.top;
-=======
-                    _data["treemaps"][index].descendants().forEach(function(d) {
-                        d.xMainG = d.xMainG0 + transformation.y;
-                        d.yMainG = d.yMainG0 + transformation.x;
->>>>>>> Panning and zooming works and updates for brushing.
                     });
                 }
             }
@@ -883,11 +873,7 @@
                     _observers.notify({
                         type: globals.signals.ZOOM,
                         index: zoomObj.attr("chart-id"),
-<<<<<<< HEAD
                         transformation: zoomObj.node().getCTM()
-=======
-                        transformation: d3.event.transform
->>>>>>> Panning and zooming works and updates for brushing.
                     })
                 });
 
@@ -903,10 +889,6 @@
                 newg.call(zoom)
                     .on("dblclick.zoom", null);
                     
-<<<<<<< HEAD
-
-=======
->>>>>>> Panning and zooming works and updates for brushing.
 
                 model.updateNodes(treeIndex,
                     function(n){

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -1,257 +1,618 @@
+
 //d3.v4
 (function (element) {
     require(['https://d3js.org/d3.v4.min.js'], function (d3) {
-        var cleanTree = argList[0].replace(/'/g, '"');
+    
+        
+        // This is the makeSignaller from class
+        var makeSignaller = function() {
+            var _subscribers = []; // Private member
 
-        var forestData = JSON.parse(cleanTree);
+            // Return the object that's created
+            return {
+                // Register a function with the notification system
+                add: function(handlerFunction) { _subscribers.push(handlerFunction); },
 
-        var rootNodeNames = [];
-        var numberOfTrees = forestData.length;
-        // Get the metric_column names
-        var metricColumns = d3.keys(forestData[0].metrics);
-        // pick the first metric listed to color the nodes
-        var selectedMetric = metricColumns[0];
-
-        forestMetrics = [];
-        forestMinMax = {};
-        for (var i = 0; i < numberOfTrees; i++) {
-            var thisTree = forestData[i];
-
-            // Get tree names for the display select options
-            rootNodeNames.push(thisTree.frame.name);
-
-            var thisTreeMetrics = {};
-            // init the min/max for all trees' metricColumns
-
-            for (var j = 0; j < metricColumns.length; j++) {
-                thisTreeMetrics[metricColumns[j]] = {};
-                thisTreeMetrics[metricColumns[j]]["min"] = Number.MAX_VALUE;
-                thisTreeMetrics[metricColumns[j]]["max"] = 0;
-            }
-
-            forestMetrics.push(thisTreeMetrics);
-        }
-        for (var j = 0; j < metricColumns.length; j++) {
-            forestMinMax[metricColumns[j]] = {};
-            forestMinMax[metricColumns[j]]["min"] = Number.MAX_VALUE;
-            forestMinMax[metricColumns[j]]["max"] = 0;
-        }
-
-        rootNodeNames.push("Show all trees");
-
-        // ************** Generate the tree diagram  *****************
-        var margin = {top: 20, right: 20, bottom: 80, left: 20},
-                treeHeight = 300,
-                width = element.clientWidth - margin.right - margin.left,
-                height = treeHeight * (numberOfTrees + 1),
-                gOffset = [{x: margin.left, y: margin.top}]; //keep track of translations to know absolute position
-
-        d3.select(element).append('label').attr('for', 'metricSelect').text('Color by:');
-        var metricInput = d3.select(element).append("select") //element
-                .attr("id", "metricSelect")
-                .selectAll('option')
-                .data(metricColumns)
-                .enter()
-                .append('option')
-                .text(d => d)
-                .attr('value', d => d);
-        document.getElementById("metricSelect").style.margin = "10px 10px 10px 0px";
-
-        d3.select(element).append('label').style('margin', '0 0 0 10px').attr('for', 'treeRootSelect').text(' Display:');
-        var treeRootInput = d3.select(element).append("select") //element
-                .attr("id", "treeRootSelect")
-                .selectAll('option')
-                .data(rootNodeNames)
-                .enter()
-                .append('option')
-                .attr('selected', d => d.name == 'Show all trees' ? true : false)
-                .text(d => d)
-                .attr('value', (d, i) => i + "|" + d);
-        document.getElementById("treeRootSelect").style.margin = "10px 10px 10px 10px";
-
-        var tooltip = d3.select(element).append("div")
-                .attr('id', 'tooltip')
-                .style('position', 'absolute')
-                .style('top', '5px')
-                .style('right', '15px')
-                .style('padding', '5px')
-                .style('border-radius', '5px')
-                .style('background', '#ccc')
-                .style('color', 'black')
-                .style('font-size', '14px')
-                .style('font-family', 'monospace')
-                .html('<p>Click a node or "Select nodes" to see more info</p>');
-
-        var svg = d3.select(element).append("svg") //element
-                .attr("width", width + margin.right + margin.left)
-                .attr("height", height + margin.top + margin.bottom);
-
-        var brushOn = 1;
-        var colorScheme = 1; //default=1 : invert=-1
-        var button = svg.append('g')
-                .attr('id', 'selectButton')
-                .append('rect')
-                .attr('width', '80px')
-                .attr('height', '15px')
-                .attr('x', 0).attr('y', 0).attr('rx', 5)
-                .style('fill', '#ccc')
-                .on('click', function () {
-                    brushOn = -1 * brushOn;
-                    activateBrush(brushOn);
-                });
-        d3.select(element).select('#selectButton').append('text')
-                .attr("x", 3)
-                .attr("y", 12)
-                .text('Select nodes')
-                .attr("font-family", "sans-serif")
-                .attr("font-size", "12px")
-                .attr('cursor', 'pointer')
-                .on('click', function () {
-                    brushOn = -1 * brushOn;
-                    activateBrush(brushOn);
-                });
-        var colorButton = svg.append('g')
-                .attr('id', 'colorButton')
-                .append('rect')
-                .attr('width', '90px')
-                .attr('height', '15px')
-                .attr('x', 90).attr('y', 0).attr('rx', 5)
-                .style('fill', '#ccc');
-        d3.select(element).select('#colorButton').append('text')
-                .attr("x", 93)
-                .attr("y", 12)
-                .text('Colors: default')
-                .attr("font-family", "sans-serif")
-                .attr("font-size", "12px")
-                .attr('cursor', 'pointer')
-                .on('click', function () {
-                    colorScheme = -1 * colorScheme;
-                    var curMetric = d3.select(element).select('#metricSelect').property('value');
-                    var curLegend = d3.select(element).select('#unifyLegends').text();
-                    d3.select(element).selectAll(".circleNode")
-                            .transition()
-                            .duration(duration)
-                            .style('fill', function (d) {
-                                if (curLegend == 'Legends: unified') {
-                                    return colorScale(d.data.metrics[curMetric], -1);
-                                }
-                                return colorScale(d.data.metrics[curMetric], d.treeIndex);
-                            })
-                            .style('stroke', 'black');
-
-                    //Update each individual legend to inverted scale
-                    for (var treeIndex = 0; treeIndex < numberOfTrees; treeIndex++) {
-                        if (curLegend == 'Legends: unified') {
-                            setColorLegend(-1);
-                        } else {
-                            setColorLegend(treeIndex);
-                        }
-                    }
-                });
-        var unifyLegends = svg.append('g')
-                .attr('id', 'unifyLegends')
-                .append('rect')
-                .attr('width', '100px')
-                .attr('height', '15px')
-                .attr('x', 190)
-                .attr('y', 0)
-                .attr('rx', 5)
-                .style('fill', '#ccc');
-        d3.select(element).select('#unifyLegends').append('text')
-                .attr("x", 195)
-                .attr("y", 12)
-                .text('Legends: unified')
-                .attr("font-family", "sans-serif")
-                .attr("font-size", "12px")
-                .attr('cursor', 'pointer')
-                .on('click', function () {
-                    var curMetric = d3.select(element).select('#metricSelect').property('value');
-                    var sameLegend = true;
-                    if (d3.select(this).text() == 'Legends: unified') {
-                        d3.select(this).text('Legends: indiv.');
-                        sameLegend = false;
-                        for (var treeIndex = 0; treeIndex < numberOfTrees; treeIndex++) {
-                            setColorLegend(treeIndex);
-                        }
-                    } else {
-                        d3.select(this).text('Legends: unified');
-                        sameLegend = true;
-                        setColorLegend(-1);
-                    }
-
-                    d3.select(element).selectAll(".circleNode")
-                            .transition()
-                            .duration(duration)
-                            .style("fill", function (d) {
-                                return sameLegend ? colorScale(d.data.metrics[curMetric], -1) : colorScale(d.data.metrics[curMetric], d.treeIndex);
-                            })
-                            .style("stroke", 'black');
-                });
-
-
-        var mainG = svg.append("g")
-                .attr('id', "mainG")
-                .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
-
-        var treemap = d3.tree().size([(treeHeight), width - margin.left]);
-
-        var maxHeight = 0;
-        // Find the tallest tree for layout purposes (used to set a uniform spreadFactor)
-        for (var treeIndex = 0; treeIndex < forestData.length; treeIndex++) {
-            currentTreeData = forestData[treeIndex];
-            currentRoot = d3.hierarchy(currentTreeData, d => d.children);
-
-            currentRoot.x0 = height;
-            currentRoot.y0 = margin.left;
-
-            var currentTreeMap = treemap(currentRoot);
-            if (currentTreeMap.height > maxHeight) {
-                maxHeight = currentTreeMap.height;
-            }
-        }
-
-        // Add a group and tree for each forestData[i]
-        for (var treeIndex = 0; treeIndex < forestData.length; treeIndex++) {
-            currentTreeData = forestData[treeIndex];
-            currentRoot = d3.hierarchy(currentTreeData, d => d.children);
-            currentRoot.x0 = height;
-            currentRoot.y0 = margin.left;
-
-            var currentTreeMap = treemap(currentRoot);
-            var newg = mainG.append("g")
-                    .attr('class', 'group ' + treeIndex)
-                    .attr("transform", "translate(" + margin.left + "," + (treeHeight * treeIndex + margin.top) + ")");
-
-            currentTreeMap.descendants().forEach(function (d) {
-                for (var i = 0; i < metricColumns.length; i++) {
-                    var tempMetric = metricColumns[i];
-                    if (d.data.metrics[tempMetric] > forestMetrics[treeIndex][tempMetric].max) {
-                        forestMetrics[treeIndex][tempMetric].max = d.data.metrics[tempMetric];
-                    }
-                    if (d.data.metrics[tempMetric] < forestMetrics[treeIndex][tempMetric].min) {
-                        forestMetrics[treeIndex][tempMetric].min = d.data.metrics[tempMetric];
-                    }
-                    if (d.data.metrics[tempMetric] > forestMinMax[tempMetric].max) {
-                        forestMinMax[tempMetric].max = d.data.metrics[tempMetric];
-                    }
-                    if (d.data.metrics[tempMetric] < forestMinMax[tempMetric].min) {
-                        forestMinMax[tempMetric].min = d.data.metrics[tempMetric];
+                // Loop through all registered function snad call them with passed
+                // arguments
+                notify: function(args) {
+                    for (var i = 0; i < _subscribers.length; i++) {
+                        _subscribers[i](args);
                     }
                 }
-            });
+            };
+        }
 
-            addColorLegendRects(newg);
+        // Create an object that handles UI object
+        var createController = function(model) {
+            var _model = model;
 
-            update(currentRoot, currentTreeMap, newg);
-            newg.style("display", "inline-block");
-        } //end for-loop "add tree"
+            return {
+                // All types of events run through a central dispatch
+                // function. The dispatch function decides what to do.
+                dispatch: function(evt) {
+                    switch(evt.type) {
+                    case (ha3.signals.HOVER):
+                        model.setHoveredPoint(evt.beverage, evt.index);
+                        break;
+                    case (ha3.signals.CLICK):
+                        model.handleClick(evt.beverage, evt.index);
+                        break;
+                    case (ha3.signals.BRUSH):
+                        model.setBrushedPoints(evt.selection, evt.x, evt.y, evt.xScale, evt.yScale);
+                        break;
+                    case (ha3.signals.BRUSHCLEAR):
+                        model.clearBrushedPoints();
+                        break;
+                        default:
+                            console.log('Unknown event type', evt.type);
+                    }
+            }
+            };
+        }
 
-        // Global min/max are the last entry of forestMetrics;
-        forestMetrics.push(forestMinMax);
+        var createModel = function(){
+            var _observers = makeSignaller();
+            
+            var _data = {"treemaps":[]};
+            var _state = {};
+            var _currTree = 0;
+
+            _state["colorScheme"] = 1;
+            _state["brushOn"] = 1;
+
+            //setup model
+            var cleanTree = argList[0].replace(/'/g, '"');
+            
+            _data["forestData"] = JSON.parse(cleanTree);
+
+            _data["rootNodeNames"] = [];
+            _data["rootNodeNames"].push("Show all trees");
+
+            _data["numberOfTrees"] = _data["forestData"].length;
+            
+            // Get the metric_column names
+            _data["metricColumns"] = d3.keys(_data["forestData"][0].metrics);
+
+            // pick the first metric listed to color the nodes
+            _state["selectedMetric"] = _data["metricColumns"][0];
+
+            forestMetrics = [];
+            forestMinMax = {};
+            for (var i = 0; i < _data["numberOfTrees"]; i++) {
+                var thisTree = _data["forestData"][i];
+
+                // Get tree names for the display select options
+                _data["rootNodeNames"].push(thisTree.frame.name);
+
+                var thisTreeMetrics = {};
+                // init the min/max for all trees' metricColumns
+
+                for (var j = 0; j < _data["metricColumns"].length; j++) {
+                    thisTreeMetrics[_data["metricColumns"][j]] = {};
+                    thisTreeMetrics[_data["metricColumns"][j]]["min"] = Number.MAX_VALUE;
+                    thisTreeMetrics[_data["metricColumns"][j]]["max"] = 0;
+                }
+
+                forestMetrics.push(thisTreeMetrics);
+            }
+            for (var j = 0; j < _data["metricColumns"].length; j++) {
+                forestMinMax[_data["metricColumns"][j]] = {};
+                forestMinMax[_data["metricColumns"][j]]["min"] = Number.MAX_VALUE;
+                forestMinMax[_data["metricColumns"][j]]["max"] = 0;
+            }
+
+            _data["forestMinMax"] = forestMinMax;
+
+            return{
+                data: _data,
+                state: _state,
+                register: function(s){
+                    _observers.add(s);
+                },
+
+                setCurrentTreeIndex: function(index){
+                    _currTree = index;
+                },
+                getCurrentTreeIndex: function(){
+                    return _currTree;
+                },
+
+                addTreeMap: function(tm){
+                    _data['treemaps'].push(tm);
+                },
+                getTreeMap: function(index){
+                    return _data['treemaps'][index];
+                },
+
+                getNodesFromMap: function(index){
+                    return _data['treemaps'][_currTree].descendants();
+                },
+                getLinksFromMap: function(index){
+                    return _data['treemaps'][_currTree].descendants().slice(1);
+                },
+
+                updateNodes: function(f){
+                    f(_data['treemaps'][_currTree].descendants());
+                }
+            }
+        }
+
+
+        var createView = function(elem, model){
+                
+            rootNodeNames = model.data["rootNodeNames"];
+            numberOfTrees = model.data["numberOfTrees"];
+            metricColumns = model.data["metricColumns"];
+            forestData = model.data["forestData"];
+            
+            selectedMetric = model.state["selectedMetric"];
+            brushOn = model.state["brushOn"];
+            
+
+            // ************** Generate the tree diagram  *****************
+            var margin = {top: 20, right: 20, bottom: 80, left: 20},
+                    treeHeight = 300,
+                    width = elem.clientWidth - margin.right - margin.left,
+                    height = treeHeight * (numberOfTrees + 1),
+                    gOffset = [{x: margin.left, y: margin.top}]; //keep track of translations to know absolute position
+
+            d3.select(elem).append('label').attr('for', 'metricSelect').text('Color by:');
+            var metricInput = d3.select(elem).append("select") //element
+                    .attr("id", "metricSelect")
+                    .selectAll('option')
+                    .data(metricColumns)
+                    .enter()
+                    .append('option')
+                    .text(d => d)
+                    .attr('value', d => d);
+            document.getElementById("metricSelect").style.margin = "10px 10px 10px 0px";
+
+            d3.select(elem).append('label').style('margin', '0 0 0 10px').attr('for', 'treeRootSelect').text(' Display:');
+            var treeRootInput = d3.select(elem).append("select") //element
+                    .attr("id", "treeRootSelect")
+                    .selectAll('option')
+                    .data(rootNodeNames)
+                    .enter()
+                    .append('option')
+                    .attr('selected', d => d.name == 'Show all trees' ? true : false)
+                    .text(d => d)
+                    .attr('value', (d, i) => i + "|" + d);
+            document.getElementById("treeRootSelect").style.margin = "10px 10px 10px 10px";
+
+            var tooltip = d3.select(elem).append("div")
+                    .attr('id', 'tooltip')
+                    .style('position', 'absolute')
+                    .style('top', '5px')
+                    .style('right', '15px')
+                    .style('padding', '5px')
+                    .style('border-radius', '5px')
+                    .style('background', '#ccc')
+                    .style('color', 'black')
+                    .style('font-size', '14px')
+                    .style('font-family', 'monospace')
+                    .html('<p>Click a node or "Select nodes" to see more info</p>');
+
+            var svg = d3.select(elem).append("svg") //element
+                    .attr("width", width + margin.right + margin.left)
+                    .attr("height", height + margin.top + margin.bottom);
+
+            var brushOn = 1;
+            // var colorScheme = 1; //default=1 : invert=-1
+            var button = svg.append('g')
+                    .attr('id', 'selectButton')
+                    .append('rect')
+                    .attr('width', '80px')
+                    .attr('height', '15px')
+                    .attr('x', 0).attr('y', 0).attr('rx', 5)
+                    .style('fill', '#ccc')
+                    .on('click', function () {
+                        brushOn = -1 * brushOn;
+                        activateBrush(brushOn);
+                    });
+            d3.select(elem).select('#selectButton').append('text')
+                    .attr("x", 3)
+                    .attr("y", 12)
+                    .text('Select nodes')
+                    .attr("font-family", "sans-serif")
+                    .attr("font-size", "12px")
+                    .attr('cursor', 'pointer')
+                    .on('click', function () {
+                        brushOn = -1 * brushOn;
+                        activateBrush(brushOn);
+                    });
+            var colorButton = svg.append('g')
+                    .attr('id', 'colorButton')
+                    .append('rect')
+                    .attr('width', '90px')
+                    .attr('height', '15px')
+                    .attr('x', 90).attr('y', 0).attr('rx', 5)
+                    .style('fill', '#ccc');
+            d3.select(elem).select('#colorButton').append('text')
+                    .attr("x", 93)
+                    .attr("y", 12)
+                    .text('Colors: default')
+                    .attr("font-family", "sans-serif")
+                    .attr("font-size", "12px")
+                    .attr('cursor', 'pointer')
+                    .on('click', function () {
+                        model.state["colorScheme"] = -1 * model.state["colorScheme"];
+                        var curMetric = d3.select(elem).select('#metricSelect').property('value');
+                        var curLegend = d3.select(elem).select('#unifyLegends').text();
+                        d3.select(elem).selectAll(".circleNode")
+                                .transition()
+                                .duration(duration)
+                                .style('fill', function (d) {
+                                    if (curLegend == 'Legends: unified') {
+                                        return colorScale(d.data.metrics[curMetric], -1);
+                                    }
+                                    return colorScale(d.data.metrics[curMetric], d.treeIndex);
+                                })
+                                .style('stroke', 'black');
+
+                        //Update each individual legend to inverted scale
+                        for (var treeIndex = 0; treeIndex < numberOfTrees; treeIndex++) {
+                            if (curLegend == 'Legends: unified') {
+                                setColorLegend(-1);
+                            } else {
+                                setColorLegend(treeIndex);
+                            }
+                        }
+                    });
+            var unifyLegends = svg.append('g')
+                    .attr('id', 'unifyLegends')
+                    .append('rect')
+                    .attr('width', '100px')
+                    .attr('height', '15px')
+                    .attr('x', 190)
+                    .attr('y', 0)
+                    .attr('rx', 5)
+                    .style('fill', '#ccc');
+            d3.select(elem).select('#unifyLegends').append('text')
+                    .attr("x", 195)
+                    .attr("y", 12)
+                    .text('Legends: unified')
+                    .attr("font-family", "sans-serif")
+                    .attr("font-size", "12px")
+                    .attr('cursor', 'pointer')
+                    .on('click', function () {
+                        var curMetric = d3.select(elem).select('#metricSelect').property('value');
+                        var sameLegend = true;
+                        if (d3.select(this).text() == 'Legends: unified') {
+                            d3.select(this).text('Legends: indiv.');
+                            sameLegend = false;
+                            for (var treeIndex = 0; treeIndex < numberOfTrees; treeIndex++) {
+                                setColorLegend(treeIndex);
+                            }
+                        } else {
+                            d3.select(this).text('Legends: unified');
+                            sameLegend = true;
+                            setColorLegend(-1);
+                        }
+
+                        d3.select(elem).selectAll(".circleNode")
+                                .transition()
+                                .duration(duration)
+                                .style("fill", function (d) {
+                                    return sameLegend ? colorScale(d.data.metrics[curMetric], -1) : colorScale(d.data.metrics[curMetric], d.treeIndex);
+                                })
+                                .style("stroke", 'black');
+                    });
+
+
+            var mainG = svg.append("g")
+                    .attr('id', "mainG")
+                    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+            // var treemap = d3.tree().size([(2000), width - margin.left]);
+            var treemap = d3.tree().size([(treeHeight), width - margin.left]);
+
+            var maxHeight = 0;
+
+            // Find the tallest tree for layout purposes (used to set a uniform spreadFactor)
+            for (var treeIndex = 0; treeIndex < forestData.length; treeIndex++) {
+                currentTreeData = forestData[treeIndex];
+                currentRoot = d3.hierarchy(currentTreeData, d => d.children);
+
+                currentRoot.x0 = height;
+                currentRoot.y0 = margin.left;
+
+                var currentTreeMap = treemap(currentRoot);
+                if (currentTreeMap.height > maxHeight) {
+                    maxHeight = currentTreeMap.height;
+                }
+
+                model.addTreeMap(currentTreeMap);
+            }
+
+            // Add a group and tree for each forestData[i]
+            for (var treeIndex = 0; treeIndex < forestData.length; treeIndex++) {
+                // currentTreeData = forestData[treeIndex];
+                // currentRoot = d3.hierarchy(currentTreeData, d => d.children);
+                // currentRoot.x0 = height;
+                // currentRoot.y0 = margin.left;
+
+                model.setCurrentTreeIndex(treeIndex);
+
+                var currentTreeMap = model.getTreeMap(treeIndex);
+                var newg = mainG.append("g")
+                        .attr('class', 'group ' + treeIndex)
+                        .attr("transform", "translate(" + margin.left + "," + (treeHeight * treeIndex + margin.top) + ")");
+
+                currentTreeMap.descendants().forEach(function (d) {
+                    for (var i = 0; i < metricColumns.length; i++) {
+                        var tempMetric = metricColumns[i];
+                        if (d.data.metrics[tempMetric] > forestMetrics[treeIndex][tempMetric].max) {
+                            forestMetrics[treeIndex][tempMetric].max = d.data.metrics[tempMetric];
+                        }
+                        if (d.data.metrics[tempMetric] < forestMetrics[treeIndex][tempMetric].min) {
+                            forestMetrics[treeIndex][tempMetric].min = d.data.metrics[tempMetric];
+                        }
+                        if (d.data.metrics[tempMetric] > forestMinMax[tempMetric].max) {
+                            forestMinMax[tempMetric].max = d.data.metrics[tempMetric];
+                        }
+                        if (d.data.metrics[tempMetric] < forestMinMax[tempMetric].min) {
+                            forestMinMax[tempMetric].min = d.data.metrics[tempMetric];
+                        }
+                    }
+                });
+
+                addColorLegendRects(newg);
+
+                //put tree itself into a group
+                newg.append('g')
+                    .attr('class', 'chart')
+                    .attr('chart-id', treeIndex);
+
+                //define and bind zoom functionality
+                var zoom = d3.zoom()
+                .scaleExtent([-8, 8])
+                .on('zoom', function() {
+                    d3.select(this)
+                    .selectAll(".chart")
+                    .attr('transform', d3.event.transform);
+
+                    //get correct chart
+                    model.setCurrentTreeIndex(d3.select(this).select(".chart").attr('chart-id'));
+
+                    //update model
+                    model.updateNodes(
+                        function(nodes){
+                            nodes.forEach(function(d){
+                                d.x0 = d.x;
+                                d.y0 = d.y;
+        
+                                // Store the overall position based on group
+                                d.xMainG = d.x + treeHeight * treeIndex + margin.top + d3.event.transform.x;
+                                d.yMainG = d.y + margin.left + d3.event.transform.y;
+                            })
+                        }
+                    )
+
+                    update();
+                });
+
+                newg.call(zoom);
+
+                
+                spreadFactor = width / (maxHeight + 1);
+                legendOffset = 30;
+
+                model.updateNodes(
+                    function(n){
+                        // Normalize for fixed-depth.
+                        n.forEach(function (d) {
+                            d.x = d.x + legendOffset ;
+                            d.y = d.depth * spreadFactor;
+                            d.treeIndex = treeIndex;
+                        });
+                    }
+                );
+
+                update(currentRoot, currentTreeMap, newg);
+
+                model.updateNodes(
+                    function(n){
+                        // Stash the old positions for transition and
+                        // stash absolute positions (absolute in mainG)
+                        n.forEach(function (d) {
+                            d.x0 = d.x;
+                            d.y0 = d.y;
+
+                            // Store the overall position based on group
+                            d.xMainG = d.x + treeHeight * treeIndex + margin.top;
+                            d.yMainG = d.y + margin.left;
+                        });
+                    }
+                );
+
+                newg.style("display", "inline-block");
+            } //end for-loop "add tree"
+
+            // Global min/max are the last entry of forestMetrics;
+            forestMetrics.push(forestMinMax);
+
+            function update(source, treeData, g) {
+                var curMetric = d3.select(element).select('#metricSelect').property('value');
+                var treeIndex = g.attr("class").split(" ")[1];
+                if (d3.select(element).select('#unifyLegends').text() == 'Legends: unified') {
+                    setColorLegend(-1);
+                } else {
+                    setColorLegend(treeIndex);
+                }
+    
+                // Compute the new tree layout
+                // var nodes = treeData.descendants();
+                // var links = treeData.descendants().slice(1);
+    
+                var nodes = model.getNodesFromMap();
+                var links = model.getLinksFromMap();
+    
+                
+                // // Normalize for fixed-depth.
+                // nodes.forEach(function (d) {
+                //     d.x = d.x + legendOffset ;
+                //     d.y = d.depth * spreadFactor;
+                //     d.treeIndex = treeIndex;
+                // });
+                
+                var chart = g.selectAll('.chart');
+    
+                // Update the nodes…
+                var node = chart.selectAll("g.node")
+                        .data(nodes, function (d) {
+                            return d.id || (d.id = ++i);
+                        });
+    
+                // Enter any new nodes at the parent's previous position.
+                nodeEnter = node.enter().append('g')
+                        .attr('class', 'node')
+                        .attr("transform", function (d) {
+                            return "translate(" + source.y0 + "," + source.x0 + ")";
+                        })
+                        .on("click", click)
+                        .on('dblclick', function (d) {
+                            doubleclick(d, treeData, g);
+                        });
+    
+                nodeEnter.append("circle")
+                        .attr('class', 'circleNode')
+                        .attr("r", 1e-6)
+                        .style("fill", function (d) {
+                            if (d3.select(element).select('#unifyLegends').text() == 'Legends: unified') {
+                                return colorScale(d.data.metrics[curMetric], -1);
+                            }
+                            return colorScale(d.data.metrics[curMetric], d.treeIndex);
+                        })
+                        .style('stroke-width', '1px')
+                        .style('stroke', 'black');
+    
+                // commenting out text for now
+                // nodeEnter.append("text")
+                //         .attr("x", function (d) {
+                //             return d.children || d._children ? -13 : 13;
+                //         })
+                //         .attr("dy", ".75em")
+                //         .attr("text-anchor", function (d) {
+                //             return d.children || d._children ? "end" : "start";
+                //         })
+                //         .text(function (d) {
+                //             return d.data.name;
+                //         })
+                //         .attr('transform', 'rotate( -15)')
+                //         .style("stroke-width", "3px")
+                //         .style("font", "12px monospace");
+    
+                //UPDATE
+                var nodeUpdate = nodeEnter.merge(node);
+    
+                // Transition nodes to their new position.
+                nodeUpdate.transition()
+                        .duration(duration)
+                        .attr("transform", function (d) {
+                            return "translate(" + d.y + "," + d.x + ")";
+                        });
+    
+                nodeUpdate.select('circle.circleNode')
+                        .attr("r", 4)
+                        .style('fill', function (d) {
+                            if (d3.select(element).select('#unifyLegends').text() == 'Legends: unified') {
+                                return colorScale(d.data.metrics[curMetric], -1);
+                            }
+                            return colorScale(d.data.metrics[curMetric], d.treeIndex);
+                        })
+                        .style('stroke', 'black')
+                        .style("stroke-dasharray", function (d) {
+                            return d._children ? '4' : '0';
+                        }) //lightblue
+                        .style('stroke-width', d => d._children ? '6px' : '1px')
+                        .attr('cursor', 'pointer');
+    
+                // Transition exiting nodes to the parent's new position.
+                var nodeExit = node.exit().transition()
+                        .duration(duration)
+                        .attr("transform", function (d) {
+                            return "translate(" + source.y + "," + source.x + ")";
+                        })
+                        .remove();
+    
+                nodeExit.select("circle")
+                        .attr("r", 1e-6);
+    
+                nodeExit.select("text")
+                        .style("fill-opacity", 1);
+    
+                /******** Links ********/
+                // Creates a curved (diagonal) path from parent to the child nodes
+                function diagonal(s, d) {
+                    path = `M ${s.y} ${s.x}
+                    C ${(s.y + d.y) / 2} ${s.x},
+                    ${(s.y + d.y) / 2} ${d.x},
+                    ${d.y} ${d.x}`
+    
+                    return path
+                }
+    
+                // Update the links…
+                var link = chart.selectAll("path.link")
+                        .data(links, function (d) {
+                            return d.id;
+                        });
+    
+                // Enter any new links at the parent's previous position.
+                var linkEnter = link.enter().insert("path", "g")
+                        .attr("class", "link")
+                        .attr("d", function (d) {
+                            var o = {x: source.x0, y: source.y0};
+                            return diagonal(o, o);
+                        })
+                        .attr('fill', 'none')
+                        .attr('stroke', '#ccc')
+                        .attr('stroke-width', '2px');
+    
+                var linkUpdate = linkEnter.merge(link);
+    
+                // Transition links to their new position.
+                linkUpdate.transition()
+                        .duration(duration)
+                        .attr("d", function (d) {
+                            return diagonal(d, d.parent);
+                        });
+    
+                // Transition exiting nodes to the parent's new position.
+                var linkExit = link.exit().transition()
+                        .duration(duration)
+                        .attr("d", function (d) {
+                            var o = {x: source.x, y: source.y};
+                            return diagonal(o, o);
+                        })
+                        .remove();
+                
+    
+    
+            
+                // Stash the old positions for transition and
+                // stash absolute positions (absolute in mainG)
+                // nodes.forEach(function (d) {
+                //     d.x0 = d.x;
+                //     d.y0 = d.y;
+    
+                //     // Store the overall position based on group
+                //     d.xMainG = d.x + treeHeight * treeIndex + margin.top;
+                //     d.yMainG = d.y + margin.left;
+                // });
+            }
+            
+        }
+
+        var model = createModel();
+
+        var view = createView(element, model);
 
         var i = 0,
-                duration = 750;
+        duration = 750;
 
+        
         // Helper function for determining which nodes are in brush
         function rectContains(selection, points) {
             if (selection) {
@@ -324,7 +685,7 @@
 
             var colorSchemeUsed;
             if (treeIndex == -1) { //all trees are displayed
-                if (colorScheme == 1) {
+                if (model.state["colorScheme"] == 1) {
                     d3.select(element).select('#colorButton text')
                             .text('Colors: default');
                     colorSchemeUsed = allTreesColors;
@@ -334,7 +695,7 @@
                     colorSchemeUsed = invertedAllTrees;
                 }
             } else { //single tree is displayed
-                if (colorScheme == 1) {
+                if (model.state["colorScheme"] == 1) {
                     d3.select(element).select('#colorButton text')
                             .text('Colors: default');
                     colorSchemeUsed = regularColors[treeIndex];
@@ -350,7 +711,12 @@
         function addColorLegendRects(thisG) {
             var treeIndex = thisG.attr("class").split(" ")[1];
 
-            const legendGroups = thisG.selectAll("g")
+            const legGroup = thisG
+                    .append('g')
+                    .attr('class', 'legend-grp-'+treeIndex)
+                    .attr('transform', 'translate(-20, 0)');
+
+            const legendGroups = legGroup.selectAll("g")
                     .data([0, 1, 2, 3, 4, 5])
                     .enter()
                     .append('g')
@@ -475,169 +841,9 @@
                     }
                 });
 
-        function update(source, treeData, g) {
-            var curMetric = d3.select(element).select('#metricSelect').property('value');
-            var treeIndex = g.attr("class").split(" ")[1];
-            if (d3.select(element).select('#unifyLegends').text() == 'Legends: unified') {
-                setColorLegend(-1);
-            } else {
-                setColorLegend(treeIndex);
-            }
-
-            // Compute the new tree layout
-            var nodes = treeData.descendants();
-            var links = treeData.descendants().slice(1);
-
-            spreadFactor = width / (maxHeight + 1);
-            legendOffset = 30;
-            // Normalize for fixed-depth.
-            nodes.forEach(function (d) {
-                d.x = d.x + legendOffset;
-                d.y = d.depth * spreadFactor;
-                d.treeIndex = treeIndex;
-            });
-
-            // Update the nodes…
-            var node = g.selectAll("g.node")
-                    .data(nodes, function (d) {
-                        return d.id || (d.id = ++i);
-                    });
-
-            // Enter any new nodes at the parent's previous position.
-            nodeEnter = node.enter().append('g')
-                    .attr('class', 'node')
-                    .attr("transform", function (d) {
-                        return "translate(" + source.y0 + "," + source.x0 + ")";
-                    })
-                    .on("click", click)
-                    .on('dblclick', function (d) {
-                        doubleclick(d, treeData, g);
-                    });
-
-            nodeEnter.append("circle")
-                    .attr('class', 'circleNode')
-                    .attr("r", 1e-6)
-                    .style("fill", function (d) {
-                        if (d3.select(element).select('#unifyLegends').text() == 'Legends: unified') {
-                            return colorScale(d.data.metrics[curMetric], -1);
-                        }
-                        return colorScale(d.data.metrics[curMetric], d.treeIndex);
-                    })
-                    .style('stroke-width', '1px')
-                    .style('stroke', 'black');
-
-            nodeEnter.append("text")
-                    .attr("x", function (d) {
-                        return d.children || d._children ? -13 : 13;
-                    })
-                    .attr("dy", ".75em")
-                    .attr("text-anchor", function (d) {
-                        return d.children || d._children ? "end" : "start";
-                    })
-                    .text(function (d) {
-                        return d.data.name;
-                    })
-                    .attr('transform', 'rotate( -15)')
-                    .style("stroke-width", "3px")
-                    .style("font", "12px monospace");
-
-            //UPDATE
-            var nodeUpdate = nodeEnter.merge(node);
-
-            // Transition nodes to their new position.
-            nodeUpdate.transition()
-                    .duration(duration)
-                    .attr("transform", function (d) {
-                        return "translate(" + d.y + "," + d.x + ")";
-                    });
-
-            nodeUpdate.select('circle.circleNode')
-                    .attr("r", 10)
-                    .style('fill', function (d) {
-                        if (d3.select(element).select('#unifyLegends').text() == 'Legends: unified') {
-                            return colorScale(d.data.metrics[curMetric], -1);
-                        }
-                        return colorScale(d.data.metrics[curMetric], d.treeIndex);
-                    })
-                    .style('stroke', 'black')
-                    .style("stroke-dasharray", function (d) {
-                        return d._children ? '4' : '0';
-                    }) //lightblue
-                    .style('stroke-width', d => d._children ? '6px' : '1px')
-                    .attr('cursor', 'pointer');
-
-            // Transition exiting nodes to the parent's new position.
-            var nodeExit = node.exit().transition()
-                    .duration(duration)
-                    .attr("transform", function (d) {
-                        return "translate(" + source.y + "," + source.x + ")";
-                    })
-                    .remove();
-
-            nodeExit.select("circle")
-                    .attr("r", 1e-6);
-
-            nodeExit.select("text")
-                    .style("fill-opacity", 1);
-
-            /******** Links ********/
-            // Creates a curved (diagonal) path from parent to the child nodes
-            function diagonal(s, d) {
-                path = `M ${s.y} ${s.x}
-          C ${(s.y + d.y) / 2} ${s.x},
-          ${(s.y + d.y) / 2} ${d.x},
-          ${d.y} ${d.x}`
-
-                return path
-            }
-
-            // Update the links…
-            var link = g.selectAll("path.link")
-                    .data(links, function (d) {
-                        return d.id;
-                    });
-
-            // Enter any new links at the parent's previous position.
-            var linkEnter = link.enter().insert("path", "g")
-                    .attr("class", "link")
-                    .attr("d", function (d) {
-                        var o = {x: source.x0, y: source.y0};
-                        return diagonal(o, o);
-                    })
-                    .attr('fill', 'none')
-                    .attr('stroke', '#ccc')
-                    .attr('stroke-width', '2px');
-
-            var linkUpdate = linkEnter.merge(link);
-
-            // Transition links to their new position.
-            linkUpdate.transition()
-                    .duration(duration)
-                    .attr("d", function (d) {
-                        return diagonal(d, d.parent);
-                    });
-
-            // Transition exiting nodes to the parent's new position.
-            var linkExit = link.exit().transition()
-                    .duration(duration)
-                    .attr("d", function (d) {
-                        var o = {x: source.x, y: source.y};
-                        return diagonal(o, o);
-                    })
-                    .remove();
-
-            // Stash the old positions for transition and
-            // stash absolute positions (absolute in mainG)
-            nodes.forEach(function (d) {
-                d.x0 = d.x;
-                d.y0 = d.y;
-
-                // Store the overall position based on group
-                d.xMainG = d.x + treeHeight * treeIndex + margin.top;
-                d.yMainG = d.y + margin.left;
-
-            });
-        }
+        
+        
+        
 
         //When metricSelect is changed (metric_col)
         d3.select(element).select('#metricSelect')
@@ -811,6 +1017,8 @@
             updateTooltip(brushedData);
 
             jsNodeSelected = printQuery(brushedData);
-       }
+        }
+
     });
+
 })(element);

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -46,6 +46,28 @@
         };
 
 
+
+        // Returns a function, that, as long as it continues to be invoked, will not
+        // be triggered. The function will be called after it stops being called for
+        // N milliseconds. If `immediate` is passed, trigger the function on the
+        // leading edge, instead of the trailing.
+        // Taken from: https://davidwalsh.name/javascript-debounce-function
+        function debounce(func, wait, immediate) {
+            var timeout;
+            return function() {
+                var context = this, args = arguments;
+                var later = function() {
+                    timeout = null;
+                    if (!immediate) func.apply(context, args);
+                };
+                var callNow = immediate && !timeout;
+                clearTimeout(timeout);
+                timeout = setTimeout(later, wait);
+                if (callNow) func.apply(context, args);
+            };
+        };
+
+
         var makeColorManager = function(model){
             
             var _regularColors = [['#006d2c', '#31a354', '#74c476', '#a1d99b', '#c7e9c0', '#edf8e9'], //green
@@ -220,6 +242,10 @@
                             _model.updateLegends();
                             break;
                         case(globals.signals.ZOOM):
+<<<<<<< HEAD
+=======
+                            // add debounce
+>>>>>>> Panning and zooming works and updates for brushing.
                             _model.updateNodeLocations(evt.index, evt.transformation);
                             break;
                         default:
@@ -494,6 +520,7 @@
                     _observers.notify();
                 },
                 updateNodeLocations: function(index, transformation){
+<<<<<<< HEAD
                     _data["treemaps"][index].descendants().forEach(function(d, i) {
                         // This function gets the absolute location for each point based on the relative
                         // locations of the points based on transformations
@@ -503,6 +530,11 @@
                         // Adapted from: https://stackoverflow.com/questions/18554224/getting-screen-positions-of-d3-nodes-after-transform
                         d.yMainG = transformation.e + d.y0*transformation.d + d.x0*transformation.c - globals.layout.margin.left;
                         d.xMainG = transformation.f + d.y0*transformation.b + d.x0*transformation.a - globals.layout.margin.top;
+=======
+                    _data["treemaps"][index].descendants().forEach(function(d) {
+                        d.xMainG = d.xMainG0 + transformation.y;
+                        d.yMainG = d.yMainG0 + transformation.x;
+>>>>>>> Panning and zooming works and updates for brushing.
                     });
                 }
             }
@@ -851,7 +883,11 @@
                     _observers.notify({
                         type: globals.signals.ZOOM,
                         index: zoomObj.attr("chart-id"),
+<<<<<<< HEAD
                         transformation: zoomObj.node().getCTM()
+=======
+                        transformation: d3.event.transform
+>>>>>>> Panning and zooming works and updates for brushing.
                     })
                 });
 
@@ -867,7 +903,10 @@
                 newg.call(zoom)
                     .on("dblclick.zoom", null);
                     
+<<<<<<< HEAD
 
+=======
+>>>>>>> Panning and zooming works and updates for brushing.
 
                 model.updateNodes(treeIndex,
                     function(n){
@@ -882,6 +921,9 @@
                             // Store the overall position based on group
                             d.xMainG = d.x + globals.treeHeight * treeIndex + _margin.top;
                             d.yMainG = d.y + _margin.left;
+
+                            d.xMainG0 = d.xMainG;
+                            d.yMainG0 = d.yMainG;
                         });
                     }
                 );

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -860,7 +860,7 @@
                     .attr('class', 'chart')
                     .attr('chart-id', treeIndex)
                     .append('rect')
-                    .attr('height', treeHeight)
+                    .attr('height', globals.treeHeight)
                     .attr('width', width)
                     .attr('fill', 'rgba(0,0,0,0)');
 

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -17,54 +17,11 @@
                 ZOOM: "ZOOM"
             },
             layout: {
-                margin: {top: 20, right: 20, bottom: 80, left: 20},
+                margin: {top: 20, right: 20, bottom: 20, left: 20},
             },
             duration: 750,
             treeHeight: 300
-        })
-
-
-        // Returns a function, that, as long as it continues to be invoked, will not
-        // be triggered. The function will be called after it stops being called for
-        // N milliseconds. If `immediate` is passed, trigger the function on the
-        // leading edge, instead of the trailing.
-        // Taken from: https://davidwalsh.name/javascript-debounce-function
-        function debounce(func, wait, immediate) {
-            var timeout;
-            return function() {
-                var context = this, args = arguments;
-                var later = function() {
-                    timeout = null;
-                    if (!immediate) func.apply(context, args);
-                };
-                var callNow = immediate && !timeout;
-                clearTimeout(timeout);
-                timeout = setTimeout(later, wait);
-                if (callNow) func.apply(context, args);
-            };
-        };
-
-
-
-        // Returns a function, that, as long as it continues to be invoked, will not
-        // be triggered. The function will be called after it stops being called for
-        // N milliseconds. If `immediate` is passed, trigger the function on the
-        // leading edge, instead of the trailing.
-        // Taken from: https://davidwalsh.name/javascript-debounce-function
-        function debounce(func, wait, immediate) {
-            var timeout;
-            return function() {
-                var context = this, args = arguments;
-                var later = function() {
-                    timeout = null;
-                    if (!immediate) func.apply(context, args);
-                };
-                var callNow = immediate && !timeout;
-                clearTimeout(timeout);
-                timeout = setTimeout(later, wait);
-                if (callNow) func.apply(context, args);
-            };
-        };
+        });
 
 
         var makeColorManager = function(model){
@@ -87,8 +44,9 @@
             var _allTreesColors = ['#d73027', '#fc8d59', '#fee090', '#e0f3f8', '#91bfdb', '#4575b4'];
             var _invertedAllTreesColors = ['#4575b4', '#91bfdb', '#e0f3f8', '#fee090', '#fc8d59', '#d73027'];
 
-            var _state = model.state;
-            var forestMinMax = model.data["forestMinMax"];
+            let _state = model.state;
+            let _forestMinMax = model.data["forestMinMax"];
+            let _forestMetrics = model.data["forestMetrics"];
 
             return {
                 setColors: function(treeIndex){
@@ -122,15 +80,15 @@
                     }
 
                     if (treeIndex == -1) { //unified color legend
-                        metric_range = forestMinMax[curMetric].max - forestMinMax[curMetric].min;
+                        metric_range = _forestMinMax[curMetric].max - _forestMinMax[curMetric].min;
                         colorScaleDomain = [0, 0.1, 0.3, 0.5, 0.7, 0.9, 1].map(function (x) {
-                            return x * metric_range + forestMinMax[curMetric].min;
+                            return x * metric_range + _forestMinMax[curMetric].min;
                         });
                     } 
                     else{
-                        metric_range = forestMetrics[treeIndex][curMetric].max - forestMetrics[treeIndex][curMetric].min;
+                        metric_range = _forestMetrics[treeIndex][curMetric].max - _forestMetrics[treeIndex][curMetric].min;
                         colorScaleDomain = [0, 0.1, 0.3, 0.5, 0.7, 0.9, 1].map(function (x) {
-                            return x * metric_range + forestMetrics[treeIndex][curMetric].min;
+                            return x * metric_range + _forestMetrics[treeIndex][curMetric].min;
                         });
                     }
 
@@ -155,11 +113,11 @@
                     var curMetric = d3.select(element).select('#metricSelect').property('value');
                     var colorSchemeUsed = this.setColors(treeIndex);
                     if (treeIndex == -1) {
-                        var metric_range = forestMinMax[curMetric].max - forestMinMax[curMetric].min;
-                        var proportion_of_total = (nodeMetric - forestMinMax[curMetric].min) / metric_range;
+                        var metric_range = _forestMinMax[curMetric].max - _forestMinMax[curMetric].min;
+                        var proportion_of_total = (nodeMetric - _forestMinMax[curMetric].min) / metric_range;
                     } else {
-                        var metric_range = forestMetrics[treeIndex][curMetric].max - forestMetrics[treeIndex][curMetric].min;
-                        var proportion_of_total = nodeMetric;
+                        var metric_range = _forestMetrics[treeIndex][curMetric].max - _forestMetrics[treeIndex][curMetric].min;
+                        var proportion_of_total = nodeMetric / 1;
     
                         if (metric_range != 0) {
                             proportion_of_total = (nodeMetric - forestMetrics[treeIndex][curMetric].min) / metric_range;
@@ -291,8 +249,8 @@
             _state["lastClicked"] = d3.hierarchy(_data["forestData"][0], d => d.children)
             _state["activeTree"] = "Show all trees";
 
-            var forestMetrics = [];
-            var forestMinMax = {}; 
+            var _forestMetrics = [];
+            var _forestMinMax = {}; 
             for (var i = 0; i < _data["numberOfTrees"]; i++) {
                 var thisTree = _data["forestData"][i];
 
@@ -308,23 +266,23 @@
                     thisTreeMetrics[_data["metricColumns"][j]]["max"] = 0;
                 }
 
-                forestMetrics.push(thisTreeMetrics);
+                _forestMetrics.push(thisTreeMetrics);
             }
             for (var j = 0; j < _data["metricColumns"].length; j++) {
-                forestMinMax[_data["metricColumns"][j]] = {};
-                forestMinMax[_data["metricColumns"][j]]["min"] = Number.MAX_VALUE;
-                forestMinMax[_data["metricColumns"][j]]["max"] = 0;
+                _forestMinMax[_data["metricColumns"][j]] = {};
+                _forestMinMax[_data["metricColumns"][j]]["min"] = Number.MAX_VALUE;
+                _forestMinMax[_data["metricColumns"][j]]["max"] = 0;
             }
 
-            _data["forestMinMax"] = forestMinMax;
-            _data["forestMetrics"] = forestMetrics;
+            _data["forestMinMax"] = _forestMinMax;
+            _data["forestMetrics"] = _forestMetrics;
 
             // HELPER FUNCTION DEFINTIONS
             function _printNodeData(nodeList) {
                 // To pretty print the node data as a IPython table
                 var nodeStr = '<table><tr><td>name</td>';
                 var numNodes = nodeList.length;
-                var metricColumns = model.data["metricColumns"];
+                var metricColumns = _data["metricColumns"];
 
                 //lay the nodes out in a table
                 for (var i = 0; i < metricColumns.length; i++) {
@@ -411,6 +369,31 @@
                 updateNodes: function(index, f){
                     f(_data['trees'][index].descendants());
                 },
+                updateForestMetrics: function(index){
+                    _data['trees'][index].descendants().forEach(function (d) {
+                        for (var i = 0; i < _data["metricColumns"].length; i++) {
+                            var tempMetric = _data["metricColumns"][i];
+                            if (d.data.metrics[tempMetric] > _forestMetrics[index][tempMetric].max) {
+                                _forestMetrics[index][tempMetric].max = d.data.metrics[tempMetric];
+                            }
+                            if (d.data.metrics[tempMetric] < _forestMetrics[index][tempMetric].min) {
+                                _forestMetrics[index][tempMetric].min = d.data.metrics[tempMetric];
+                            }
+                            if (d.data.metrics[tempMetric] > _forestMinMax[tempMetric].max) {
+                                _forestMinMax[tempMetric].max = d.data.metrics[tempMetric];
+                            }
+                            if (d.data.metrics[tempMetric] < _forestMinMax[tempMetric].min) {
+                                _forestMinMax[tempMetric].min = d.data.metrics[tempMetric];
+                            }
+                        }
+                    });
+
+                    _data["forestMetrics"] = _forestMetrics;
+
+                    // Global min/max are the last entry of forestMetrics;
+                    _data["forestMinMax"] = _forestMinMax;
+                    _data["forestMetrics"].push(_forestMinMax);
+                },
                 updateSelected: function(nodes){
 
                     _state['selectedNodes'] = nodes;
@@ -431,7 +414,7 @@
                         _state["collapsedNodes"].push(d);
                     }
                     else{
-                        index = _state["collapsedNodes"].indexOf(d);
+                        var index = _state["collapsedNodes"].indexOf(d);
                         _state["collapsedNodes"].splice(index, 1);
                     }
 
@@ -541,6 +524,10 @@
             
             var selectedMetric = model.state["selectedMetric"];
             var brushOn = model.state["brushOn"];
+            var curColor = model.state["colorScheme"];
+            var colors = model.data["colors"];        
+            var curLegend = model.state["legend"];
+            var legends = model.data["legends"];
 
                  
             //initialize bounds for svg
@@ -784,7 +771,7 @@
 
             // Creates a curved (diagonal) path from parent ------------------to the child nodes
             function diagonal(s, d) {
-                path = `M ${s.y} ${s.x}
+                let path = `M ${s.y} ${s.x}
                 C ${(s.y + d.y) / 2} ${s.x},
                 ${(s.y + d.y) / 2} ${d.x},
                 ${d.y} ${d.x}`
@@ -816,10 +803,7 @@
                 let min = minmax["min"];
                 let max = minmax["max"];
 
-                if (max == min) {
-                    return Math.abs(max);
-                }
-                return Math.abs(max) + Math.abs(min);
+                return max - min;
             }
 
             function _getSelectionHeight(elem){
@@ -835,8 +819,8 @@
 
             // Find the tallest tree for layout purposes (used to set a uniform spreadFactor)
             for (var treeIndex = 0; treeIndex < forestData.length; treeIndex++) {
-                var currentTreeData = forestData[treeIndex];
-                var currentRoot = d3.hierarchy(currentTreeData, d => d.children);
+                let currentTreeData = forestData[treeIndex];
+                let currentRoot = d3.hierarchy(currentTreeData, d => d.children);
 
                 currentRoot.x0 = height;
                 currentRoot.y0 = _margin.left;
@@ -857,33 +841,14 @@
 
             // Add a group and tree for each forestData[i]
             for (var treeIndex = 0; treeIndex < forestData.length; treeIndex++) {
-                var forestMetrics = model.data["forestMetrics"];
-                var forestMinMax = model.data["forestMinMax"];
-
+                model.updateForestMetrics(treeIndex);
+                
                 var currentTree = model.getTree(treeIndex);
                 var newg = mainG.append("g")
                         .attr('class', 'group-' + treeIndex + ' subchart')
                         .attr('tree_id', treeIndex)
                         .attr("transform", "translate(" + _margin.left + "," + chartOffset + ")");
 
-                currentTree.descendants().forEach(function (d) {
-                    for (var i = 0; i < metricColumns.length; i++) {
-                        var tempMetric = metricColumns[i];
-                        if (d.data.metrics[tempMetric] > forestMetrics[treeIndex][tempMetric].max) {
-                            forestMetrics[treeIndex][tempMetric].max = d.data.metrics[tempMetric];
-                        }
-                        if (d.data.metrics[tempMetric] < forestMetrics[treeIndex][tempMetric].min) {
-                            forestMetrics[treeIndex][tempMetric].min = d.data.metrics[tempMetric];
-                        }
-                        if (d.data.metrics[tempMetric] > forestMinMax[tempMetric].max) {
-                            forestMinMax[tempMetric].max = d.data.metrics[tempMetric];
-                        }
-                        if (d.data.metrics[tempMetric] < forestMinMax[tempMetric].min) {
-                            forestMinMax[tempMetric].min = d.data.metrics[tempMetric];
-                        }
-                    }
-                });
-                    
                 const legGroup = newg
                 .append('g')
                 .attr('class', 'legend-grp-' + treeIndex)
@@ -915,7 +880,7 @@
 
 
                 var zoom = d3.zoom().on("zoom", function (){
-                    zoomObj = d3.select(this).selectAll(".chart");
+                    let zoomObj = d3.select(this).selectAll(".chart");
 
                     zoomObj.attr("transform", d3.event.transform);
 
@@ -929,14 +894,17 @@
 
                 legendOffset = legGroup.node().getBBox().height;
 
-                //put tree itself into a group
-                newg.append('g')
-                    .attr('class', 'chart')
-                    .attr('chart-id', treeIndex)
-                    .append('rect')
+
+                //make an invisible rectangle for zooming on
+                newg.append('rect')
                     .attr('height', treeLayoutHeights[treeIndex])
                     .attr('width', width)
                     .attr('fill', 'rgba(0,0,0,0)');
+
+                //put tree itself into a group
+                newg.append('g')
+                    .attr('class', 'chart')
+                    .attr('chart-id', treeIndex);
 
                 newg.call(zoom)
                     .on("dblclick.zoom", null);
@@ -949,7 +917,7 @@
                     function(n){
                         // Normalize for fixed-depth.
                         n.forEach(function (d) {
-                            d.x = d.x + treeOffset + Math.abs(minmax[treeIndex]["min"]);
+                            d.x = d.x + treeOffset - minmax[treeIndex]["min"];
                             d.y = (d.depth * spreadFactor);
 
                             d.x0 = d.x;
@@ -967,17 +935,13 @@
 
                 newg.style("display", "inline-block");
 
+                
                 //updates
                 chartOffset += treeLayoutHeights[treeIndex] + treeOffset + _margin.top;
                 height += chartOffset;
             } //end for-loop "add tree"
-
-
+            
             svg.attr("height", height);
-
-            // Global min/max are the last entry of forestMetrics;
-            forestMetrics.push(forestMinMax);
-
 
             return{
                 register: function(s){
@@ -985,6 +949,7 @@
                 },
                 render: function(){
                     chartOffset = _margin.top;
+                    height = _margin.top + _margin.bottom;
                     //render for any number of trees
                     for(var treeIndex = 0; treeIndex < model.data["numberOfTrees"]; treeIndex++){
 
@@ -1202,7 +1167,11 @@
                                 .remove();
 
                         chartOffset += treeLayoutHeights[treeIndex] + treeOffset + _margin.top;
+                        height += chartOffset;
                     }                    
+
+                    //hack: fix in future
+                    svg.attr("height", height-treeOffset);
                 }
             }
             

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -73,6 +73,7 @@
                     const curColorScheme = _state["colorScheme"];
                     
                     // so hacky: need to fix later
+                    // Suraj: Cant really understand why this needs to be done.!!!
                     if (model.data["legends"][_state["legend"]].includes("Unified")) {
                         treeIndex = -1;
                     }
@@ -268,18 +269,27 @@
                 var thisTreeMetrics = {};
 
                 // init the min/max for all trees' metricColumns
-                for (var j = 0; j < _data["metricColumns"].length; j++) {
-                    thisTreeMetrics[_data["metricColumns"][j]] = {};
-                    thisTreeMetrics[_data["metricColumns"][j]]["min"] = Number.MAX_VALUE;
-                    thisTreeMetrics[_data["metricColumns"][j]]["max"] = 0;
+                for (let metric of _data["metricColumns"]) {
+                    let _d;
+                    if (metric === "module") {
+                        _d = [];
+                    }
+                    else {
+                        _d = { "min": Number.MAX_VALUE, "max": 0 }
+                    }
+                    thisTreeMetrics[metric] = _d;
                 }
 
                 _forestMetrics.push(thisTreeMetrics);
             }
-            for (var j = 0; j < _data["metricColumns"].length; j++) {
-                _forestMinMax[_data["metricColumns"][j]] = {};
-                _forestMinMax[_data["metricColumns"][j]]["min"] = Number.MAX_VALUE;
-                _forestMinMax[_data["metricColumns"][j]]["max"] = 0;
+            for (let metric of _data["metricColumns"]) {
+                if (metric === "module") {
+                    _d = [];
+                }
+                else {
+                    _d = { "min": Number.MAX_VALUE, "max": 0 }
+                }
+                _forestMinMax[metric] = _d;
             }
 
             _data["forestMinMax"] = _forestMinMax;
@@ -427,19 +437,18 @@
                      * @param {Number} index - The index of the tree we are updating
                      */
                     _data['trees'][index].descendants().forEach(function (d) {
-                        for (var i = 0; i < _data["metricColumns"].length; i++) {
-                            var tempMetric = _data["metricColumns"][i];
-                            if (d.data.metrics[tempMetric] > _forestMetrics[index][tempMetric].max) {
-                                _forestMetrics[index][tempMetric].max = d.data.metrics[tempMetric];
-                            }
-                            if (d.data.metrics[tempMetric] < _forestMetrics[index][tempMetric].min) {
-                                _forestMetrics[index][tempMetric].min = d.data.metrics[tempMetric];
-                            }
-                            if (d.data.metrics[tempMetric] > _forestMinMax[tempMetric].max) {
-                                _forestMinMax[tempMetric].max = d.data.metrics[tempMetric];
-                            }
-                            if (d.data.metrics[tempMetric] < _forestMinMax[tempMetric].min) {
-                                _forestMinMax[tempMetric].min = d.data.metrics[tempMetric];
+                        for (let metric of _data["metricColumns"]) {
+                            if (metric === "module") {
+                                if (!_forestMetrics[index][metric].includes(d.data.metrics[metric])) {
+                                    _forestMetrics[index][metric].push(d.data.metrics[metric]);  
+                                    _forestMinMax[metric].push(d.data.metrics[metric]);                 
+                                }
+                            } else {
+                                _forestMetrics[index][metric].min = Math.min(_forestMetrics[index][metric].min, d.data.metrics[metric]);
+                                _forestMetrics[index][metric].max = Math.max(_forestMetrics[index][metric].max, d.data.metrics[metric]);
+                                _forestMinMax[metric].min = Math.min(_forestMinMax[metric].min, d.data.metrics[metric]);
+                                _forestMinMax[metric].max = Math.max(_forestMinMax[metric].max, d.data.metrics[metric]);
+
                             }
                         }
                     });

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -50,6 +50,12 @@
 
             return {
                 setColors: function(treeIndex){
+                    /**
+                     * Sets the color pallet per tree to be either inverse or regular or unified/divergent
+                     * 
+                     * @param {Int} treeIndex - The index of the current tree's colors being set
+                     */
+
                     var colorSchemeUsed;
     
                     if (treeIndex == -1) { //all trees are displayed
@@ -70,6 +76,12 @@
                     return colorSchemeUsed;
                 },
                 getLegendDomains: function(treeIndex){
+                    /**
+                     * Sets the min and max of our legend. 
+                     * 
+                     * @param {Int} treeIndex - The index of the current tree's legend being set
+                     */
+
                     var colorScaleDomain;
                     var metric_range;
                     var curMetric = _state["selectedMetric"];
@@ -95,6 +107,11 @@
                     return colorScaleDomain;
                 },
                 getColorLegend: function(treeIndex) {
+                    /**
+                     * Gets the color scheme used for a legend contigent on divergent or unified color schemes.
+                     * 
+                     * @param {Int} treeIndex - The index of the current tree's legend being set
+                     */
                 
                     //hacky need to fix later
                     if (model.data["legends"][_state["legend"]].includes("Unified")) {
@@ -110,8 +127,16 @@
                     return colorSchemeUsed;
                 },
                 calcColorScale: function(nodeMetric, treeIndex) {
+                    /**
+                     * Calcaultes the bins for our color scheme based on the domain of our metrics.
+                     * 
+                     * @param {String} nodeMetric - the name of our current metric being mapped to a color range
+                     * @param {Int} treeIndex - The index of the current tree's legend being set
+                     */
+
                     var curMetric = d3.select(element).select('#metricSelect').property('value');
                     var colorSchemeUsed = this.setColors(treeIndex);
+                    
                     if (treeIndex == -1) {
                         var metric_range = _forestMinMax[curMetric].max - _forestMinMax[curMetric].min;
                         var proportion_of_total = (nodeMetric - _forestMinMax[curMetric].min) / metric_range;
@@ -279,7 +304,12 @@
 
             // HELPER FUNCTION DEFINTIONS
             function _printNodeData(nodeList) {
-                // To pretty print the node data as a IPython table
+                /**
+                  * To pretty print the node data as a IPython table
+                  * 
+                  * @param {Array} nodeList - An array of selected nodes for formatting
+                  */
+                
                 var nodeStr = '<table><tr><td>name</td>';
                 var numNodes = nodeList.length;
                 var metricColumns = _data["metricColumns"];
@@ -307,6 +337,11 @@
             }
 
             function _printQuery(nodeList) {
+                /**
+                  * Prints out our selected nodes as a query string which can be used in the GraphFrame.filter() function.
+                  * 
+                  * @param {Array} nodeList - An array of selected nodes for formatting
+                  */
                 var leftMostNode = {depth: Number.MAX_VALUE, data: {name: 'default'}};
                 var rightMostNode = {depth: 0, data: {name: 'default'}};
                 var lastNode = "";
@@ -352,24 +387,62 @@
                 data: _data,
                 state: _state,
                 register: function(s){
+                    /**
+                     * Registers a signaller (a callback function) to be run with _observers.notify()
+                     * 
+                     * @param {Function} s - (a callback function) to be run with _observers.notify()
+                     */
                     _observers.add(s);
                 },
                 addTree: function(tm){
+                    /**
+                     * Pushes a tree into our model.
+                     * 
+                     * @param {Object} tm - A d3 tree constructed from a d3 hierarchy
+                     */
+
                     _data['trees'].push(tm);
                 },
                 getTree: function(index){
+                    /**
+                     * Retrieves a tree from our model.
+                     * 
+                     * @param {Number} index - The index of the tree we want to get
+                     */
                     return _data['trees'][index];
                 },
                 getNodesFromMap: function(index){
+                    /**
+                     * Retrieves tree nodes from our model
+                     * 
+                     * @param {Number} index - The index of the tree nodes we want to get
+                     */
                     return _data['trees'][index].descendants();
                 },
                 getLinksFromMap: function(index){
+                    /**
+                     * Retrieves tree links from our model
+                     * 
+                     * @param {Number} index - The index of the tree links we want to get
+                     */
                     return _data['trees'][index].descendants().slice(1);
                 },
                 updateNodes: function(index, f){
+                    /**
+                     * Updates the nodes in our model according to the passed in callback function.
+                     *
+                     * @param {Number} index - The index of the tree we are updating
+                     * @param {Function} f - The callback function being applied to the nodes
+                     */
                     f(_data['trees'][index].descendants());
                 },
                 updateForestMetrics: function(index){
+                    /**
+                     * Updates the global metrics for a single tree in our forest and stores
+                     * them in the model.
+                     *
+                     * @param {Number} index - The index of the tree we are updating
+                     */
                     _data['trees'][index].descendants().forEach(function (d) {
                         for (var i = 0; i < _data["metricColumns"].length; i++) {
                             var tempMetric = _data["metricColumns"][i];
@@ -395,6 +468,11 @@
                     _data["forestMetrics"].push(_forestMinMax);
                 },
                 updateSelected: function(nodes){
+                    /**
+                     * Updates which nodes are "Selected" by the user in the model
+                     *
+                     * @param {Array} nodes - A list of selected nodes
+                     */
 
                     _state['selectedNodes'] = nodes;
                     this.updateTooltip(nodes);
@@ -408,6 +486,13 @@
                     _observers.notify();
                 },
                 handleDoubleClick: function(d){
+                    /**
+                     * Handles the model functionlaity of hiding and un-hiding subtrees
+                     * on double click
+                     *
+                     * @param {Object} d - The node which was double clicked
+                     */
+
                     // if the node is not already collapsed
                     // keep track of our collapsed nodes
                     if (! _state["collapsedNodes"].includes(d) ){
@@ -435,10 +520,23 @@
                     _observers.notify();
                 },
                 toggleBrush: function(){
+                    /**
+                     * Toggles the brushing functionality with a button click
+                     *
+                     */
+
                     _state["brushOn"] = -_state["brushOn"];
                     _observers.notify();
                 },
                 setBrushedPoints(selection, end){
+                    /**
+                     * Calculates which nodes are in the brushing area.
+                     * 
+                     * @param {Array} selection - A d3 selection matrix with svg coordinates showing the selected space
+                     * @param {Boolean} end - A variable which tests if the brushing is over or not
+                     *
+                     */
+
                     var brushedNodes = [];
 
                     if(selection){
@@ -465,6 +563,13 @@
                     
                 },
                 updateTooltip: function(nodes){
+                    /**
+                     * Updates the model with new tooltip information based on user selection
+                     * 
+                     * @param {Array} nodes - A list of selected nodes
+                     *
+                     */
+
                     if(nodes.length > 0){
                         var longestName = 0;
                         nodes.forEach(function (d) {
@@ -480,24 +585,52 @@
                     }
                 },
                 changeMetric: function(newMetric){
+                    /**
+                     * Changes the currently selected metric in the model.
+                     * 
+                     * @param {String} newMetric - the most recently selected metric
+                     *
+                     */
+
                     _state["selectedMetric"] = newMetric;
                     _observers.notify();
                 },
                 changeColorScheme: function(){
+                    /**
+                     * Changes the current color scheme to inverse or regular. Updates the view
+                     *
+                     */
+
                     //loop through the possible color schemes
                     _state["colorScheme"] = (_state["colorScheme"] + 1) % _data["colors"].length;
                     _observers.notify();
                 },
                 updateLegends: function(){
+                    /**
+                     * Toggles between divergent or unified legends. Updates the view
+                     *
+                     */
                     //loop through legend configruations
                     _state["legend"] = (_state["legend"] + 1) % _data["legends"].length;
                     _observers.notify();
                 },
                 updateActiveTrees: function(activeTree){
+                    /**
+                     * Sets which tree is currently "active" in the model. Updates the view.
+                     *
+                     */
                     _state["activeTree"] = activeTree;
                     _observers.notify();
                 },
                 updateNodeLocations: function(index, transformation){
+                    /**
+                     * Transforms the x and y values of nodes based on transformations
+                     * applied to their parent group
+                     * 
+                     * @param {Number} index - Index of the tree who's nodes are being updated
+                     * @param {Object} transformation - The current transformation matrix (CTM) of an parent group
+                     *
+                     */
                     _data["trees"][index].descendants().forEach(function(d, i) {
                         // This function gets the absolute location for each point based on the relative
                         // locations of the points based on transformations
@@ -513,16 +646,17 @@
         }
 
         var createMenuView = function(elem, model){
-            //setup menu view
+            /**
+             * View class for the menu portion of our visualization
+             * 
+             * @param {DOMElement} elem - The current cell of our jupyter notebook
+             * @param {Model} model - The model object for our MVC pattern
+             */
+
             let _observers = makeSignaller();
-            var _colorManager = makeColorManager(model);
 
             var rootNodeNames = model.data["rootNodeNames"];
-            var numberOfTrees = model.data["numberOfTrees"];
             var metricColumns = model.data["metricColumns"];
-            var forestData = model.data["forestData"];
-            
-            var selectedMetric = model.state["selectedMetric"];
             var brushOn = model.state["brushOn"];
             var curColor = model.state["colorScheme"];
             var colors = model.data["colors"];        
@@ -534,6 +668,9 @@
             var width = element.clientWidth - globals.layout.margin.right - globals.layout.margin.left;
             var height = globals.treeHeight * (model.data["numberOfTrees"] + 1);
 
+            // ----------------------------------------------
+            // Create HTML interactables
+            // ----------------------------------------------
 
             d3.select(elem).append('label').attr('for', 'metricSelect').text('Color by:');
             var metricInput = d3.select(elem).append("select") //element
@@ -567,6 +704,10 @@
                         });
                     });
 
+            
+            // ----------------------------------------------
+            // Create SVG and SVG-based interactables
+            // ----------------------------------------------
 
             //make an svg in the scope of our current
             // element/drawing space
@@ -650,7 +791,9 @@
                 .attr('id', "mainG")
                 .attr("transform", "translate(" + globals.layout.margin.left + "," + globals.layout.margin.top + ")");
 
-            //setup brush
+           // ----------------------------------------------
+            // Define and set d3 callbacks for changes
+            // ----------------------------------------------
             var brush = d3.brush()
                     .extent([[0, 0], [2 * width, 2 * (height + globals.layout.margin.top + globals.layout.margin.bottom)]])
                     .on('brush', function(){
@@ -680,7 +823,6 @@
                     type: globals.signals.METRICCHANGE,
                     newMetric: this.value
                 })
-                // changeMetric();
             });
 
             return{
@@ -688,15 +830,18 @@
                     _observers.add(s);
                 },
                 render: function(){
+                    /**
+                     * Core call for drawing menu related screen elements
+                     */
+
                     selectedMetric = model.state["selectedMetric"];
                     brushOn = model.state["brushOn"];
-
                     curColor = model.state["colorScheme"];
                     colors = model.data["colors"];
-                    
                     curLegend = model.state["legend"];
                     legends = model.data["legends"];
 
+                    //Remove brush and reset if active
                     d3.selectAll('.brush').remove();
 
                     //updates
@@ -747,17 +892,11 @@
         var createChartView = function(svg, model){
             let _observers = makeSignaller();
             var _colorManager = makeColorManager(model);
-
-            var metricColumns = model.data["metricColumns"];
-            var forestData = model.data["forestData"];
-                 
+            var forestData = model.data["forestData"];        
             var width = element.clientWidth - globals.layout.margin.right - globals.layout.margin.left;
             var height = globals.layout.margin.top + globals.layout.margin.bottom;
             var _margin = globals.layout.margin;
-            var widths = [];
-
             var _nodeRadius = 10;
-
             var treeLayoutHeights = [];
 
             //layout variables            
@@ -769,8 +908,16 @@
             var minmax = [];
 
 
-            // Creates a curved (diagonal) path from parent ------------------to the child nodes
+            
             function diagonal(s, d) {
+                /**
+                 * Creates a curved diagonal path from parent to child nodes
+                 * 
+                 * @param {Object} s - parent node
+                 * @param {Object} d - child node
+                 * 
+                 */
+
                 let path = `M ${s.y} ${s.x}
                 C ${(s.y + d.y) / 2} ${s.x},
                 ${(s.y + d.y) / 2} ${d.x},
@@ -780,6 +927,13 @@
             }
 
             function _getMinxMaxxFromTree(root){
+                /**
+                 * Get the minimum x value and maximum x value from a tree layout
+                 * Used for calculating canvas offsets before drawing
+                 * 
+                 * @param {Object} root - The root node of our tree
+                 */
+
                 var obj = {}
                 var min = Infinity;
                 var max = -Infinity;
@@ -799,6 +953,12 @@
             }
 
             function _getHeightFromTree(root){
+                /**
+                 * Get the vertical space required to draw the tree
+                 * by subtracting the min x value from the maximum
+                 * 
+                 * @param {Object} root - The root node of our tree
+                 */
                 let minmax = _getMinxMaxxFromTree(root);
                 let min = minmax["min"];
                 let max = minmax["max"];
@@ -806,16 +966,13 @@
                 return max - min;
             }
 
-            function _getSelectionHeight(elem){
-                return elem.node().getBBox().height;
-            }
-            
-            var mainG = svg.select("#mainG");
+            // --------------------------------------------------------------
+            // Initialize layout before first render
+            // --------------------------------------------------------------
 
+            var mainG = svg.select("#mainG");
             var tree = d3.tree().nodeSize([_nodeRadius, _nodeRadius]);
             // .size([treeHeight, width - _margin.left]);
-
-    
 
             // Find the tallest tree for layout purposes (used to set a uniform spreadFactor)
             for (var treeIndex = 0; treeIndex < forestData.length; treeIndex++) {
@@ -839,7 +996,7 @@
             
             spreadFactor = width/maxHeight;
 
-            // Add a group and tree for each forestData[i]
+            // Add a group and tree for each tree in our forest
             for (var treeIndex = 0; treeIndex < forestData.length; treeIndex++) {
                 model.updateForestMetrics(treeIndex);
                 
@@ -878,20 +1035,6 @@
                         .style('font-family', 'monospace')
                         .style('font-size', '12px');
 
-
-                var zoom = d3.zoom().on("zoom", function (){
-                    let zoomObj = d3.select(this).selectAll(".chart");
-
-                    zoomObj.attr("transform", d3.event.transform);
-
-                    //update for scale view
-                    _observers.notify({
-                        type: globals.signals.ZOOM,
-                        index: zoomObj.attr("chart-id"),
-                        transformation: zoomObj.node().getCTM()
-                    })
-                });
-
                 legendOffset = legGroup.node().getBBox().height;
 
 
@@ -906,13 +1049,27 @@
                     .attr('class', 'chart')
                     .attr('chart-id', treeIndex);
 
+                //Create d3 zoom element and affix to each tree individually
+                var zoom = d3.zoom().on("zoom", function (){
+                    let zoomObj = d3.select(this).selectAll(".chart");
+
+                    zoomObj.attr("transform", d3.event.transform);
+
+                    //update for scale view
+                    _observers.notify({
+                        type: globals.signals.ZOOM,
+                        index: zoomObj.attr("chart-id"),
+                        transformation: zoomObj.node().getCTM()
+                    })
+                });
+
                 newg.call(zoom)
                     .on("dblclick.zoom", null);
                 
-                
+                //X value where tree should start being drawn
                 treeOffset = 0 + legendOffset + _margin.top;
 
-
+                //Initialize nodes with x/y data based on their current location
                 model.updateNodes(treeIndex,
                     function(n){
                         // Normalize for fixed-depth.
@@ -936,9 +1093,10 @@
                 newg.style("display", "inline-block");
 
                 
-                //updates
+                //Add just calculated layout to total layout heights
                 chartOffset += treeLayoutHeights[treeIndex] + treeOffset + _margin.top;
                 height += chartOffset;
+
             } //end for-loop "add tree"
             
             svg.attr("height", height);
@@ -948,8 +1106,15 @@
                     _observers.add(s);
                 },
                 render: function(){
+                    /**
+                     * Core render function for the chart portion of the view, including legends
+                     * Called from the model with observers.notify
+                     * 
+                     */
+
                     chartOffset = _margin.top;
                     height = _margin.top + _margin.bottom;
+
                     //render for any number of trees
                     for(var treeIndex = 0; treeIndex < model.data["numberOfTrees"]; treeIndex++){
 
@@ -962,8 +1127,9 @@
                         var chart = svg.selectAll('.group-' + treeIndex);
                         var tree = chart.selectAll('.chart');
 
-
-                        //ENTER 
+                        // ---------------------------------------------
+                        // ENTER 
+                        // ---------------------------------------------
                         // Update the nodes…
                         var i = 0;
                         var node = tree.selectAll("g.node")
@@ -1046,7 +1212,9 @@
                                 .attr('stroke-width', '2px');
 
         
-                        //UPDATES
+                        // ---------------------------------------------
+                        // Updates 
+                        // ---------------------------------------------
                         var nodeUpdate = nodeEnter.merge(node);
                         var linkUpdate = linkEnter.merge(link);
                 
@@ -1142,7 +1310,9 @@
 
 
                                 
-                        //EXIT
+                        // ---------------------------------------------
+                        // Exit
+                        // ---------------------------------------------
                         // Transition exiting nodes to the parent's new position.
                         var nodeExit = node.exit().transition()
                                 .duration(globals.duration)
@@ -1170,14 +1340,19 @@
                         height += chartOffset;
                     }                    
 
-                    //hack: fix in future
-                    svg.attr("height", height-treeOffset);
+                    svg.attr("height", height);
                 }
             }
             
         }
 
         var createTooltipView = function(elem, model){
+            /**
+             * Class that instantiates the view for the tooltip that appears with selected nodes.
+             * 
+             * @param {DOM Element} elem - The current cell of our Jupyter notebook
+             * @param {Model} model - The model from our MVC pattern
+             */
             var _observers = makeSignaller();
             var _tooltip = d3.select(elem).append("div")
                     .attr('id', 'tooltip')
@@ -1202,6 +1377,10 @@
             }
         }
 
+        // ---------------------------------------------
+        // Main driver area 
+        // ---------------------------------------------
+        
         //model
         var model = createModel();
         //controller

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -7,7 +7,8 @@
                 CLICK: "CLICK",
                 BRUSH: "BRUSH",
                 HOVER: "HOVER",
-                ACTIVATEBRUSH: "ACTIVATEBRUSH"
+                ACTIVATEBRUSH: "ACTIVATEBRUSH",
+                COLLAPSE: "COLLAPSE"
             },
             layout: {
                 margin: {top: 20, right: 20, bottom: 80, left: 20},
@@ -453,144 +454,6 @@
             // Global min/max are the last entry of forestMetrics;
             forestMetrics.push(forestMinMax);
 
-            // function update(source, treeData, g) {
-            //     var curMetric = d3.select(element).select('#metricSelect').property('value');
-            //     var treeIndex = g.attr("class").split(" ")[1];
-            //     if (d3.select(element).select('#unifyLegends').text() == 'Legends: unified') {
-            //         setColorLegend(-1);
-            //     } else {
-            //         setColorLegend(treeIndex);
-            //     }
-    
-            //     var nodes = model.getNodesFromMap();
-            //     var links = model.getLinksFromMap();
-                
-            //     var chart = g.selectAll('.chart');
-    
-            //     // Update the nodes…
-            //     var node = chart.selectAll("g.node")
-            //             .data(nodes, function (d) {
-            //                 return d.id || (d.id = ++i);
-            //             });
-                
-            //     //ENTER
-            //     // Enter any new nodes at the parent's previous position.
-            //     var nodeEnter = node.enter().append('g')
-            //             .attr('class', 'node')
-            //             .attr("transform", function (d) {
-            //                 return "translate(" + source.y0 + "," + source.x0 + ")";
-            //             })
-            //             .on("click", click)
-            //             .on('dblclick', function (d) {
-            //                 doubleclick(d, treeData, g);
-            //             });
-    
-            //     nodeEnter.append("circle")
-            //             .attr('class', 'circleNode')
-            //             .attr("r", 1e-6)
-            //             .style("fill", function (d) {
-            //                 if (d3.select(element).select('#unifyLegends').text() == 'Legends: unified') {
-            //                     return colorScale(d.data.metrics[curMetric], -1);
-            //                 }
-            //                 return colorScale(d.data.metrics[curMetric], d.treeIndex);
-            //             })
-            //             .style('stroke-width', '1px')
-            //             .style('stroke', 'black');
-    
-            //     // commenting out text for now
-            //     // nodeEnter.append("text")
-            //     //         .attr("x", function (d) {
-            //     //             return d.children || d._children ? -13 : 13;
-            //     //         })
-            //     //         .attr("dy", ".75em")
-            //     //         .attr("text-anchor", function (d) {
-            //     //             return d.children || d._children ? "end" : "start";
-            //     //         })
-            //     //         .text(function (d) {
-            //     //             return d.data.name;
-            //     //         })
-            //     //         .attr('transform', 'rotate( -15)')
-            //     //         .style("stroke-width", "3px")
-            //     //         .style("font", "12px monospace");
-
-            //     // Update the links…
-            //     var link = chart.selectAll("path.link")
-            //     .data(links, function (d) {
-            //         return d.id;
-            //     });
-
-            //     // Enter any new links at the parent's previous position.
-            //     var linkEnter = link.enter().insert("path", "g")
-            //             .attr("class", "link")
-            //             .attr("d", function (d) {
-            //                 var o = {x: source.x0, y: source.y0};
-            //                 return diagonal(o, o);
-            //             })
-            //             .attr('fill', 'none')
-            //             .attr('stroke', '#ccc')
-            //             .attr('stroke-width', '2px');
-
-            //     var linkUpdate = linkEnter.merge(link);
-
-            //     // Transition links to their new position.
-            //     linkUpdate.transition()
-            //             .duration(duration)
-            //             .attr("d", function (d) {
-            //                 return diagonal(d, d.parent);
-            //             });
-    
-    
-
-            //     //UPDATE
-            //     var nodeUpdate = nodeEnter.merge(node);
-    
-            //     // Transition nodes to their new position.
-            //     nodeUpdate.transition()
-            //             .duration(duration)
-            //             .attr("transform", function (d) {
-            //                 return "translate(" + d.y + "," + d.x + ")";
-            //             });
-    
-            //     nodeUpdate.select('circle.circleNode')
-            //             .attr("r", 4)
-            //             .style('fill', function (d) {
-            //                 if (d3.select(element).select('#unifyLegends').text() == 'Legends: unified') {
-            //                     return colorScale(d.data.metrics[curMetric], -1);
-            //                 }
-            //                 return colorScale(d.data.metrics[curMetric], d.treeIndex);
-            //             })
-            //             .style('stroke', 'black')
-            //             .style("stroke-dasharray", function (d) {
-            //                 return d._children ? '4' : '0';
-            //             }) //lightblue
-            //             .style('stroke-width', d => d._children ? '6px' : '1px')
-            //             .attr('cursor', 'pointer');
-    
-            //     //EXIT
-            //     // Transition exiting nodes to the parent's new position.
-            //     var nodeExit = node.exit().transition()
-            //             .duration(duration)
-            //             .attr("transform", function (d) {
-            //                 return "translate(" + source.y + "," + source.x + ")";
-            //             })
-            //             .remove();
-    
-            //     nodeExit.select("circle")
-            //             .attr("r", 1e-6);
-    
-            //     nodeExit.select("text")
-            //             .style("fill-opacity", 1);
-    
-            //     // Transition exiting links to the parent's new position.
-            //     var linkExit = link.exit().transition()
-            //             .duration(duration)
-            //             .attr("d", function (d) {
-            //                 var o = {x: source.x, y: source.y};
-            //                 return diagonal(o, o);
-            //             })
-            //             .remove();
-                
-            // }
 
             return{
                 register: function(s){
@@ -602,6 +465,7 @@
                         var source = d3.hierarchy(model.data["forestData"][treeIndex], d => d.children);
                         
                         var curMetric = d3.select(element).select('#metricSelect').property('value');
+
                         if (d3.select(element).select('#unifyLegends').text() == 'Legends: unified') {
                             setColorLegend(-1);
                         } else {
@@ -613,7 +477,10 @@
                         
                         var chart = svg.selectAll('.group-' + treeIndex);
             
+                        console.log(nodes);
+                        console.log(source);
                         // Update the nodes…
+                        var i = 0;
                         var node = chart.selectAll("g.node")
                                 .data(nodes, function (d) {
                                     return d.id || (d.id = ++i);
@@ -624,7 +491,7 @@
                         var nodeEnter = node.enter().append('g')
                                 .attr('class', 'node')
                                 .attr("transform", function (d) {
-                                    return "translate(" + source.y0 + "," + source.x0 + ")";
+                                    return "translate(" + source.y0 + "," + source.x0 + ")"; //source is for collapsed nodes
                                 })
                                 .on("click", click)
                                 .on('dblclick', function (d) {
@@ -744,9 +611,6 @@
 
         var model = createModel();
    
-
-
-
         var menu = createMenuView(element, model);
         menu.render();
 
@@ -755,6 +619,7 @@
         
 
         model.register(menu.render);
+        model.register(chart.render);
 
         var i = 0,
         duration = 750;

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -229,7 +229,7 @@
                             _model.updateLegends();
                             break;
                         case(globals.signals.ZOOM):
-                            _model.updateNodeLocations(evt.index, evt.transformation);
+                            // _model.updateNodeLocations(evt.index, evt.transformation);
                             break;
                         default:
                             console.log('Unknown event type', evt.type);
@@ -281,11 +281,19 @@
 
             var _forestMetrics = [];
             var _forestMinMax = {}; 
+            console.log(_data["numberOfTrees"]);
             for (var i = 0; i < _data["numberOfTrees"]; i++) {
                 var thisTree = _data["forestData"][i];
 
+                let name = "";
+                if(!thisTree.frame["name"]) {
+                    name = thisTree.frame.file;
+                } else {
+                    name = thisTree.frame.name;
+                }
+
                 // Get tree names for the display select options
-                _data["rootNodeNames"].push(thisTree.frame.name);
+                _data["rootNodeNames"].push(name);
 
                 var thisTreeMetrics = {};
 
@@ -695,6 +703,8 @@
                     .attr('value', d => d);
             document.getElementById("metricSelect").style.margin = "10px 10px 10px 0px";
 
+            console.log(rootNodeNames);
+
             d3.select(elem).append('label').style('margin', '0 0 0 10px').attr('for', 'treeRootSelect').text(' Display:');
             var treeRootInput = d3.select(elem).append("select") //element
                     .attr("id", "treeRootSelect")
@@ -702,7 +712,10 @@
                     .data(rootNodeNames)
                     .enter()
                     .append('option')
-                    .attr('selected', d => d.includes('Show all trees') ? "selected" : null)
+                    .attr('selected', d => {
+                        console.log(d);
+                        return d.includes('Show all trees') ? "selected" : null;
+                    })
                     .text(d => d)
                     .attr('value', (d, i) => i + "|" + d);
 

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -220,8 +220,7 @@
                             _model.updateLegends();
                             break;
                         case(globals.signals.ZOOM):
-                            // add debounce
-                            _model.updateNodeLocations(evt.index, evt.transformation, evt.trans);
+                            _model.updateNodeLocations(evt.index, evt.transformation);
                             break;
                         default:
                             console.log('Unknown event type', evt.type);
@@ -494,13 +493,14 @@
                     _state["activeTree"] = activeTree;
                     _observers.notify();
                 },
-                updateNodeLocations: function(index, transformation, trans){
+                updateNodeLocations: function(index, transformation){
                     _data["treemaps"][index].descendants().forEach(function(d, i) {
-                        //this function gets the absolute location for each point based on the relative
+                        // This function gets the absolute location for each point based on the relative
                         // locations of the points based on transformations
                         // the margins were being added into the .e and .f values so they have to be subtracted
-                        // I think they come from the margins being added into the main group when it is created
+                        // I think they come from the margins being added into the "main group" when it is created
                         // We can brush regardless of zoom or pan
+                        // Adapted from: https://stackoverflow.com/questions/18554224/getting-screen-positions-of-d3-nodes-after-transform
                         d.yMainG = transformation.e + d.y0*transformation.d + d.x0*transformation.c - globals.layout.margin.left;
                         d.xMainG = transformation.f + d.y0*transformation.b + d.x0*transformation.a - globals.layout.margin.top;
                     });
@@ -851,8 +851,7 @@
                     _observers.notify({
                         type: globals.signals.ZOOM,
                         index: zoomObj.attr("chart-id"),
-                        transformation: zoomObj.node().getCTM(),
-                        trans: d3.event.transform
+                        transformation: zoomObj.node().getCTM()
                     })
                 });
 

--- a/hatchet/external/roundtrip/roundtripTree.js
+++ b/hatchet/external/roundtrip/roundtripTree.js
@@ -868,6 +868,7 @@
                     .on("dblclick.zoom", null);
                     
 
+
                 model.updateNodes(treeIndex,
                     function(n){
                         // Normalize for fixed-depth.

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -777,7 +777,7 @@ class GraphFrame:
                 df_index = hnode
 
             metrics_dict = {}
-            for m in sorted(self.inc_metrics + self.exc_metrics):
+            for m in sorted(self.inc_metrics + self.exc_metrics + ['module']):
                 node_metric_val = self.dataframe.loc[df_index, m]
                 metrics_dict[m] = node_metric_val
 


### PR DESCRIPTION
This PR adds functionality to encode the literal tree visualization using a categorical variable (e.g., `module`). This is WIP PR. Dont merge yet.