### PR TITLE
Store run (meta)data in GraphFrame

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -52,7 +52,7 @@ class GraphFrame:
         exc_metrics=None,
         inc_metrics=None,
         default_metric="time",
-        rundata={}
+        metadata={}
     ):
         """Create a new GraphFrame from a graph and a dataframe.
 
@@ -83,7 +83,7 @@ class GraphFrame:
         self.exc_metrics = [] if exc_metrics is None else exc_metrics
         self.inc_metrics = [] if inc_metrics is None else inc_metrics
         self.default_metric = default_metric
-        self.rundata = rundata
+        self.metadata = metadata
 
     @staticmethod
     def from_hpctoolkit(dirname):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -52,7 +52,7 @@ class GraphFrame:
         exc_metrics=None,
         inc_metrics=None,
         default_metric="time",
-        metadata={}
+        metadata={},
     ):
         """Create a new GraphFrame from a graph and a dataframe.
 

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -52,6 +52,7 @@ class GraphFrame:
         exc_metrics=None,
         inc_metrics=None,
         default_metric="time",
+        rundata={}
     ):
         """Create a new GraphFrame from a graph and a dataframe.
 
@@ -82,6 +83,7 @@ class GraphFrame:
         self.exc_metrics = [] if exc_metrics is None else exc_metrics
         self.inc_metrics = [] if inc_metrics is None else inc_metrics
         self.default_metric = default_metric
+        self.rundata = rundata
 
     @staticmethod
     def from_hpctoolkit(dirname):

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -179,5 +179,6 @@ class CaliperNativeReader:
 
         metadata = self.filename_or_caliperreader.globals
 
-        return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics,
-                                             metadata=metadata)
+        return hatchet.graphframe.GraphFrame(
+            graph, dataframe, exc_metrics, inc_metrics, metadata=metadata
+        )

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -177,7 +177,7 @@ class CaliperNativeReader:
             else:
                 exc_metrics.append(column)
 
-        rundata = self.filename_or_caliperreader.globals
+        metadata = self.filename_or_caliperreader.globals
 
         return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics,
-                                             rundata=rundata)
+                                             metadata=metadata)

--- a/hatchet/readers/caliper_native_reader.py
+++ b/hatchet/readers/caliper_native_reader.py
@@ -177,4 +177,7 @@ class CaliperNativeReader:
             else:
                 exc_metrics.append(column)
 
-        return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics)
+        rundata = self.filename_or_caliperreader.globals
+
+        return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics,
+                                             rundata=rundata)

--- a/hatchet/readers/caliper_reader.py
+++ b/hatchet/readers/caliper_reader.py
@@ -43,6 +43,8 @@ class CaliperReader:
         self.json_cols_mdata = {}
         self.json_nodes = {}
 
+        self.rundata = {}
+
         self.idx_to_label = {}
         self.idx_to_node = {}
 
@@ -77,6 +79,12 @@ class CaliperReader:
         self.json_cols = json_obj["columns"]
         self.json_cols_mdata = json_obj["column_metadata"]
         self.json_nodes = json_obj["nodes"]
+
+        # read run metadata: all top-level elements in the json object that aren't
+        # one of the above sections are run metadata
+        skip = [ "data", "columns", "column_metadata", "nodes" ]
+        keys = [ k for k in json_obj.keys() if k not in skip ]
+        self.rundata = { k : json_obj[k] for k in keys }
 
         # decide which column to use as the primary path hierarchy
         # first preference to callpath if available
@@ -381,4 +389,5 @@ class CaliperReader:
             else:
                 exc_metrics.append(column)
 
-        return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics)
+        return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics,
+                                             rundata=self.rundata)

--- a/hatchet/readers/caliper_reader.py
+++ b/hatchet/readers/caliper_reader.py
@@ -43,7 +43,7 @@ class CaliperReader:
         self.json_cols_mdata = {}
         self.json_nodes = {}
 
-        self.rundata = {}
+        self.metadata = {}
 
         self.idx_to_label = {}
         self.idx_to_node = {}
@@ -84,7 +84,7 @@ class CaliperReader:
         # one of the above sections are run metadata
         skip = [ "data", "columns", "column_metadata", "nodes" ]
         keys = [ k for k in json_obj.keys() if k not in skip ]
-        self.rundata = { k : json_obj[k] for k in keys }
+        self.metadata = { k : json_obj[k] for k in keys }
 
         # decide which column to use as the primary path hierarchy
         # first preference to callpath if available
@@ -390,4 +390,4 @@ class CaliperReader:
                 exc_metrics.append(column)
 
         return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics,
-                                             rundata=self.rundata)
+                                             metadata=self.metadata)

--- a/hatchet/readers/caliper_reader.py
+++ b/hatchet/readers/caliper_reader.py
@@ -84,7 +84,7 @@ class CaliperReader:
         # one of the above sections are run metadata
         skip = ["data", "columns", "column_metadata", "nodes"]
         keys = [k for k in json_obj.keys() if k not in skip]
-        self.metadata = {k : json_obj[k] for k in keys}
+        self.metadata = {k: json_obj[k] for k in keys}
 
         # decide which column to use as the primary path hierarchy
         # first preference to callpath if available

--- a/hatchet/readers/caliper_reader.py
+++ b/hatchet/readers/caliper_reader.py
@@ -82,9 +82,9 @@ class CaliperReader:
 
         # read run metadata: all top-level elements in the json object that aren't
         # one of the above sections are run metadata
-        skip = [ "data", "columns", "column_metadata", "nodes" ]
-        keys = [ k for k in json_obj.keys() if k not in skip ]
-        self.metadata = { k : json_obj[k] for k in keys }
+        skip = ["data", "columns", "column_metadata", "nodes"]
+        keys = [k for k in json_obj.keys() if k not in skip]
+        self.metadata = {k : json_obj[k] for k in keys}
 
         # decide which column to use as the primary path hierarchy
         # first preference to callpath if available
@@ -389,5 +389,6 @@ class CaliperReader:
             else:
                 exc_metrics.append(column)
 
-        return hatchet.graphframe.GraphFrame(graph, dataframe, exc_metrics, inc_metrics,
-                                             metadata=self.metadata)
+        return hatchet.graphframe.GraphFrame(
+            graph, dataframe, exc_metrics, inc_metrics, metadata=self.metadata
+        )

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -215,6 +215,7 @@ def test_graphframe_native_lulesh_from_file(lulesh_caliper_cali):
     print(list(gf.dataframe.columns))
 
     assert len(gf.dataframe.groupby("name")) == 19
+    assert "cali.caliper.version" in gf.rundata.keys()
 
     for col in gf.dataframe.columns:
         if col in ("time (inc)", "time"):
@@ -236,6 +237,7 @@ def test_graphframe_native_lulesh_from_caliperreader(lulesh_caliper_cali):
     gf = GraphFrame.from_caliperreader(r)
 
     assert len(gf.dataframe.groupby("name")) == 19
+    assert "cali.caliper.version" in gf.rundata.keys()
 
     for col in gf.dataframe.columns:
         if col in ("time (inc)", "time"):

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -215,7 +215,7 @@ def test_graphframe_native_lulesh_from_file(lulesh_caliper_cali):
     print(list(gf.dataframe.columns))
 
     assert len(gf.dataframe.groupby("name")) == 19
-    assert "cali.caliper.version" in gf.rundata.keys()
+    assert "cali.caliper.version" in gf.metadata.keys()
 
     for col in gf.dataframe.columns:
         if col in ("time (inc)", "time"):
@@ -237,7 +237,7 @@ def test_graphframe_native_lulesh_from_caliperreader(lulesh_caliper_cali):
     gf = GraphFrame.from_caliperreader(r)
 
     assert len(gf.dataframe.groupby("name")) == 19
-    assert "cali.caliper.version" in gf.rundata.keys()
+    assert "cali.caliper.version" in gf.metadata.keys()
 
     for col in gf.dataframe.columns:
         if col in ("time (inc)", "time"):


### PR DESCRIPTION
This adds a `rundata` dict to `GraphFrame` to store run metadata. The Caliper readers fill this with the Adiak/Caliper globals from the given datasets.  