### PR TITLE
bugfix: scorep: change how we access the MinValue object

### DIFF
--- a/hatchet/readers/scorep_reader.py
+++ b/hatchet/readers/scorep_reader.py
@@ -66,7 +66,7 @@ class ScorePReader:
             if metric_name == "min_time" or metric_name == "max_time":
                 metric_value = metric_values.location_value(
                     pycubexr_cnode, location.id
-                ).value
+                )._values
             else:
                 metric_value = metric_values.location_value(pycubexr_cnode, location.id)
 


### PR DESCRIPTION
The value attribute of the MinValue object has changed. `_values` is scalar, not vector.