### PR TITLE
fix incorrect dataset filename in split-JSON Caliper file example

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -75,7 +75,7 @@ the ``from_caliper`` method:
   import hatchet as ht
 
   if __name__ == "__main__":
-      filename = ("hatchet/tests/data/caliper-lulesh-json/lulesh-sample-annotation-profile.json")
+      filename = ("hatchet/tests/data/caliper-lulesh-json/lulesh-annotation-profile.json")
       gf = ht.GraphFrame.from_caliper(filename)
 
 Examples of reading in other file formats can be found in


### PR DESCRIPTION
The second example under the [**Reading in a dataset**](https://hatchet.readthedocs.io/en/latest/user_guide.html#reading-in-a-dataset) section contained the incorrect filename for the split-JSON Caliper dataset.

This PR changes the filename in the docs from `"hatchet/tests/data/caliper-lulesh-json/lulesh-sample-annotation-profile.json"` to `"hatchet/tests/data/caliper-lulesh-json/lulesh-annotation-profile.json"`, to reflect the [correct filename of the project](https://github.com/hatchet/hatchet/tree/develop/hatchet/tests/data/caliper-lulesh-json).