### PR TITLE
Adds GitHub Action Runner to Automatically Update PR Labels by Review Status

### DIFF
--- a/.github/workflows/pr-review-auto-label.yaml
+++ b/.github/workflows/pr-review-auto-label.yaml
@@ -2,7 +2,7 @@ name: pull request review auto label
 
 on:
   pull_request_review:
-    types: [submitted]
+    types: [submitted, edited]
 
 jobs:
   build:
@@ -20,6 +20,7 @@ jobs:
         with:
           add-labels: 'status: approved, status: ready to merge'
           remove-labels: 'status: ready for review'
+          issue-number: ${{ github.event.pull_request.number }}
       - name: Auto Label if Revisions Needed
         if: github.event.review.state == 'changes_requested'
         # There's a bug in master of this tool that causes action to fail.
@@ -28,3 +29,4 @@ jobs:
         with:
           add-labels: 'status: revisions needed'
           remove-labels: 'status: ready for review'
+          issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-review-auto-label.yaml
+++ b/.github/workflows/pr-review-auto-label.yaml
@@ -14,13 +14,17 @@ jobs:
 
       - name: Auto Label if Approved
         if: github.event.review.state == 'approved'
-        uses: andymckay/labeler@master
+        # There's a bug in master of this tool that causes action to fail.
+        # TODO Replace with newer version when bug is fixed
+        uses: andymckay/labeler@1.0.3
         with:
           add-labels: 'status: approved, status: ready to merge'
           remove-labels: 'status: ready for review'
       - name: Auto Label if Revisions Needed
         if: github.event.review.state == 'changes_requested'
-        uses: andymckay/labeler@master
+        # There's a bug in master of this tool that causes action to fail.
+        # TODO Replace with newer version when bug is fixed
+        uses: andymckay/labeler@1.0.3
         with:
           add-labels: 'status: revisions needed'
           remove-labels: 'status: ready for review'

--- a/.github/workflows/pr-review-auto-label.yaml
+++ b/.github/workflows/pr-review-auto-label.yaml
@@ -1,0 +1,26 @@
+name: pull request review auto label
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Auto Label if Approved
+        if: github.event.review.state == 'approved'
+        uses: andymckay/labeler@master
+        with:
+          add-labels: 'status: approved, status: ready to merge'
+          remove-labels: 'status: ready for review'
+      - name: Auto Label if Revisions Needed
+        if: github.event.review.state == 'changes_requested'
+        uses: andymckay/labeler@master
+        with:
+          add-labels: 'status: revisions needed'
+          remove-labels: 'status: ready for review'


### PR DESCRIPTION
This PR is a follow-up to the work @cscully-allison and I did on standardizing the labels in the Hatchet repo.

This PR adds a GitHub Action script that will automatically change some of the labels on a PR based on the result of a review. The changes that this script will make can be summarized as follows:

On approval, the ![](https://img.shields.io/github/labels/hatchet/hatchet/status%3A%20ready%20for%20review) label will be replaced by the ![](https://img.shields.io/github/labels/hatchet/hatchet/status%3A%20approved) and ![](https://img.shields.io/github/labels/hatchet/hatchet/status%3A%20ready%20to%20merge) labels.

If the review requests changes, the ![](https://img.shields.io/github/labels/hatchet/hatchet/status%3A%20ready%20for%20review) label will be replaced by the ![](https://img.shields.io/github/labels/hatchet/hatchet/status%3A%20revisions%20needed) label.