### PR TITLE
WIP: fix CI build for python 2.7

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -28,7 +28,19 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
+    - name: Install Python2.7 dependencies
+      if: ${{ matrix.python-version == 2.7 }}
+      run: |
+        python -m pip install --upgrade flake8 pytest numexpr==2.7.3
+        pip install -r requirements.txt
+        # Optional Dependency for HDF Checkpointing
+        pip install tables
+        python setup.py install
+        python setup.py build_ext --inplace
+        python -m pip list
+
+    - name: Install Python3 dependencies
+      if: ${{ matrix.python-version != 2.7 }}
       run: |
         python -m pip install --upgrade pip flake8 pytest
         pip install -r requirements.txt


### PR DESCRIPTION
```
Collecting numexpr>=2.6.2
  Downloading numexpr-2.8.1.tar.gz (94 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /opt/hostedtoolcache/Python/2.7.18/x64/bin/python /opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-m6tcyR/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools wheel oldest-supported-numpy
       cwd: None
  Complete output (7 lines):
  DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
  Collecting setuptools
    Downloading setuptools-44.1.1-py2.py3-none-any.whl (583 kB)
  Collecting wheel
    Downloading wheel-0.37.0-py2.py3-none-any.whl (35 kB)
  ERROR: Could not find a version that satisfies the requirement oldest-supported-numpy (from versions: none)
  ERROR: No matching distribution found for oldest-supported-numpy
  ----------------------------------------
ERROR: Command errored out with exit status 1: /opt/hostedtoolcache/Python/2.7.18/x64/bin/python /opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-m6tcyR/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools wheel oldest-supported-numpy Check the logs for full command output.
```