### PR TITLE
Make hpctoolkitv4 reader sparse

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -127,14 +127,17 @@ class GraphFrame:
                 )
             setattr(self, x, y)
 
+    # TODO: Remove sparse format argument before next release
     @staticmethod
     @Logger.loggable
-    def from_hpctoolkit(dirname):
+    def from_hpctoolkit(dirname, sparse_format=False):
         """Read an HPCToolkit database directory into a new GraphFrame.
 
         Arguments:
             dirname (str): parent directory of an HPCToolkit
                 experiment.xml file
+            sparse_format (bool): whether to read in data in the sparse format
+                TODO: To be removed before next major release
 
         Returns:
             (GraphFrame): new GraphFrame containing HPCToolkit profile data
@@ -144,9 +147,10 @@ class GraphFrame:
         from .readers.hpctoolkit_v4_reader import HPCToolkitV4Reader
 
         if "experiment.xml" in os.listdir(dirname):
+            # TODO: Make old hpctoolkit outputs sparse?
             return HPCToolkitReader(dirname).read()
         else:
-            return HPCToolkitV4Reader(dirname).read()
+            return HPCToolkitV4Reader(dirname, sparse_format=sparse_format).read()
 
     @staticmethod
     @Logger.loggable

--- a/hatchet/readers/hpctoolkit_v4_reader.py
+++ b/hatchet/readers/hpctoolkit_v4_reader.py
@@ -1607,6 +1607,7 @@ class CCTReader:
             )
 
         # remove the visited profiles.
+        # TODO: remove this code when sparse output format is the default
         if not self.sparse_format:
             not_visited_profiles = [
                 i

--- a/hatchet/readers/hpctoolkit_v4_reader.py
+++ b/hatchet/readers/hpctoolkit_v4_reader.py
@@ -1247,6 +1247,7 @@ class CCTReader:
         meta_reader: MetaReader,
         profile_reader: ProfileReader,
         defaults_reader: DefaultReader,
+        sparse_format: bool = False,
     ) -> None:
         # open file
         self.file = open(file_location, "rb")
@@ -1261,6 +1262,8 @@ class CCTReader:
         self.byte_order = "little"
         self.signed = False
         self.encoding = "ASCII"
+
+        self.sparse_format = sparse_format
 
         # The cct.db header consists of the common .db header and n sections.
         # We're going to do a little set up work, so that's easy to change if
@@ -1617,20 +1620,23 @@ class CCTReader:
 
                 # fills all the metric values in not visited profiles
                 # with 0.
-                self.__create_node_dict(
-                    dummy_identifier,
-                    dummy_profile_info,
-                    node_name,
-                    node,
-                    context_info,
-                    metric_names=visited_metrics,
-                    value=0,
-                )
+
+                if not self.sparse_format:
+                    self.__create_node_dict(
+                        dummy_identifier,
+                        dummy_profile_info,
+                        node_name,
+                        node,
+                        context_info,
+                        metric_names=visited_metrics,
+                        value=0,
+                    )
 
 
 class HPCToolkitV4Reader:
-    def __init__(self, directory: str) -> None:
+    def __init__(self, directory: str, sparse_format: bool = False) -> None:
         self.directory = directory
+        self.sparse_format = sparse_format
 
     def read(self):
         self.meta_reader: MetaReader = MetaReader(self.directory + "/meta.db")
@@ -1645,6 +1651,7 @@ class HPCToolkitV4Reader:
             self.meta_reader,
             self.profile_reader,
             self.defaults_reader,
+            sparse_format=self.sparse_format,
         )
 
         return self.create_graphframe()

--- a/hatchet/readers/hpctoolkit_v4_reader.py
+++ b/hatchet/readers/hpctoolkit_v4_reader.py
@@ -1609,7 +1609,9 @@ class CCTReader:
         # remove the visited profiles.
         if not self.sparse_format:
             not_visited_profiles = [
-                i for j, i in enumerate(not_visited_profiles) if j not in visited_profiles
+                i
+                for j, i in enumerate(not_visited_profiles)
+                if j not in visited_profiles
             ]
 
             # iterate over the not visited nodes and create dummy instances.

--- a/hatchet/readers/hpctoolkit_v4_reader.py
+++ b/hatchet/readers/hpctoolkit_v4_reader.py
@@ -1607,21 +1607,20 @@ class CCTReader:
             )
 
         # remove the visited profiles.
-        not_visited_profiles = [
-            i for j, i in enumerate(not_visited_profiles) if j not in visited_profiles
-        ]
+        if not self.sparse_format:
+            not_visited_profiles = [
+                i for j, i in enumerate(not_visited_profiles) if j not in visited_profiles
+            ]
 
-        # iterate over the not visited nodes and create dummy instances.
-        for profile in not_visited_profiles:
-            hit_pointer = profile["hit_pointer"]
-            if hit_pointer != 0:
-                dummy_profile_info = self.profile_reader.hit_map[hit_pointer]
-                dummy_identifier = (node,) + tuple(dummy_profile_info.values())
+            # iterate over the not visited nodes and create dummy instances.
+            for profile in not_visited_profiles:
+                hit_pointer = profile["hit_pointer"]
+                if hit_pointer != 0:
+                    dummy_profile_info = self.profile_reader.hit_map[hit_pointer]
+                    dummy_identifier = (node,) + tuple(dummy_profile_info.values())
 
-                # fills all the metric values in not visited profiles
-                # with 0.
-
-                if not self.sparse_format:
+                    # fills all the metric values in not visited profiles
+                    # with 0.
                     self.__create_node_dict(
                         dummy_identifier,
                         dummy_profile_info,

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -62,8 +62,6 @@ procedures = [
 ]
 
 
-# TODO: remove False option once sparse is only option in next major release
-@pytest.mark.parametrize("sparse_format", [False, True])
 def test_graphframe(data_dir, calc_pi_hpct_db, sparse_format):
     """Sanity test a GraphFrame object with known data."""
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db), sparse_format=sparse_format)
@@ -79,11 +77,6 @@ def test_graphframe(data_dir, calc_pi_hpct_db, sparse_format):
             assert gf.dataframe[col].dtype == np.int64
         elif col in ("name", "type", "file", "module", "node"):
             assert gf.dataframe[col].dtype == object
-
-    # In case of sparse format check to make sure we are not inserting dummy values
-    # into the dataframe
-    if sparse_format:
-        assert 0 not in gf.dataframe["time (inc)"]
 
     # add tests to confirm values in dataframe
     df = pd.read_csv(str(os.path.join(data_dir, "hpctoolkit-cpi-graphframe.csv")))
@@ -240,9 +233,12 @@ def test_inclusive_time_calculation(data_dir, calc_pi_hpct_db):
 
 
 # START OF TESTS FOR THE NEW FORMAT
-def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db):
+
+# TODO: remove False option once sparse is only option in next major release
+@pytest.mark.parametrize("sparse_format", [False, True])
+def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db, sparse_format):
     """Sanity test a GraphFrame object with known data."""
-    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_v4_db))
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_v4_db), sparse_format=sparse_format)
 
     for col in gf.dataframe.columns:
         if col in gf.inc_metrics or col in gf.exc_metrics:
@@ -251,6 +247,15 @@ def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db):
             assert gf.dataframe[col].dtype == np.int64
         elif col in ("name", "node", "file", "module"):
             assert gf.dataframe[col].dtype == object
+
+    # In case of sparse format check to make sure we are not inserting dummy values
+    # into the dataframe
+    if sparse_format:
+        assert 0 not in gf.dataframe["time (inc)"]
+        # Data specific checks
+        assert len(gf.dataframe.reset_index()) == 461
+    else:
+        assert len(gf.dataframe.reset_index()) == 3280
 
     # TODO: add tests to confirm values in dataframe
 

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -239,9 +239,7 @@ def test_inclusive_time_calculation(data_dir, calc_pi_hpct_db):
 @pytest.mark.parametrize("sparse_format", [False, True])
 def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db):
     """Sanity test a GraphFrame object with known data."""
-    gf = GraphFrame.from_hpctoolkit(
-        str(calc_pi_hpct_v4_db)
-    )
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_v4_db))
     df = gf.dataframe
 
     for col in gf.dataframe.columns:

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -239,7 +239,9 @@ def test_inclusive_time_calculation(data_dir, calc_pi_hpct_db):
 @pytest.mark.parametrize("sparse_format", [False, True])
 def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db, sparse_format):
     """Sanity test a GraphFrame object with known data."""
-    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_v4_db), sparse_format=sparse_format)
+    gf = GraphFrame.from_hpctoolkit(
+        str(calc_pi_hpct_v4_db), sparse_format=sparse_format
+    )
     df = gf.dataframe
 
     for col in gf.dataframe.columns:

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -239,6 +239,7 @@ def test_inclusive_time_calculation(data_dir, calc_pi_hpct_db):
 def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db, sparse_format):
     """Sanity test a GraphFrame object with known data."""
     gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_v4_db), sparse_format=sparse_format)
+    df = gf.dataframe
 
     for col in gf.dataframe.columns:
         if col in gf.inc_metrics or col in gf.exc_metrics:
@@ -251,9 +252,14 @@ def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db, sparse_format):
     # In case of sparse format check to make sure we are not inserting dummy values
     # into the dataframe
     if sparse_format:
-        assert 0 not in gf.dataframe["time (inc)"]
+        assert 0 not in df["time (inc)"]
         # Data specific checks
-        assert len(gf.dataframe.reset_index()) == 461
+        assert len(df.reset_index()) == 461
+
+        first_node = df.index.get_level_values("node")[0]
+        # only 1 rank/thread ran
+        assert len(df.loc[first_node] == 1)
+        assert df.loc[(first_node, 0, 3), "time (inc)"] == 0.011382
     else:
         assert len(gf.dataframe.reset_index()) == 3280
 

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -234,11 +234,14 @@ def test_inclusive_time_calculation(data_dir, calc_pi_hpct_db):
 
 # START OF TESTS FOR THE NEW FORMAT
 
+
 # TODO: remove False option once sparse is only option in next major release
 @pytest.mark.parametrize("sparse_format", [False, True])
 def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db, sparse_format):
     """Sanity test a GraphFrame object with known data."""
-    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_v4_db), sparse_format=sparse_format)
+    gf = GraphFrame.from_hpctoolkit(
+        str(calc_pi_hpct_v4_db), sparse_format=sparse_format
+    )
     df = gf.dataframe
 
     for col in gf.dataframe.columns:

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -62,9 +62,9 @@ procedures = [
 ]
 
 
-def test_graphframe(data_dir, calc_pi_hpct_db, sparse_format):
+def test_graphframe(data_dir, calc_pi_hpct_db):
     """Sanity test a GraphFrame object with known data."""
-    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db), sparse_format=sparse_format)
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_db))
 
     assert len(gf.dataframe.groupby("module")) == 5
     assert len(gf.dataframe.groupby("file")) == 11
@@ -237,9 +237,9 @@ def test_inclusive_time_calculation(data_dir, calc_pi_hpct_db):
 
 # TODO: remove False option once sparse is only option in next major release
 @pytest.mark.parametrize("sparse_format", [False, True])
-def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db):
+def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db, sparse_format):
     """Sanity test a GraphFrame object with known data."""
-    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_v4_db))
+    gf = GraphFrame.from_hpctoolkit(str(calc_pi_hpct_v4_db), sparse_format=sparse_format)
     df = gf.dataframe
 
     for col in gf.dataframe.columns:

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -237,10 +237,10 @@ def test_inclusive_time_calculation(data_dir, calc_pi_hpct_db):
 
 # TODO: remove False option once sparse is only option in next major release
 @pytest.mark.parametrize("sparse_format", [False, True])
-def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db, sparse_format):
+def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db):
     """Sanity test a GraphFrame object with known data."""
     gf = GraphFrame.from_hpctoolkit(
-        str(calc_pi_hpct_v4_db), sparse_format=sparse_format
+        str(calc_pi_hpct_v4_db)
     )
     df = gf.dataframe
 


### PR DESCRIPTION
I made the hpctoolkit reader have the option to output in sparse format, and gated the option behind a keyword.

When we get the rest of the methods working, we should flip the default value to True from False.

Then, before the release we should delete the keyword.