### PR TITLE
add optional as_index arg to flat_profile

### DIFF
--- a/hatchet/chopper.py
+++ b/hatchet/chopper.py
@@ -9,12 +9,7 @@ import numpy as np
 class Chopper:
     """High-level API for performance analysis."""
 
-    def flat_profile(
-        self,
-        graphframe,
-        groupby_column=None,
-        as_index=True
-    ):
+    def flat_profile(self, graphframe, groupby_column=None, as_index=True):
         """Generates flat profile for a given graphframe.
         Returns a new dataframe."""
         graphframe2 = graphframe.deepcopy()
@@ -25,7 +20,9 @@ class Chopper:
         # TODO: change drop_index_levels(). Drop only ranks or threads.
         graphframe2.drop_index_levels()
 
-        result_dataframe = graphframe2.dataframe.groupby(groupby_column, as_index=as_index).sum()
+        result_dataframe = graphframe2.dataframe.groupby(
+            groupby_column, as_index=as_index
+        ).sum()
         result_dataframe = result_dataframe.sort_values(
             by=[graphframe.default_metric], ascending=False
         )

--- a/hatchet/chopper.py
+++ b/hatchet/chopper.py
@@ -13,6 +13,7 @@ class Chopper:
         self,
         graphframe,
         groupby_column=None,
+        as_index=True
     ):
         """Generates flat profile for a given graphframe.
         Returns a new dataframe."""
@@ -24,7 +25,7 @@ class Chopper:
         # TODO: change drop_index_levels(). Drop only ranks or threads.
         graphframe2.drop_index_levels()
 
-        result_dataframe = graphframe2.dataframe.groupby(groupby_column).sum()
+        result_dataframe = graphframe2.dataframe.groupby(groupby_column, as_index=as_index).sum()
         result_dataframe = result_dataframe.sort_values(
             by=[graphframe.default_metric], ascending=False
         )

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -1267,12 +1267,14 @@ class GraphFrame:
     def flat_profile(
         self,
         groupby_column=None,
+        as_index=True
     ):
         """Generates flat profile for a given graphframe.
         Returns a new dataframe."""
         return Chopper().flat_profile(
             self,
             groupby_column,
+            as_index
         )
 
     @Logger.loggable

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -1264,18 +1264,10 @@ class GraphFrame:
         return new_gf
 
     @Logger.loggable
-    def flat_profile(
-        self,
-        groupby_column=None,
-        as_index=True
-    ):
+    def flat_profile(self, groupby_column=None, as_index=True):
         """Generates flat profile for a given graphframe.
         Returns a new dataframe."""
-        return Chopper().flat_profile(
-            self,
-            groupby_column,
-            as_index
-        )
+        return Chopper().flat_profile(self, groupby_column, as_index)
 
     @Logger.loggable
     def flatten(self, groupby_column=None):

--- a/hatchet/tests/chopper.py
+++ b/hatchet/tests/chopper.py
@@ -30,6 +30,10 @@ def test_flat_profile(calc_pi_hpct_db):
         graphframe.dataframe.loc[another]["time (inc)"].to_numpy()
     )
 
+    # If as_index is False, check if the index is properly numbered
+    flat_profile = graphframe.flat_profile(as_index=False)
+    assert sorted(flat_profile.index.tolist()) == list(range(len(flat_profile)))
+
 
 def test_calculate_load_imbalance(calc_pi_hpct_db):
     """Validate that the load imbalance is calculated correctly."""


### PR DESCRIPTION
In its current implementation, `flat_profile` returns a dataframe in which the groupby_column becomes the index. This PR adds an additional as_index argument that, if set to False, will set the index to a numbered list rather than the grouper.

The as_index argument is one provided by the [pandas groupby function](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html) itself. By default, the parameter is set to True in both pandas' API and this PR implementation. This PR simply allows the user more control over the output of the `flat_profile` function by modifying an already-existing parameter in pandas' implementation. This also saves users an extra line of code, in which they would have to use `reset_index` after the function call to perform the same action.