### PR TITLE
bugfix: display terminal tree for gprof profiles

### DIFF
--- a/hatchet/readers/gprof_dot_reader.py
+++ b/hatchet/readers/gprof_dot_reader.py
@@ -64,14 +64,15 @@ class GprofDotReader:
                     node_name = node_name.strip('"')
                     hnode = self.name_to_hnode.get(node_name)
                     if not hnode:
-                        # create a node if it doesn't exist yet
-                        hnode = Node(
-                            Frame({"type": "function", "name": node_name}), None
-                        )
-                        self.name_to_hnode[node_name] = hnode
+                        if node.obj_dict["attributes"].get("label") is None:
+                            continue
+                        else:
+                            # create a node if it doesn't exist yet
+                            hnode = Node(
+                                Frame({"type": "function", "name": node_name}), None
+                            )
+                            self.name_to_hnode[node_name] = hnode
 
-                    if node.obj_dict["attributes"].get("label") is None:
-                        continue
                     node_label = node.obj_dict["attributes"].get("label").strip('"')
 
                     module, _, inc, exc, _ = node_label.split(r"\n")

--- a/hatchet/tests/callgrind.py
+++ b/hatchet/tests/callgrind.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from hatchet import GraphFrame
 from hatchet.readers.gprof_dot_reader import GprofDotReader
+from hatchet.external.console import ConsoleRenderer
 
 roots = [
     "psm_no_lock",
@@ -44,3 +45,27 @@ def test_read_calc_pi_database(calc_pi_callgrind_dot):
         root_names.append(root.frame.attrs["name"])
 
     assert all(rt in root_names for rt in roots)
+
+
+def test_tree(calc_pi_callgrind_dot):
+    gf = GraphFrame.from_gprof_dot(str(calc_pi_callgrind_dot))
+
+    output = ConsoleRenderer(unicode=True, color=False).render(
+        gf.graph.roots,
+        gf.dataframe,
+        metric_column="time",
+        precision=3,
+        name_column="name",
+        expand_name=False,
+        context_column="file",
+        rank=0,
+        thread=0,
+        depth=10000,
+        highlight_name=False,
+        colormap="RdYlGn",
+        invert_colormap=False,
+    )
+
+    assert "0.580 MPIR_Request_complete" in output
+    assert "1.400 malloc_consolidate" in output
+    assert "0.080 MPIR_Reduce_impl" in output


### PR DESCRIPTION
Graph was creating a node with an empty label in error, and this node was not
being added to the dataframe. Displaying the tree produced this error:
KeyError: Node({'name': '\\n', 'type': 'function'})

- add gprof test for displaying terminal tree