### PR TITLE
add terminal visualization support for hot paths

### DIFF
--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -61,6 +61,7 @@ class ConsoleRenderer:
         self.highlight = kwargs["highlight_name"]
         self.colormap = kwargs["colormap"]
         self.invert_colormap = kwargs["invert_colormap"]
+        self.hotpath = kwargs["hotpath"]
 
         if self.color:
             self.colors = self.colors_enabled
@@ -243,6 +244,16 @@ class ConsoleRenderer:
         df_index = _set_dataframe_index(node)
         node_metric = dataframe.loc[df_index, self.primary_metric]
 
+        # The indents that will be used to change the nodes according to hoth paths nodes found
+        hotpath_indents = {
+            "├": self.colors.left + u"├─ " + self.colors.end,
+            "│": self.colors.left + u"│ " + self.colors.end,
+            "└": self.colors.left + u"└─ " + self.colors.end,
+            " ": u"   ",
+        }
+        # if self.hotpath:
+        #     hotpath = hotpaths(graphframe)
+
         metric_precision = "{:." + str(self.precision) + "f}"
         metric_str = (
             self._ansi_color_for_metric(node_metric)
@@ -261,7 +272,14 @@ class ConsoleRenderer:
         if self.expand is False:
             if len(node_name) > 39:
                 node_name = node_name[:18] + "..." + node_name[(len(node_name) - 18) :]
-        name_str = self._ansi_color_for_name(node_name) + node_name + self.colors.end
+        # If the user wants hotpaths to be shown then this will mark the nodes which are in the hotpaths
+        if len(self.hotpath) > 0 and node_name in self.hotpath:
+            name_str = self.colors.left + node_name + self.colors.end
+        # This will render the tree with no changes in the nodes whether its a regular tree or one that uses hotpaths
+        else:
+            name_str = (
+                self._ansi_color_for_name(node_name) + node_name + self.colors.end
+            )
 
         # Print the graph based on the depth of a node and check if its
         # below the default or user specified depth.
@@ -304,14 +322,57 @@ class ConsoleRenderer:
                 sorted_children = sorted(node.children, key=lambda n: n.frame)
                 if sorted_children:
                     last_child = sorted_children[-1]
-
+                # this is a variable that's defined to stop the hotpath to mark the nodes when
+                # finished visiting all the nodes in a hotpath
+                found = False
                 for child in sorted_children:
                     if child is not last_child:
-                        c_indent = child_indent + indents["├"]
                         cc_indent = child_indent + indents["│"]
+                        c_indent = child_indent + indents["├"]
+                        # For Hotpaths: This condition will determine id the child of a node is present in
+                        # the hotpath, if it is present then it will mark the indent adjacent to the node
+                        if (
+                            len(self.hotpath) > 0
+                            and child.frame.get("name") in self.hotpath
+                        ):
+                            c_indent = child_indent + hotpath_indents["├"]
+                            found = True
+                        # For Hotpaths: This condition will mark the indents thats are path of the hotpath
+                        # between the current node and the next child in the hotpath
+                        elif (
+                            len(self.hotpath) > 0
+                            and node_name in self.hotpath
+                            and self.hotpath[-1] != node_name
+                        ):
+                            c_indent = child_indent + hotpath_indents["├"]
+                            cc_indent = child_indent + hotpath_indents["│"]
+                            if self.hotpath[-1] == node_name:
+                                found = True
+                        # This is the default condition if in case the user doesnt want to use the hotpath function
+                        # Or For Hotpaths: this is also the condition to render the tree without marking its indent
+                        # if its not present in the hotpath
+                        else:
+                            cc_indent = child_indent + indents["│"]
+                            c_indent = child_indent + indents["├"]
                     else:
+                        # default condition to print indents of the tree
                         c_indent = child_indent + indents["└"]
                         cc_indent = child_indent + indents[" "]
+                        # For Hotpaths: this is to mark the node of the child node of the last node in the hotpath
+                        if (
+                            len(self.hotpath) > 0
+                            and node_name in self.hotpath
+                            and child.frame.get("name") in self.hotpath
+                        ):
+                            c_indent = child_indent + hotpath_indents["└"]
+                            if self.hotpath[-1] == child.frame.get("name"):
+                                found = True
+                        elif (
+                            len(self.hotpath) > 0
+                            and child.frame.get("name") in self.hotpath
+                            and not found
+                        ):
+                            c_indent = child_indent + hotpath_indents["└"]
                     result += self.render_frame(
                         child, dataframe, indent=c_indent, child_indent=cc_indent
                     )
@@ -322,19 +383,16 @@ class ConsoleRenderer:
                 )
             else:
                 _get_subtree_info(node, subtree_info)
