### PR TITLE
Checks python version during pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "hatchet.tests",
         "hatchet.cython_modules.libs",
     ],
-    install_requires=["pydot", "PyYAML", "matplotlib", "numpy", "pandas"],
+    install_requires=["pydot", "PyYAML", "matplotlib", "numpy", "pandas", "python<=3.8"],
     ext_modules=[
         Extension(
             "hatchet.cython_modules.libs.reader_modules",


### PR DESCRIPTION
Hatchet 1.3.0 doesn't seem to work with Python 3.9. One could include statements such as below in `setup.py` to guard against such incompatibilities. 