### PR TITLE
Add PyTorch Geometric Writer

### DIFF
--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -429,14 +429,14 @@ class GraphFrame:
         HDF5Writer(filename).write(self, key=key, **kwargs)
 
     @Logger.loggable
-    def to_pyg(self, filename, encoder=None, **kwargs):
+    def to_pyg(self, encoder=None, **kwargs):
         # create PyTorch Geometric graph from GraphFrame
         # returns a torch_geometric.data.Data graph object
 
         # import this lazily to avoid circular dependencies
         from .writers.pyg_writer import PyGWriter
 
-        return PyGWriter(filename).write(self, encoder=encoder, **kwargs)
+        return PyGWriter().write(self, encoder=encoder, **kwargs)
 
     @Logger.loggable
     def update_metadata(self, num_processes=None, num_threads=None, metadata=None):

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -429,6 +429,16 @@ class GraphFrame:
         HDF5Writer(filename).write(self, key=key, **kwargs)
 
     @Logger.loggable
+    def to_pyg(self, filename, encoder=None, **kwargs):
+        # create PyTorch Geometric graph from GraphFrame
+        # returns a torch_geometric.data.Data graph object
+
+        # import this lazily to avoid circular dependencies
+        from .writers.pyg_writer import PyGWriter
+
+        return PyGWriter(filename).write(self, encoder=encoder, **kwargs)
+
+    @Logger.loggable
     def update_metadata(self, num_processes=None, num_threads=None, metadata=None):
         """Update a GraphFrame object's metadata."""
         if num_processes is not None:

--- a/hatchet/graphframe.py
+++ b/hatchet/graphframe.py
@@ -429,14 +429,32 @@ class GraphFrame:
         HDF5Writer(filename).write(self, key=key, **kwargs)
 
     @Logger.loggable
-    def to_pyg(self, encoder=None, **kwargs):
-        # create PyTorch Geometric graph from GraphFrame
-        # returns a torch_geometric.data.Data graph object
+    def to_pyg(self, metrics=["time", "time (inc)"], encoder=None, **kwargs):
+        """
+        Convert the GraphFrame to a PyTorch Geometric graph.
+
+        This method creates a PyTorch Geometric graph from the current GraphFrame
+        and returns a `torch_geometric.data.Data` graph object.
+
+        Each node in the PyTorch Geometric graph is represented by a node in the
+        GraphFrame. The value of each node is a vector consisting of [metrics..., encoding...].
+        By default, time and time (inc) are used as the metrics and the encoding is ignored.
+        Pass a callable to encoder that maps strings to lists of integers to include
+        encoding in the PyTorch Geometric graph. For example, `lambda encoder: [ord(c) for c in encoder]`.
+
+        Parameters:
+        metrics (list): A list of metric names to include in the PyTorch Geometric graph.
+        encoder (optional): An optional encoder map name strings to lists of integers.
+        **kwargs: Additional keyword arguments to pass to the PyGWriter.
+
+        Returns:
+        torch_geometric.data.Data: The resulting PyTorch Geometric graph object.
+        """
 
         # import this lazily to avoid circular dependencies
         from .writers.pyg_writer import PyGWriter
 
-        return PyGWriter().write(self, encoder=encoder, **kwargs)
+        return PyGWriter().write(self, encoder=encoder, metrics=metrics, **kwargs)
 
     @Logger.loggable
     def update_metadata(self, num_processes=None, num_threads=None, metadata=None):

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1340,11 +1340,8 @@ def test_update_metadata(mock_graph_literal):
 
 def test_to_pyg(mock_graph_literal):
     try:
-        # noqa: F401
-        import torch
-
-        # noqa: F401
-        import torch_geometric
+        import torch  # noqa: F401
+        import torch_geometric  # noqa: F401
     except ImportError:
         pytest.skip("PyTorch and/or PyTorch Geometric are not installed.")
 

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1340,7 +1340,9 @@ def test_update_metadata(mock_graph_literal):
 
 def test_to_pyg(mock_graph_literal):
     try:
+        # noqa: F401
         import torch
+        # noqa: F401
         import torch_geometric
     except ImportError:
         pytest.skip("PyTorch and/or PyTorch Geometric are not installed.")

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1342,6 +1342,7 @@ def test_to_pyg(mock_graph_literal):
     try:
         # noqa: F401
         import torch
+
         # noqa: F401
         import torch_geometric
     except ImportError:

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1336,3 +1336,38 @@ def test_update_metadata(mock_graph_literal):
 
     # check if both graphframes contain the same metadata
     assert gf_test.metadata == gf_dummy.metadata
