### PR TITLE
add methods to timer API

### DIFF
--- a/hatchet/util/timer.py
+++ b/hatchet/util/timer.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from datetime import datetime
 from io import StringIO
-import statistics
 
 
 class Timer(object):

--- a/hatchet/util/timer.py
+++ b/hatchet/util/timer.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from datetime import datetime
 from io import StringIO
+import statistics
 
 
 class Timer(object):
@@ -48,6 +49,51 @@ class Timer(object):
         for phase, delta in self._times.items():
             out.write("    %-20s %.2fs\n" % (phase + ":", delta.total_seconds()))
         return out.getvalue()
+
+    def get_time(self, phase):
+        """Returns time for given phase."""
+        return self._times.get(phase).total_seconds()
+
+    def get_phases(self, time, precision=None):
+        """Returns a list of phases whose time values are equal to the given time.
+        Inputs:
+         - time: The time value of the desired phases.
+         - precision (optional): The number of decimal places to which the phase times should be compared with the given time.
+        Output:
+         - List of phases with the given time, adjusted for given precision.
+        """
+        time = str(float(time))
+        if precision:
+            precision = int(precision)
+        phases = []
+        for p, t in self._times.items():
+            t = str(t.total_seconds())
+            if (
+                int(float(time)) == int(t.split(".")[0])
+                and (time.split(".")[1] + "0" * precision)[:precision]
+                == t.split(".")[1][:precision]
+            ):
+                phases.append(p)
+        return phases
+
+    def max_time(self):
+        """Returns greatest time of all phases."""
+        return max(self._times.values()).total_seconds()
+
+    def min_time(self):
+        """Returns smallest time of all phases."""
+        return min(self._times.values()).total_seconds()
+
+    def total_time(self):
+        """Returns total time from all phases."""
+        total_time = 0
+        for time in self._times.values():
+            total_time += time.total_seconds()
+        return total_time
+
+    def average(self):
+        """Returns average time of all phases."""
+        return self.total_time() / len(self._times.values())
 
     @contextmanager
     def phase(self, name):


### PR DESCRIPTION
This PR adds the following methods to the timer API:

- **get_time**: returns time for a given phase
- **get_phases**: returns a list of phases whose times equal a given time, adjusted for a given precision
- **max_time**: returns the max time of all phases
- **min_time**: returns the min time of all phases
- **total_time**: returns the total time of all phases
- **average**: returns the average time of all phases