### PR TITLE
ci: set caliperreader pypi package to 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ PyYAML
 cython
 multiprocess
 textX
-caliper-reader
+caliper-reader == 0.3.0
 pycubexr; python_version >= '3.6'


### PR DESCRIPTION
The caliperreader pip package has a new release 0.4.0 which breaks hatchet tests for the "native" caliper reader.

The entire caliperreader code needs to be reviewed. This is a stop-gap measure.