### PR TITLE
auto-detection for profile formats and multi-graphframe constructor

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -145,7 +145,7 @@ class GraphFrame:
 
         def _parse_json(filename):
             with open(str(filename), "r") as f:
-                return json.load(f)
+                return json.loads(f.read())
 
         JSON_SCHEMAS = {
             "caliper_json": {

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -286,22 +286,25 @@ class GraphFrame:
         return None
 
     @staticmethod
-    def from_paths(datasets=[]):
+    def construct_from(datasets=[]):
         """Construct GraphFrame objects from a list of datasets.
 
         Arguments:
-            datasets (list): contains list of data
-                Each item in the list is either a string path to a file or directory,
-                or a list object.
+            datasets (list, str, tuple):
+                * list:
+                    Each item in the list is either a string path to a file or directory, or a list object. The input may also be a single list object.
+                    For data that require additional parameters, use a tuple containing the path and a dictionary of parameters.
+                    ex. ["path/to/file", "path/to/directory", [{"frame":...}], ("path/to/file", {"per_thread": True, "select": "cpu_clock"})]
+                    [
+                * str:
+                    The input may be a single string path to a file or directory.
                     ex. "path/to/file"
-                For data that require additional parameters, use a tuple containing
-                the path and a dictionary of parameters.
-                    ex. ("path/to/file", {"per_thread": True})
-            Example input:
-                ["path/to/file", "path/to/dir", ("path/to/file", {"select": "cpu_clock", "per_rank": True, "per_thread": True})]
+                * tuple:
+                    The input may be a single tuple containing the path and a dictionary of parameters.
+                    ex. ("path/to/file", {"per_rank": True})
 
         Returns:
-            A list of respective GraphFrame objects
+            A list of respective GraphFrame objects (if input contained multiple datasets, else a single GraphFrame object)
         """
 
         def from_path(data):
@@ -341,7 +344,9 @@ class GraphFrame:
                     "'GraphFrame.from_path' failed to recognize the data format. Please fallback to respective `GraphFrame.from_*`, where * is the data format."
                 )
 
-        assert len(datasets) != 0, "list 'datasets' must contain at least 1 dataset"
+        assert (
+            len(datasets) != 0 and datasets is not None
+        ), "list 'datasets' must contain at least 1 dataset"
 
         if not isinstance(datasets, list):
             datasets = [datasets]
@@ -349,6 +354,9 @@ class GraphFrame:
         graphframes = []
         for data in datasets:
             graphframes.append(from_path(data))
+
+        if len(graphframes) == 1:
+            return graphframes[0]
 
         return graphframes
 

--- a/hatchet/tests/caliper.py
+++ b/hatchet/tests/caliper.py
@@ -297,3 +297,12 @@ def test_sw4_cuda_summary_from_caliperreader(
 
     for col in gf.exc_metrics + gf.inc_metrics:
         assert col in gf.dataframe.columns
+
+
+def test_graphframe_constructor_caliper_json(lulesh_caliper_json):
+    """Validate that the graphframe constructor function is working correctly."""
+    gf_test = GraphFrame.construct_from(str(lulesh_caliper_json))
+    gf_actual = GraphFrame.from_caliper(str(lulesh_caliper_json))
+
+    assert gf_actual.dataframe.equals(gf_test.dataframe)
+    assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/callgrind.py
+++ b/hatchet/tests/callgrind.py
@@ -44,3 +44,12 @@ def test_read_calc_pi_database(calc_pi_callgrind_dot):
         root_names.append(root.frame.attrs["name"])
 
     assert all(rt in root_names for rt in roots)
+
+
+def test_graphframe_constructor_gprof(calc_pi_callgrind_dot):
+    """Validate that the graphframe constructor function is working correctly."""
+    gf_test = GraphFrame.construct_from(str(calc_pi_callgrind_dot))
+    gf_actual = GraphFrame.from_gprof_dot(str(calc_pi_callgrind_dot))
+
+    assert gf_actual.dataframe.equals(gf_test.dataframe)
+    assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/cprofile.py
+++ b/hatchet/tests/cprofile.py
@@ -65,3 +65,12 @@ def test_tree(hatchet_cycle_pstats):
     )
     assert "f pstats_reader_test.py" in output
     assert re.match("(.|\n)*recursive(.|\n)*recursive", output)
+
+
+def test_graphframe_constructor_cprofile(hatchet_cycle_pstats):
+    """Validate that the graphframe constructor function is working correctly."""
+    gf_test = GraphFrame.construct_from(str(hatchet_cycle_pstats))
+    gf_actual = GraphFrame.from_cprofile(str(hatchet_cycle_pstats))
+
+    assert gf_actual.dataframe.equals(gf_test.dataframe)
+    assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/graph_literal.py
+++ b/hatchet/tests/graph_literal.py
@@ -134,3 +134,12 @@ def test_inclusive_time_calculation_mock_dag_modules(
     assert all(
         gf8.dataframe["time (inc)"].values == gf8.dataframe["orig_inc_time"].values
     )
+
+
+def test_graphframe_constructor_literal(mock_graph_literal):
+    """Validate that the graphframe constructor function is working correctly."""
+    gf_test = GraphFrame.construct_from(mock_graph_literal)
+    gf_actual = GraphFrame.from_literal(mock_graph_literal)
+
+    assert gf_actual.dataframe.equals(gf_test.dataframe)
+    assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -235,5 +235,11 @@ def test_graphframe_constructor_hpctoolkit(calc_pi_hpct_db):
     gf_test = GraphFrame.construct_from(str(calc_pi_hpct_db))
     gf_actual = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
 
+    gf_test.drop_index_levels()
+    gf_actual.drop_index_levels()
+
+    gf_actual.dataframe.sort_values(by=["nid"], ignore_index=True, inplace=True)
+    gf_test.dataframe.sort_values(by=["nid"], ignore_index=True, inplace=True)
+
     assert gf_actual.dataframe.equals(gf_test.dataframe)
     assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -238,8 +238,5 @@ def test_graphframe_constructor_hpctoolkit(calc_pi_hpct_db):
     gf_test.drop_index_levels()
     gf_actual.drop_index_levels()
 
-    gf_actual.dataframe.sort_values(by=["nid"], ignore_index=True, inplace=True)
-    gf_test.dataframe.sort_values(by=["nid"], ignore_index=True, inplace=True)
-
     assert gf_actual.dataframe.equals(gf_test.dataframe)
     assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -228,3 +228,12 @@ def test_inclusive_time_calculation(data_dir, calc_pi_hpct_db):
     assert all(
         gf.dataframe["time (inc)"].values == gf.dataframe["orig_inc_time"].values
     )
+
+
+def test_graphframe_constructor_hpctoolkit(calc_pi_hpct_db):
+    """Validate that the graphframe constructor function is working correctly."""
+    gf_test = GraphFrame.construct_from(str(calc_pi_hpct_db))
+    gf_actual = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
+
+    assert gf_actual.dataframe.equals(gf_test.dataframe)
+    assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -121,3 +121,12 @@ def test_graphframe_to_literal(hatchet_pyinstrument_json):
     gf2 = GraphFrame.from_literal(graph_literal)
 
     assert len(gf.graph) == len(gf2.graph)
+
+
+def test_graphframe_constructor_pyinstrument(hatchet_pyinstrument_json):
+    """Validate that the graphframe constructor function is working correctly."""
+    gf_test = GraphFrame.construct_from(str(hatchet_pyinstrument_json))
+    gf_actual = GraphFrame.from_pyinstrument(str(hatchet_pyinstrument_json))
+
+    assert gf_actual.dataframe.equals(gf_test.dataframe)
+    assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -136,8 +136,5 @@ def test_graphframe_constructor_pyinstrument(hatchet_pyinstrument_json):
     for node in nodes_actual:
         gf_actual.dataframe.at[node, "val"] = nodes_actual.index(node)
 
-    gf_test.dataframe.sort_values(by=["val"], ignore_index=True, inplace=True)
-    gf_actual.dataframe.sort_values(by=["val"], ignore_index=True, inplace=True)
-
     assert gf_actual.dataframe.equals(gf_test.dataframe)
     assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -6,7 +6,6 @@
 import json
 
 import numpy as np
-import pandas as pd
 
 from hatchet import GraphFrame
 from hatchet.external.console import ConsoleRenderer

--- a/hatchet/tests/pyinstrument.py
+++ b/hatchet/tests/pyinstrument.py
@@ -6,6 +6,7 @@
 import json
 
 import numpy as np
+import pandas as pd
 
 from hatchet import GraphFrame
 from hatchet.external.console import ConsoleRenderer
@@ -127,6 +128,17 @@ def test_graphframe_constructor_pyinstrument(hatchet_pyinstrument_json):
     """Validate that the graphframe constructor function is working correctly."""
     gf_test = GraphFrame.construct_from(str(hatchet_pyinstrument_json))
     gf_actual = GraphFrame.from_pyinstrument(str(hatchet_pyinstrument_json))
+
+    nodes_test = list(gf_test.graph.traverse())
+    nodes_actual = list(gf_actual.graph.traverse())
+
+    for node in nodes_test:
+        gf_test.dataframe.at[node, "val"] = nodes_test.index(node)
+    for node in nodes_actual:
+        gf_actual.dataframe.at[node, "val"] = nodes_actual.index(node)
+
+    gf_test.dataframe.sort_values(by=["val"], ignore_index=True, inplace=True)
+    gf_actual.dataframe.sort_values(by=["val"], ignore_index=True, inplace=True)
 
     assert gf_actual.dataframe.equals(gf_test.dataframe)
     assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/scorep.py
+++ b/hatchet/tests/scorep.py
@@ -114,3 +114,13 @@ def test_graphframe_to_literal(scorep_profile_cubex):
     gf2 = GraphFrame.from_literal(graph_literal)
 
     assert len(gf.graph) == len(gf2.graph)
+
+
+@pytest.mark.skipif(not pycubexr_avail, reason="pycubexr package not available")
+def test_graphframe_constructor_scorep(scorep_profile_cubex):
+    """Validate that the graphframe constructor function is working correctly."""
+    gf_test = GraphFrame.construct_from(str(scorep_profile_cubex))
+    gf_actual = GraphFrame.from_scorep(str(scorep_profile_cubex))
+
+    assert gf_actual.dataframe.equals(gf_test.dataframe)
+    assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/spotdb_test.py
+++ b/hatchet/tests/spotdb_test.py
@@ -77,3 +77,16 @@ def test_from_spotdb(spotdb_data):
     assert metrics < set(gfs[0].dataframe.columns)
 
     assert "launchdate" in gfs[0].metadata.keys()
+
+
+@pytest.mark.skipif(not spotdb_avail, reason="spotdb module not available")
+def test_graphframe_constructor_spotdb(spotdb_data):
+    """Validate that the graphframe constructor function is working correctly."""
+    db = spotdb_data
+    runs = db.get_all_run_ids()
+    gfs_test = GraphFrame.construct_from((str(spotdb_data), {"list_of_ids": runs[0:2]}))
+    gfs_actual = GraphFrame.from_spotdb(spotdb_data, runs[0:2])
+
+    for i in range(len(gfs_test)):
+        assert gfs_actual[i].dataframe.equals(gfs_test[i].dataframe)
+        assert gfs_actual[i].graph == gfs_test[i].graph

--- a/hatchet/tests/tau.py
+++ b/hatchet/tests/tau.py
@@ -98,3 +98,12 @@ def test_graphframe_to_literal(tau_profile_dir):
     gf_literal = GraphFrame.from_literal(graph_literal)
 
     assert len(gf.graph) == len(gf_literal.graph)
+
+
+def test_graphframe_constructor_tau(tau_profile_dir):
+    """Validate that the graphframe constructor function is working correctly."""
+    gf_test = GraphFrame.construct_from(str(tau_profile_dir))
+    gf_actual = GraphFrame.from_tau(str(tau_profile_dir))
+
+    assert gf_actual.dataframe.equals(gf_test.dataframe)
+    assert gf_actual.graph == gf_test.graph

--- a/hatchet/tests/timemory_test.py
+++ b/hatchet/tests/timemory_test.py
@@ -100,3 +100,17 @@ def test_default_metric(timemory_json_data):
         lhs = "{}".format(getattr(gf, func)(gf.default_metric))
         rhs = "{}".format(getattr(gf, func)())
         assert lhs == rhs
+
+
+@pytest.mark.skipif(not timemory_avail, reason="timemory package not available")
+def test_graphframe_constructor_timemory(timemory_json_data):
+    """Validate that the graphframe constructor function is working correctly."""
+    from timemory.component import WallClock
+
+    wc_s = WallClock.id()  # string identifier
+
+    gf_test = GraphFrame.construct_from((timemory_json_data, {"select": [wc_s]}))
+    gf_actual = GraphFrame.from_timemory(timemory_json_data, [wc_s])
+
+    assert gf_actual.dataframe.equals(gf_test.dataframe)
+    assert gf_actual.graph == gf_test.graph

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ caliper-reader == 0.3.0
 pycubexr; python_version >= '3.6'
 perfetto; python_version >= '3.6'
 dataclasses; python_version >= '3.6'
+jsonschema

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "multiprocess",
         "caliper-reader",
         "pycubexr; python_version >= '3.6'",
+        "jsonschema",
     ],
     ext_modules=[
         Extension(


### PR DESCRIPTION
This PR borrows code from #313 to implement a function that can auto-detect a given profile's format using file extensions and JSON schemas. Additionally, it adds a graphframe constructor function that takes a list of dataset directories and/or file paths as input and, utilizing the auto-detect function, returns a list of respective graphframes.