+
+
+def test_to_pyg(mock_graph_literal):
+    try:
+        import torch
+        import torch_geometric
+    except ImportError:
+        pytest.skip("PyTorch and/or PyTorch Geometric are not installed.")
+
+    gf = GraphFrame.from_literal(mock_graph_literal)
+    num_nodes = len(gf.graph)
+    num_edges = sum([len(node.children) for node in gf.graph.traverse()])
+
+    # a simple PyG graph with 2 features per node: time and time (inc)
+    pyg = gf.to_pyg()
+    assert isinstance(pyg, torch_geometric.data.Data), "Graph is not a PyG Data object."
+    assert pyg.x.shape[0] == num_nodes, "Number of nodes in PyG Data object does not match."
+    assert pyg.x.shape[1] == 2, "Default number of features in PyG Data object is not 2."
+    assert pyg.edge_index.shape[1] == num_edges, "Number of edges in PyG Data object does not match."
+    
+    # a simpler PyG graph with 1 feature per node: time (inc)
+    pyg = gf.to_pyg(metrics=["time (inc)"])
+    assert isinstance(pyg, torch_geometric.data.Data), "Graph is not a PyG Data object."
+    assert pyg.x.shape[0] == num_nodes, "Number of nodes in PyG Data object does not match."
+    assert pyg.x.shape[1] == 1, "Number of features in PyG Data object is not 1."
+    assert pyg.edge_index.shape[1] == num_edges, "Number of edges in PyG Data object does not match."
+
+    # a PyG graph with an encoder
+    def name_encoder(name): # constant scheme for test
+        return [0, 1, 2, 3]
+    pyg = gf.to_pyg(encoder=name_encoder)
+    assert isinstance(pyg, torch_geometric.data.Data), "Graph is not a PyG Data object."
+    assert pyg.x.shape[0] == num_nodes, "Number of nodes in PyG Data object does not match."
+    assert pyg.x.shape[1] == 2+4, "Number of features in PyG Data object is not 6."
+    assert pyg.edge_index.shape[1] == num_edges, "Number of edges in PyG Data object does not match."

--- a/hatchet/tests/graphframe.py
+++ b/hatchet/tests/graphframe.py
@@ -1352,22 +1352,37 @@ def test_to_pyg(mock_graph_literal):
     # a simple PyG graph with 2 features per node: time and time (inc)
     pyg = gf.to_pyg()
     assert isinstance(pyg, torch_geometric.data.Data), "Graph is not a PyG Data object."
-    assert pyg.x.shape[0] == num_nodes, "Number of nodes in PyG Data object does not match."
-    assert pyg.x.shape[1] == 2, "Default number of features in PyG Data object is not 2."
-    assert pyg.edge_index.shape[1] == num_edges, "Number of edges in PyG Data object does not match."
-    
+    assert (
+        pyg.x.shape[0] == num_nodes
+    ), "Number of nodes in PyG Data object does not match."
+    assert (
+        pyg.x.shape[1] == 2
+    ), "Default number of features in PyG Data object is not 2."
+    assert (
+        pyg.edge_index.shape[1] == num_edges
+    ), "Number of edges in PyG Data object does not match."
+
     # a simpler PyG graph with 1 feature per node: time (inc)
     pyg = gf.to_pyg(metrics=["time (inc)"])
     assert isinstance(pyg, torch_geometric.data.Data), "Graph is not a PyG Data object."
-    assert pyg.x.shape[0] == num_nodes, "Number of nodes in PyG Data object does not match."
+    assert (
+        pyg.x.shape[0] == num_nodes
+    ), "Number of nodes in PyG Data object does not match."
     assert pyg.x.shape[1] == 1, "Number of features in PyG Data object is not 1."
-    assert pyg.edge_index.shape[1] == num_edges, "Number of edges in PyG Data object does not match."
+    assert (
+        pyg.edge_index.shape[1] == num_edges
+    ), "Number of edges in PyG Data object does not match."
 
     # a PyG graph with an encoder
-    def name_encoder(name): # constant scheme for test
+    def name_encoder(name):  # constant scheme for test
         return [0, 1, 2, 3]
+
     pyg = gf.to_pyg(encoder=name_encoder)
     assert isinstance(pyg, torch_geometric.data.Data), "Graph is not a PyG Data object."