-                result = (
-                    u"{indent}{metric_str} {name_str}".format(
-                        indent=indent, metric_str=metric_str, name_str=name_str
-                    )
-                    + "\n{child_indent}└─".format(child_indent=child_indent)
-                    + u"\u2B24"
-                    + "  Subtree Info (Total Metric: "
-                    + str(subtree_info["sum_metric"])
-                    + ", # Descendants: "
-                    + str(subtree_info["descendants"])
-                    + ", # Remaining Levels: "
-                    + str(subtree_info["levels"] - node_depth)
-                    + ")\n"
+                summary_string = "{indent}{metric_str} {name_str}\n{child_indent}└─\u25C0\u25AE Subtree Info (Total Metric: {metric}, # Descendants: {desc}, # Remaining Levels {levels})\n"
+
+                result = summary_string.format(
+                    indent=indent,
+                    metric_str=metric_str,
+                    name_str=name_str,
+                    child_indent=child_indent,
+                    metric=str(subtree_info["sum_metric"]),
+                    desc=str(subtree_info["descendants"]),
+                    levels=str(subtree_info["levels"] - node_depth),
                 )
         return result
 

--- a/hatchet/external/console.py
+++ b/hatchet/external/console.py
@@ -334,6 +334,8 @@ class ConsoleRenderer:
                         if (
                             len(self.hotpath) > 0
                             and child.frame.get("name") in self.hotpath
+                            and self.hotpath[-1] != child.frame.get("name")
+                            and not found
                         ):
                             c_indent = child_indent + hotpath_indents["├"]
                             found = True
@@ -343,6 +345,7 @@ class ConsoleRenderer:
                             len(self.hotpath) > 0
                             and node_name in self.hotpath
                             and self.hotpath[-1] != node_name
+                            and not found
                         ):
                             c_indent = child_indent + hotpath_indents["├"]
                             cc_indent = child_indent + hotpath_indents["│"]
@@ -363,9 +366,10 @@ class ConsoleRenderer:
                             len(self.hotpath) > 0
                             and node_name in self.hotpath
                             and child.frame.get("name") in self.hotpath
+                            and not found
                         ):
                             c_indent = child_indent + hotpath_indents["└"]
-                            if self.hotpath[-1] == child.frame.get("name"):
+                            if self.hotpath[-1] == node_name:
                                 found = True
                         elif (
                             len(self.hotpath) > 0

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -795,6 +795,7 @@ class GraphFrame:
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     ):
         """Format this graphframe as a tree and return the resulting string."""
         color = sys.stdout.isatty()
@@ -832,6 +833,7 @@ class GraphFrame:
             highlight_name=highlight_name,
             colormap=colormap,
             invert_colormap=invert_colormap,
+            hotpath=hotpath,
         )
 
     @Logger.loggable

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -176,6 +176,7 @@ def test_tree(lulesh_caliper_json):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "121489.000 main" in output
     assert "663.000 LagrangeElements" in output
@@ -195,6 +196,7 @@ def test_tree(lulesh_caliper_json):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "662712.000 EvalEOSForElems" in output
     assert "2895319.000 LagrangeNodal" in output

