### PR TITLE
Preserve existing inc_metrics in update_inclusive_columns

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -658,7 +658,8 @@ class GraphFrame:
         if not self.exc_metrics:
             return
 
-        self.inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
+        new_inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
+        self.inc_metrics.extend(new_inc_metrics)
         self.subgraph_sum(self.exc_metrics, self.inc_metrics)
 
     def show_metric_columns(self):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -659,7 +659,7 @@ class GraphFrame:
             return
 
         new_inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
-        self.inc_metrics.extend(new_inc_metrics)
+        self.inc_metrics = list(set(self.inc_metrics + new_inc_metrics))
         self.subgraph_sum(self.exc_metrics, self.inc_metrics)
 
     def show_metric_columns(self):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -658,9 +658,12 @@ class GraphFrame:
         if not self.exc_metrics:
             return
 
-        new_inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
-        self.inc_metrics = list(set(self.inc_metrics + new_inc_metrics))
+        # TODO When Python 2.7 support is dropped, change this line to the more idiomatic:
+        # old_inc_metrics = self.inc_metrics.copy()
+        old_inc_metrics = list(self.inc_metrics)
+        self.inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
         self.subgraph_sum(self.exc_metrics, self.inc_metrics)
+        self.inc_metrics = list(set(self.inc_metrics + old_inc_metrics))
 
     def show_metric_columns(self):
         """Returns a list of dataframe column labels."""


### PR DESCRIPTION
This is a small PR to fix a bug in `GraphFrame.update_inclusive_columns` that causes existing values in `GraphFrame.inc_columns` to be dropped.

As an example, consider a `GraphFrame` with the following metrics:
* `exc_metrics`: `["time"]`
* `inc_metrics`: `["foo"]`

Currently, after calling `update_inclusive_columns`, `inc_metrics` will no longer contain `"foo"`. Instead, `inc_metrics` will simply be `["time (inc)"]`.

This PR will extend `inc_metrics` instead of overriding. So, in the above example, `inc_metrics` will now be `["foo", "time (inc)"]`.