-    assert pyg.x.shape[0] == num_nodes, "Number of nodes in PyG Data object does not match."
-    assert pyg.x.shape[1] == 2+4, "Number of features in PyG Data object is not 6."
-    assert pyg.edge_index.shape[1] == num_edges, "Number of edges in PyG Data object does not match."
+    assert (
+        pyg.x.shape[0] == num_nodes
+    ), "Number of nodes in PyG Data object does not match."
+    assert pyg.x.shape[1] == 2 + 4, "Number of features in PyG Data object is not 6."
+    assert (
+        pyg.edge_index.shape[1] == num_edges
+    ), "Number of edges in PyG Data object does not match."

--- a/hatchet/writers/pyg_writer.py
+++ b/hatchet/writers/pyg_writer.py
@@ -1,0 +1,75 @@
+# Copyright 2017-2024 Lawrence Livermore National Security, LLC and other
+# Hatchet Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+
+
+class PyGWriter:
+    """ Create PyTorch Geometric Data graph object from a GraphFrame.
+
+        Creates a node for each nid in the GraphFrame. Uses an encoding of the
+        node name as the value for each node. Also includes metric values in the
+        encoding.
+    """
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def _build_node_representation(self, node, metric_columns, dataframe, encoder):
+        embedding = dataframe.loc[node, metric_columns].values.tolist()
+        if encoder:
+            name = dataframe.loc[node, 'name']
+            encoding = encoder(name)
+            embedding.extend(encoding)
+        return embedding
+
+    def _build_graph(self, node, visited, nodes, edges, metric_columns, dataframe, encoder):
+        node_id = node._hatchet_nid
+
+        embedding = self._build_node_representation(node, metric_columns, dataframe, encoder)
+        nodes[node_id] = embedding
+
+        visited.append(node)
+        for child in node.children:
+            child_id = child._hatchet_nid
+            if child not in visited:
+                self._build_graph(child, visited, nodes, edges, metric_columns, dataframe, encoder)
+            edges.append((node_id, child_id))
+
+    def write(
+        self, 
+        gf, 
+        metrics=['time', 'time (inc)'], 
+        encoder=None,
+        **kwargs
+    ):
+        """ Return a PyG Data object from a GraphFrame. """
+        import torch
+        from torch_geometric.data import Data
+
+        gf = gf.deepcopy()
+
+        if any([metric not in gf.dataframe.columns for metric in metrics]):
+            raise ValueError(f"Some metrics in {metrics} are missing from the dataframe.")
+
+        # check if 'rank' or 'thread' are in the index
+        if "rank" in gf.dataframe.index.names or "thread" in gf.dataframe.index.names:
+            # TODO -- add support for rank and thread
+            raise ValueError("PyGWriter does not support 'rank' or 'thread' in the index.")
+
+        # assert that if encoder is not None/False, then it must be callable
+        if encoder and not callable(encoder):
+            raise ValueError("encoder must be callable")
+
+        nodes = [None] * len(gf.dataframe)
+        edges = []
+        weights = None # TODO -- use call information to weight edges
+
+        visited = []
+        for root in gf.graph.roots:
+            self._build_graph(root, visited, nodes, edges, metrics, gf.dataframe, encoder)
+        
+        nodes = torch.tensor(nodes, dtype=torch.float)
+        edges = torch.tensor(edges, dtype=torch.long).t().contiguous()
+        return Data(x=nodes, edge_index=edges, edge_attr=weights)

--- a/hatchet/writers/pyg_writer.py
+++ b/hatchet/writers/pyg_writer.py
@@ -13,8 +13,8 @@ class PyGWriter:
         encoding.
     """
 
-    def __init__(self, filename):
-        self.filename = filename
+    def __init__(self):
+        pass
 
     def _build_node_representation(self, node, metric_columns, dataframe, encoder):
         embedding = dataframe.loc[node, metric_columns].values.tolist()

--- a/hatchet/writers/pyg_writer.py
+++ b/hatchet/writers/pyg_writer.py
@@ -4,13 +4,12 @@
 # SPDX-License-Identifier: MIT
 
 
-
 class PyGWriter:
-    """ Create PyTorch Geometric Data graph object from a GraphFrame.
+    """Create PyTorch Geometric Data graph object from a GraphFrame.
 
-        Creates a node for each nid in the GraphFrame. Uses an encoding of the
-        node name as the value for each node. Also includes metric values in the
-        encoding.
+    Creates a node for each nid in the GraphFrame. Uses an encoding of the
+    node name as the value for each node. Also includes metric values in the
+    encoding.
     """
 
     def __init__(self):
@@ -19,44 +18,48 @@ class PyGWriter:
     def _build_node_representation(self, node, metric_columns, dataframe, encoder):
         embedding = dataframe.loc[node, metric_columns].values.tolist()
         if encoder:
