### PR TITLE
hpctoolkit v4: avoid IntCastingNaNError by using pandas Int64 for identifier cols

### DIFF
--- a/hatchet/readers/hpctoolkit_v4_reader.py
+++ b/hatchet/readers/hpctoolkit_v4_reader.py
@@ -1694,12 +1694,12 @@ class HPCToolkitV4Reader:
             self.cct_reader.exclusive_metrics
         ].fillna(0)
 
-        if "line" in dataframe.columns:
-            dataframe["line"] = dataframe["line"].astype("int64")
-        if "core" in dataframe.columns:
-            dataframe["core"] = dataframe["core"].astype("int64")
-        if "node_pid" in dataframe.columns:
-            dataframe["node_pid"] = dataframe["node_pid"].astype("int64")
+        # Coerce columns to nullable integer dtype
+        for col in ("line", "core", "node_pid"):
+            if col in dataframe.columns:
+                ser = pd.to_numeric(dataframe[col], errors="coerce")
+                # pandas nullable int allows <NA>
+                dataframe[col] = ser.astype("Int64")
 
         return hatchet.graphframe.GraphFrame(
             graph,

--- a/hatchet/readers/hpctoolkit_v4_reader.py
+++ b/hatchet/readers/hpctoolkit_v4_reader.py
@@ -1697,9 +1697,9 @@ class HPCToolkitV4Reader:
         # Coerce columns to nullable integer dtype
         for col in ("line", "core", "node_pid"):
             if col in dataframe.columns:
-                ser = pd.to_numeric(dataframe[col], errors="coerce")
-                # pandas nullable int allows <NA>
-                dataframe[col] = ser.astype("Int64")
+                dataframe[col] = pd.to_numeric(dataframe[col], errors="coerce").astype(
+                    "Int64"
+                )
 
         return hatchet.graphframe.GraphFrame(
             graph,

--- a/hatchet/tests/hpctoolkit.py
+++ b/hatchet/tests/hpctoolkit.py
@@ -238,8 +238,8 @@ def test_graphframe_v4(data_dir, calc_pi_hpct_v4_db):
     for col in gf.dataframe.columns:
         if col in gf.inc_metrics or col in gf.exc_metrics:
             assert gf.dataframe[col].dtype == np.float64
-        elif col in ("line"):
-            assert gf.dataframe[col].dtype == np.int64
+        elif col in ("line", "core", "node_pid"):
+            assert gf.dataframe[col].dtype == "Int64"
         elif col in ("name", "node", "file", "module"):
             assert gf.dataframe[col].dtype == object
 


### PR DESCRIPTION
The reader did astype("int64") on line/core/node_pid. NumPy int64 cannot represent missing values.