### PR TITLE
fix column argument name for groupby-aggregate function

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -1101,7 +1101,7 @@ class GraphFrame:
         return self
 
     @Logger.loggable
-    def groupby_aggregate(self, groupby_function, agg_function):
+    def groupby_aggregate(self, groupby_column, agg_function):
         """Groupby-aggregate dataframe and reindex the Graph.
 
         Reindex the graph to match the groupby-aggregated dataframe.
@@ -1110,7 +1110,7 @@ class GraphFrame:
 
         Arguments:
             self (graphframe): self's graphframe
-            groupby_function: groupby function on dataframe
+            groupby_column: groupby column on dataframe
             agg_function: aggregate function on dataframe
 
         Return:
@@ -1169,7 +1169,7 @@ class GraphFrame:
                     reindex(child, super_node, visited)
 
         # groupby-aggregate dataframe based on user-supplied functions
-        groupby_obj = self.dataframe.groupby(groupby_function)
+        groupby_obj = self.dataframe.groupby(groupby_column)
         agg_df = groupby_obj.agg(agg_function)
 
         # traverse groupby_obj, determine old node to super node mapping

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -1110,7 +1110,7 @@ class GraphFrame:
 
         Arguments:
             self (graphframe): self's graphframe
-            groupby_column: groupby column on dataframe
+            groupby_column: column to groupby on dataframe
             agg_function: aggregate function on dataframe
 
         Return:

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -867,9 +867,9 @@ def test_groupby_aggregate_simple(mock_dag_literal_module):
 
     gf = GraphFrame.from_literal(mock_dag_literal_module)
 
-    groupby_func = ["module"]
+    groupby_col = ["module"]
     agg_func = {"time (inc)": np.max, "time": np.max}
-    out_gf = gf.groupby_aggregate(groupby_func, agg_func)
+    out_gf = gf.groupby_aggregate(groupby_col, agg_func)
 
     assert all(m in out_gf.dataframe.name.values for m in modules)
     assert len(out_gf.graph) == len(modules)
@@ -898,9 +898,9 @@ def test_groupby_aggregate_complex(mock_dag_literal_module_complex):
 
     gf = GraphFrame.from_literal(mock_dag_literal_module_complex)
 
-    groupby_func = ["module"]
+    groupby_col = ["module"]
     agg_func = {"time (inc)": np.sum, "time": np.sum}
-    out_gf = gf.groupby_aggregate(groupby_func, agg_func)
+    out_gf = gf.groupby_aggregate(groupby_col, agg_func)
 
     assert all(m in out_gf.dataframe.name.values for m in modules)
     assert len(out_gf.graph) == len(modules)
@@ -930,9 +930,9 @@ def test_groupby_aggregate_more_complex(mock_dag_literal_module_more_complex):
 
     gf = GraphFrame.from_literal(mock_dag_literal_module_more_complex)
 
-    groupby_func = ["module"]
+    groupby_col = ["module"]
     agg_func = {"time (inc)": np.sum, "time": np.sum}
-    out_gf = gf.groupby_aggregate(groupby_func, agg_func)
+    out_gf = gf.groupby_aggregate(groupby_col, agg_func)
 
     assert all(m in out_gf.dataframe.name.values for m in modules)
     assert len(out_gf.graph) == len(modules)


### PR DESCRIPTION
This PR changes the column argument name for the Hatchet `groupby_aggregate()` function from `groupby_function` to `groupby_column`. 