--- a/hatchet/tests/cprofile.py
+++ b/hatchet/tests/cprofile.py
@@ -44,6 +44,7 @@ def test_tree(hatchet_cycle_pstats):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "g pstats_reader_test.py" in output
     assert "<method 'disable' ...Profiler' objects> ~" in output
@@ -62,6 +63,7 @@ def test_tree(hatchet_cycle_pstats):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "f pstats_reader_test.py" in output
     assert re.match("(.|\n)*recursive(.|\n)*recursive", output)

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -699,6 +699,7 @@ def test_tree(mock_graph_literal):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "0.000 foo" in output
     assert "10.000 waldo" in output
@@ -718,6 +719,7 @@ def test_tree(mock_graph_literal):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "55.000 waldo" in output
     assert "15.000 garply" in output
@@ -776,6 +778,7 @@ def test_sub_decorator(small_mock1, small_mock2, small_mock3):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "0.000 C" in output
     assert u"nan D ▶" in output
@@ -805,6 +808,7 @@ def test_sub_decorator(small_mock1, small_mock2, small_mock3):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "15.000 A" in output
     assert u"5.000 C ◀" in output
@@ -839,6 +843,7 @@ def test_div_decorator(small_mock1, small_mock2):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "1.000 C" in output
     assert "inf B" in output

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -115,6 +115,7 @@ def test_tree(calc_pi_hpct_db):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "0.000 <program root> <unknown file>" in output
     assert (
@@ -136,6 +137,7 @@ def test_tree(calc_pi_hpct_db):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "17989.000 interp.c:0 interp.c" in output
     assert (

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -91,8 +91,7 @@ def test_tree(hatchet_pyinstrument_json):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
-        hotpath=[],        
-
+        hotpath=[],
     )
     assert "0.000 <module> examples.py" in output
     assert "0.025 read hatchet/readers/caliper_reader.py" in output

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -91,6 +91,8 @@ def test_tree(hatchet_pyinstrument_json):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],        
+
     )
     assert "0.000 <module> examples.py" in output
     assert "0.025 read hatchet/readers/caliper_reader.py" in output
@@ -109,6 +111,7 @@ def test_tree(hatchet_pyinstrument_json):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "0.478 <module> examples.py" in output
     assert "0.063 from_caliper_json hatchet/graphframe.py" in output

--- a/hatchet/tests/tau.py
+++ b/hatchet/tests/tau.py
@@ -43,6 +43,7 @@ def test_tree(tau_profile_dir):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[]
     )
     assert "449.000 .TAU application" in output
     assert "4458.000 MPI_Finalize()" in output
@@ -63,6 +64,7 @@ def test_tree(tau_profile_dir):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
     assert "419.000 .TAU application" in output
     assert "4894.000 MPI_Finalize()" in output

--- a/hatchet/tests/tau.py
+++ b/hatchet/tests/tau.py
@@ -43,7 +43,7 @@ def test_tree(tau_profile_dir):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
-        hotpath=[]
+        hotpath=[],
     )
     assert "449.000 .TAU application" in output
     assert "4458.000 MPI_Finalize()" in output

--- a/hatchet/tests/timemory_test.py
+++ b/hatchet/tests/timemory_test.py
@@ -59,6 +59,7 @@ def test_tree(timemory_json_data):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[],
     )
 
     print(output)
@@ -77,6 +78,7 @@ def test_tree(timemory_json_data):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
+        hotpath=[]
     )
 
     print(output)

--- a/hatchet/tests/timemory_test.py
+++ b/hatchet/tests/timemory_test.py
@@ -78,7 +78,7 @@ def test_tree(timemory_json_data):
         highlight_name=False,
         colormap="RdYlGn",
         invert_colormap=False,
-        hotpath=[]
+        hotpath=[],
     )
 
     print(output)


### PR DESCRIPTION
This PR includes the method to visualize hot path nodes based on users request. This version visualizes the hot paths when the user mentions the node names of the hot paths in a list format. The complete implementation of hot paths will be implemented when the hot path function PR is merged.