-            name = dataframe.loc[node, 'name']
+            name = dataframe.loc[node, "name"]
             encoding = encoder(name)
             embedding.extend(encoding)
         return embedding
 
-    def _build_graph(self, node, visited, nodes, edges, metric_columns, dataframe, encoder):
+    def _build_graph(
+        self, node, visited, nodes, edges, metric_columns, dataframe, encoder
+    ):
         node_id = node._hatchet_nid
 
-        embedding = self._build_node_representation(node, metric_columns, dataframe, encoder)
+        embedding = self._build_node_representation(
+            node, metric_columns, dataframe, encoder
+        )
         nodes[node_id] = embedding
 
         visited.append(node)
         for child in node.children:
             child_id = child._hatchet_nid
             if child not in visited:
-                self._build_graph(child, visited, nodes, edges, metric_columns, dataframe, encoder)
+                self._build_graph(
+                    child, visited, nodes, edges, metric_columns, dataframe, encoder
+                )
             edges.append((node_id, child_id))
 
-    def write(
-        self, 
-        gf, 
-        metrics=['time', 'time (inc)'], 
-        encoder=None,
-        **kwargs
-    ):
-        """ Return a PyG Data object from a GraphFrame. """
+    def write(self, gf, metrics=["time", "time (inc)"], encoder=None, **kwargs):
+        """Return a PyG Data object from a GraphFrame."""
         import torch
         from torch_geometric.data import Data
 
         gf = gf.deepcopy()
 
         if any([metric not in gf.dataframe.columns for metric in metrics]):
-            raise ValueError(f"Some metrics in {metrics} are missing from the dataframe.")
+            raise ValueError(
+                f"Some metrics in {metrics} are missing from the dataframe."
+            )
 
         # check if 'rank' or 'thread' are in the index
         if "rank" in gf.dataframe.index.names or "thread" in gf.dataframe.index.names:
             # TODO -- add support for rank and thread
-            raise ValueError("PyGWriter does not support 'rank' or 'thread' in the index.")
+            raise ValueError(
+                "PyGWriter does not support 'rank' or 'thread' in the index."
+            )
 
         # assert that if encoder is not None/False, then it must be callable
         if encoder and not callable(encoder):
@@ -64,12 +67,14 @@ class PyGWriter:
 
         nodes = [None] * len(gf.dataframe)
         edges = []
-        weights = None # TODO -- use call information to weight edges
+        weights = None  # TODO -- use call information to weight edges
 
         visited = []
         for root in gf.graph.roots:
-            self._build_graph(root, visited, nodes, edges, metrics, gf.dataframe, encoder)
-        
+            self._build_graph(
+                root, visited, nodes, edges, metrics, gf.dataframe, encoder
+            )
+
         nodes = torch.tensor(nodes, dtype=torch.float)
         edges = torch.tensor(edges, dtype=torch.long).t().contiguous()
         return Data(x=nodes, edge_index=edges, edge_attr=weights)

--- a/hatchet/writers/pyg_writer.py
+++ b/hatchet/writers/pyg_writer.py
@@ -1,5 +1,5 @@
-# Copyright 2017-2024 Lawrence Livermore National Security, LLC and other
-# Hatchet Project Developers. See the top-level LICENSE file for details.
+# Copyright 2021-2024 University of Maryland and other Hatchet Project
+# Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
This adds a writer to create PyTorch Geometric graphs for using CCTs in graph neural networks. It can be used as:

```python
gf = ht.GraphFrame.from_caliper("profile.json")
pyg_graph = gf.to_pyg()
```

The `pyg_graph` object can then be fed into torch geometric GNNs for training or inference. There are some additional options to control how data is embedded in the nodes. You can pass _metrics_ and/or _encoder_ to specify what gets included in the vector. In the example below, each node would be a vector of values: `[time, time(inc), l2_misses, word2vec embedding of node name...]`

```python
pyg_graph = gf.to_pyg(metrics=["time", "time (inc)", "L2_CACHE_MISSES"], encoder=Word2Vec)
```

I added this as a writer for now in _writers/_. It doesn't create a file, but it felt like the best place. It requires [torch](https://pytorch.org/get-started/locally/) and [torch geometric](https://pytorch-geometric.readthedocs.io/en/2.5.2/notes/installation.html) to be installed, but they're not imported until `to_pyg` is called.

Let me know if this is something useful to be in Hatchet. I can also move it to a separate public repo if that's better.

[EDIT] I'm not entirely sure why, but this is failing the CI for reading in omnitrace profiles. Is this an issue from somewhere else in hatchet?