### PR TITLE
Calculates exclusive metrics from corresponding inclusive metrics

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -672,16 +672,16 @@ class GraphFrame:
                         full_idx = (node, *non_node_idx)
                         inc_sum = 0
                         for child in node.children:
-                            inc_sum += self.dataframe[(child, *non_node_idx), inc]
-                        new_data[full_idx] = self.dataframe[full_idx, inc] - inc_sum
+                            inc_sum += self.dataframe.loc[(child, *non_node_idx), inc]
+                        new_data[full_idx] = self.dataframe.loc[full_idx, inc] - inc_sum
                 self.dataframe[exc] = pd.Series(data=new_data)
             else:
                 new_data = {n: -1 for n in self.dataframe.index.values}
                 for node in self.graph.traverse():
                     inc_sum = 0
                     for child in node.children:
-                        inc_sum += self.dataframe[child, inc]
-                    new_data[node] = self.dataframe[node, inc] - inc_sum
+                        inc_sum += self.dataframe.loc[child, inc]
+                    new_data[node] = self.dataframe.loc[node, inc] - inc_sum
                 self.dataframe[exc] = pd.Series(data=new_data)
         self.exc_metrics.extend([metric_tuple[0] for metric_tuple in generation_pairs])
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -693,7 +693,15 @@ class GraphFrame:
         if not self.exc_metrics:
             return
 
-        self.inc_metrics = ["%s (inc)" % s for s in self.exc_metrics]
+        # TODO Change this logic when inc_metrics and exc_metrics are changed
+        new_inc_metrics = []
+        for exc in self.exc_metrics:
+            if exc.endswith("(exc)"):
+                new_inc_metrics.append(exc[:-len("(exc)")].strip())
+            else:
+                new_inc_metrics.append("%s (inc)" % exc)
+        self.inc_metrics = new_inc_metrics
+
         self.subgraph_sum(self.exc_metrics, self.inc_metrics)
 
     def show_metric_columns(self):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -665,8 +665,16 @@ class GraphFrame:
                 generation_pairs.append((inc + " (exc)", inc))
         for exc, inc in generation_pairs:
             if isinstance(self.dataframe.index, pd.MultiIndex):
-                # See subtree_sum for indexing help
-                pass
+                new_data = {}
+                for node in self.graph.traverse():
+                    for non_node_idx in self.dataframe.loc[(node)].index.unique():
+                        assert isinstance(non_node_idx, tuple) or isinstance(non_node_idx, list), "MultiIndex iteration is not producing the expected type"
+                        full_idx = (node, *non_node_idx)
+                        inc_sum = 0
+                        for child in node.children:
+                            inc_sum += self.dataframe[(child, *non_node_idx), inc]
+                        new_data[full_idx] = self.dataframe[full_idx, inc] - inc_sum
+                self.dataframe[exc] = pd.Series(data=new_data)
             else:
                 new_data = {n: -1 for n in self.dataframe.index.values}
                 for node in self.graph.traverse():

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -683,6 +683,7 @@ class GraphFrame:
                         inc_sum += self.dataframe[child, inc]
                     new_data[node] = self.dataframe[node, inc] - inc_sum
                 self.dataframe[exc] = pd.Series(data=new_data)
+        self.exc_metrics.extend([metric_tuple[0] for metric_tuple in generation_pairs])
 
     def update_inclusive_columns(self):
         """Update inclusive columns (typically after operations that rewire the


### PR DESCRIPTION
This PR adds the `generate_exclusive_columns` function to calculate exclusive metrics from inclusive metrics. It does this by calculating the sum of the inclusive metric for each node's children and then subtracting that from the node's inclusive metric. It will only attempt to calculate exclusive metrics in certain situations, namely:
* The inclusive metric name ends in "(inc)", but there is not an exclusive metric with the same name, minus the "(inc)"
* There is an inclusive metric without the "(inc)" suffix

This might not be ideal. However, Hatchet currently provides no mechanism internally for explicitly correlating exclusive and inclusive metrics. So, until such functionality is added, this PR must use some solution based on metric names to determine what to calculate. When the internal mechanism for recording inclusive and exclusive metrics is updated, this function will be updated to use that new feature.